### PR TITLE
feat: melhorias no dashboard do projeto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 ### Fixed
 - **Contributors incompletos no dashboard**: substituída varredura por branches (múltiplas chamadas, risco de duplicatas) pelo endpoint `/stats/contributors` — uma única chamada que retorna contagem real de commits únicos por autor em todo o repositório; inclui retry automático para retorno 202
 - **Dashboard travava no 403 (rate limit)**: refatorada `fetchData` com `safeApiFetch` — cada seção falha de forma isolada e um banner de aviso é exibido quando o rate limit da API pública do GitHub (60 req/hora) é atingido
+- **Contributors zerados quando `/stats/contributors` retorna erro**: adicionado fallback automático para o endpoint `/contributors` simples — garante exibição do ranking mesmo quando as estatísticas calculadas não estão disponíveis
 
 ---
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -274,28 +274,20 @@
      * nesse caso aguardamos 3s e tentamos uma segunda vez.
      */
     async function fetchAllContributors() {
-        const url = `https://api.github.com/repos/${OWNER}/${REPO}/stats/contributors`;
-
-        let res = await fetch(url, { headers: { 'Accept': 'application/vnd.github+json' } });
-
-        // 202 = GitHub ainda está calculando as estatísticas; tentar novamente
-        if (res.status === 202) {
-            await new Promise(r => setTimeout(r, 3000));
-            res = await fetch(url, { headers: { 'Accept': 'application/vnd.github+json' } });
-        }
-
-        if (!res.ok) return [];
-
-        const data = await res.json();
-        if (!Array.isArray(data)) return [];
-
-        return data
-            .map(entry => ({
-                login:         entry.author.login,
-                avatar_url:    entry.author.avatar_url,
-                contributions: entry.total,   // total de commits únicos no repositório
-            }))
-            .sort((a, b) => b.contributions - a.contributions);
+        try {
+            // Tenta o endpoint de estatísticas
+            let res = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/stats/contributors`);
+            if (res.status === 202) { await new Promise(r => setTimeout(r, 2000)); res = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/stats/contributors`); }
+            
+            if (res.ok) {
+                const data = await res.json();
+                if (Array.isArray(data)) return data.map(e => ({ login: e.author.login, avatar_url: e.author.avatar_url, contributions: e.total })).sort((a,b) => b.contributions - a.contributions);
+            }
+            
+            // FALLBACK: Se falhar, usa o endpoint simples
+            const simpleData = await apiFetch(`https://api.github.com/repos/${OWNER}/${REPO}/contributors`);
+            return simpleData.map(u => ({ login: u.login, avatar_url: u.avatar_url, contributions: u.contributions }));
+        } catch (e) { return []; }
     }
 
     // ─── Renderização ─────────────────────────────────────────────────────────

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -346,3 +346,20 @@ Objetivo:
 4. Exibir banner de aviso amarelo quando rate limit for detectado
 
 Arquivos gerados/modificados: `dashboard/index.html`, `CHANGELOG.md`, `docs/prompts/Vitor.md`
+
+---
+
+## Prompt 10 — fix(dashboard): fallback para /contributors quando /stats/contributors falha
+Autor: Vitor
+Data: 2026-05-03
+
+Contexto:
+O endpoint `/stats/contributors` pode retornar erro (ex: repositório sem histórico calculado
+ou rate limit) deixando o ranking de contributors vazio mesmo com o retry de 202.
+
+Objetivo:
+Adicionar fallback automático em `fetchAllContributors`: se `/stats/contributors` falhar
+ou retornar dado inválido, a função tenta o endpoint simples `/contributors` como segunda
+opção, garantindo que o ranking sempre exiba dados disponíveis.
+
+Arquivos gerados/modificados: `dashboard/index.html`, `CHANGELOG.md`, `docs/prompts/Vitor.md`


### PR DESCRIPTION
## Descrição

Corrige o dashboard de acompanhamento do projeto, que exibia contributors incompletos e travava com erro 403 ao atingir o rate limit da API pública do GitHub. A solução substitui a estratégia de varredura por branches por chamadas mais eficientes e resilientes.

---

## Tipo de mudança

- [ ] `feat` — nova funcionalidade
- [x] `fix` — correção de bug
- [ ] `refactor` — refatoração sem mudança de comportamento
- [ ] `docs` — apenas documentação
- [ ] `chore` — CI, dependências, configuração

---

## O que foi feito

- Substituída `fetchAllContributors` por chamada única ao endpoint `/stats/contributors`, que retorna todos os autores do repositório independente da branch, eliminando duplicatas e reduzindo drasticamente o número de chamadas à API
- Adicionado retry automático de 2s quando o endpoint retorna `202` (GitHub calculando estatísticas)
- Adicionado fallback para `/contributors` simples caso `/stats/contributors` falhe ou retorne dado inválido
- Refatorada `fetchData` com `safeApiFetch` — cada seção carrega de forma independente; uma falha não derruba as demais
- Adicionado banner de aviso amarelo quando rate limit (60 req/hora) é detectado

---

## Como testar

1. `npm install`
2. Abrir `dashboard/index.html` diretamente no browser (não precisa de `npm run dev`)
3. Verificar que o ranking de contributors exibe todos os membros do repositório com contagem de commits
4. Para testar o fallback: throttle a rede no DevTools para simular falha no `/stats/contributors` e confirmar que o ranking ainda aparece via `/contributors`
5. Para testar o rate limit: fazer mais de 60 requisições à API pública e confirmar que o banner amarelo aparece sem quebrar as outras seções

---

## Evidências

---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/Vitor.md` (se usei IA neste PR)
- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser

---

## Observações

O endpoint `/stats/contributors` é assíncrono do lado do GitHub — na primeira chamada após um período sem atividade pode retornar `202`. O retry de 2s cobre a maioria dos casos, mas em repositórios grandes pode ser necessário recarregar a página. A API pública tem limite de 60 req/hora sem autenticação; adicionar um token `GITHUB_TOKEN` como parâmetro de query removeria essa restrição.
