### PR TITLE
chore: upgrade Phaser 3.60.0 to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "phaser": "3.60.0"
+        "phaser": "4.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.2",
@@ -1444,7 +1444,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2029,12 +2028,12 @@
       }
     },
     "node_modules/phaser": {
-      "version": "3.60.0",
-      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.60.0.tgz",
-      "integrity": "sha512-IKUy35EnoEVcl2EmJ8WOyK4X8OoxHYdlhZLgRGpNrvD1fEagYffhVmwHcapE/tGiLgyrnezmXIo5RrH2NcrTHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.0.0.tgz",
+      "integrity": "sha512-f9oYpu3/UymB5JJDZRqOsNQm5FkMMC7u8eL8yQuqGAa54wTbgE2QbTOn70vgvlOVuYeQcw2mOQ52PpJHBSBkfQ==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.0"
+        "eventemitter3": "^5.0.4"
       }
     },
     "node_modules/picocolors": {
@@ -2287,7 +2286,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,17 @@
     "test": "vitest run",
     "prepare": "husky"
   },
-  "keywords": ["phaser3", "rpg", "dungeon", "roguelike", "javascript"],
+  "keywords": [
+    "phaser3",
+    "rpg",
+    "dungeon",
+    "roguelike",
+    "javascript"
+  ],
   "author": "Equipe 7",
   "license": "ISC",
   "dependencies": {
-    "phaser": "3.60.0"
+    "phaser": "4.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.2",

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,10 @@ const config = {
   backgroundColor: '#1a1a2e', // Fundo escuro fora do mapa
   parent: 'game-container',   // div no index.html
 
+  // Phaser 4 muda o padrão de roundPixels para false — forçar true
+  // para manter renderização precisa dos tiles pixel-art
+  roundPixels: true,
+
   // Escala responsiva
   scale: {
     mode: Phaser.Scale.FIT,


### PR DESCRIPTION
## O que muda

- Atualiza dependência \phaser\ de \3.60.0\ para \4.0.0\
- Adiciona \oundPixels: true\ no config do jogo (\src/main.js\)

## Por que o roundPixels

No Phaser 4 o padrão de \oundPixels\ mudou de \	rue\ para \alse\. Sem essa config explícita, os tiles do jogo poderiam apresentar bordas borradas ou posicionamento impreciso. A flag garante o mesmo comportamento visual que tínhamos no Phaser 3.

## Compatibilidade verificada

Todas as APIs usadas no projeto (cenas, input, câmera, tweens, formas geométricas, texto, eventos) são compatíveis com o Phaser 4 sem alterações adicionais.