### PR TITLE
feat: implantacao da v0.2 do projeto com melhorias gerais no combate …

### DIFF
--- a/.kiro/specs/combat.spec.md
+++ b/.kiro/specs/combat.spec.md
@@ -26,19 +26,23 @@ O sistema de combate resolve interações de ataque entre o player e os inimigos
 ## Fórmula de Dano
 
 ```
-damage = attacker.attack
+hitChance = 80%
+if random < hitChance:
+  damage = attacker.attack
+else:
+  miss (damage = 0)
 ```
 
-> MVP usa dano fixo. Variação (crítico, defesa) é expansão futura.
+> Dano fixo em caso de acerto. Crítico e defesa são expansão futura.
 
 ---
 
 ## Regras
 
 - R1: Combate é iniciado quando player tenta mover para tile com inimigo
-- R2: Player ataca primeiro, depois o inimigo contra-ataca (se ainda vivo)
-- R3: Dano é sempre o valor de `attack` do atacante (sem aleatoriedade no MVP)
-- R4: Inimigo morto não contra-ataca
+- R2: Player ataca primeiro via `TurnManager`; inimigo age no turno seguinte
+- R3: Cada ataque tem 80% de chance de acerto — miss não aplica dano
+- R4: Inimigo morto não age no turno de inimigos
 - R5: Combate não consome o "turno de movimento" — player fica no tile atual
 - R6: Após combate, se inimigo morreu: conceder XP ao player via sistema de XP
 - R7: Feedback visual de dano deve aparecer por 800ms e desaparecer

--- a/.kiro/specs/enemy.spec.md
+++ b/.kiro/specs/enemy.spec.md
@@ -45,9 +45,12 @@ Inimigos são entidades hostis posicionadas na dungeon. No MVP, possuem comporta
 - R4: HP nunca fica abaixo de 0
 - R5: Quando HP = 0, `alive` = false, sprite removido, evento `enemy-died` emitido
 
-### Comportamento (MVP)
-- R6: No MVP, inimigos são estáticos (não se movem)
-- R7: Estrutura preparada para receber lógica de movimento futura
+### Comportamento (v0.2)
+- R6: Inimigos possuem máquina de estados: `IDLE → CHASING → ATTACKING`
+- R7: Detecção: entra em `CHASING` se player estiver na mesma sala BSP ou dentro do `detectionRadius` (8 tiles)
+- R8: Movimento: 1 tile por turno em direção ao player, priorizando o eixo de maior distância; respeita paredes e colisão entre inimigos
+- R9: Ataque: quando adjacente (distância Manhattan = 1), ataca com 80% de chance de acerto via `CombatSystem.attack()`
+- R10: Inimigos só agem após a ação do jogador (controlado pelo `TurnManager`)
 
 ---
 

--- a/.kiro/specs/input.spec.md
+++ b/.kiro/specs/input.spec.md
@@ -1,7 +1,7 @@
 # Spec — Input
 
 ## Descrição
-O sistema de input captura e interpreta as teclas pressionadas pelo jogador, traduzindo-as em ações do jogo (mover, atacar, esperar). No MVP, o input é processado pela `GameScene` usando o `InputPlugin` nativo do Phaser. Apenas um input é processado por turno.
+O sistema de input captura e interpreta as teclas pressionadas pelo jogador, traduzindo-as em ações do jogo (mover, atacar, esperar). O input é processado pela `GameScene` via `Phaser.Input.Keyboard.JustDown` — apenas um disparo por keypress. A ação é delegada ao `TurnManager`, que processa o turno completo (player + inimigos) antes de aceitar novo input.
 
 ---
 
@@ -38,13 +38,13 @@ O sistema de input captura e interpreta as teclas pressionadas pelo jogador, tra
 ## Regras
 
 - R1: Input só é processado quando o estado do jogo é `PLAYING`
-- R2: Apenas um input é processado por turno — inputs simultâneos são ignorados
-- R3: Teclas W/↑, S/↓, A/←, D/→ são equivalentes (ambas mapeiam para a mesma direção)
-- R4: Se o tile destino é `FLOOR` e está vazio → emite ação `move`
-- R5: Se o tile destino contém um inimigo vivo → emite ação `attack` (sem mover)
-- R6: Se o tile destino é `WALL` ou fora dos limites → input ignorado silenciosamente
-- R7: Espaço sempre emite ação `wait`, independente do tile adjacente
-- R8: Input não é processado durante animações ou transições de cena (futuro)
+- R2: Apenas um input por keypress (`JustDown`) — segurar a tecla não repete a ação
+- R3: Input bloqueado enquanto `TurnManager.isPlayerTurn()` retornar `false`
+- R4: Teclas W/↑, S/↓, A/←, D/→ são equivalentes (ambas mapeiam para a mesma direção)
+- R5: Se o tile destino é `FLOOR` e está vazio → ação `MOVE`
+- R6: Se o tile destino contém um inimigo vivo → ação `ATTACK` (player não move)
+- R7: Se o tile destino é `WALL` ou fora dos limites → input ignorado silenciosamente
+- R8: Espaço gera ação `WAIT` — passa o turno sem mover, inimigos ainda agem
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,16 +50,41 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ## [Unreleased]
 
-### Added
-- Spec de Fog of War (`.kiro/specs/fog-of-war.spec.md`): define os 3 estados de visibilidade de tile (`HIDDEN`, `VISIBLE`, `REVEALED`), raio de visão por distância de Chebyshev, revelação de sala inteira ao entrar, ocultação de sprites de inimigos fora do campo de visão e 10 cenários testáveis (incluindo 2 property-based tests de monotonicidade de estado)
+---
+
+## [0.2.0] — 2026-05-04
 
 ### Added
-- Variantes de chão aleatórias por sessão: 14 frames distintos do `Ground0.png` (pedra, terra, grama, areia, neve, rocha vulcânica, etc.)
-- Cada nova partida sorteia um tipo de chão diferente, gerando ambientes visualmente únicos
+
+#### Sistema de Turnos Real (`TurnManager`)
+- Novo `src/systems/TurnManager.ts`: centraliza o controle de turno — o jogo só avança quando o jogador age
+- Tipo `Action` explícito: `MOVE | ATTACK | WAIT` — cada tecla pressiona gera exatamente uma ação
+- Input migrado de `isDown` (contínuo) para `JustDown` (um keypress = um turno) — elimina o cooldown de 150ms
+- Tecla `SPACE` registrada para ação `WAIT` (passa o turno sem mover)
+- Inimigos só agem após a ação do jogador ser processada — sem paralelismo de turno
+
+#### Entidade Enemy pura (`src/entities/Enemy.ts`)
+- Nova classe `Enemy` sem dependência de Phaser: apenas dados (`gridX`, `gridY`, `hp`, `attack`, `alive`) e lógica de domínio
+- Método `takeDamage(amount)` com guarda de `alive`
+- Método `getPixelPos()` para conversão de grid para pixels
+- Separação clara entre entidade de domínio (`Enemy.ts`) e lógica de IA + sprite (`EnemySystem.ts`)
+
+#### Combate com Chance de Acerto
+- `CombatSystem.attack(attacker, defender)`: novo método com **80% de chance de acerto** por ataque
+- Miss resulta em mensagem `"Você errou o ataque"` / `"Inimigo errou"` no log
+- Método `resolve()` anterior mantido para não quebrar testes existentes
+
+#### Feedback de Combate no Log
+- Mensagens detalhadas por evento: dano causado, miss, morte de inimigo, morte do player
+- Todas as mensagens emitidas via `EventBus` (`EVENTS.UI_LOG`) para o log da UIScene
 
 ### Changed
-- Reorganização da arquitetura de documentação: specs movidas de `.kiro/steering/` para `.kiro/specs/`, seguindo o padrão correto do Kiro
-- Recriado `.kiro/steering/game-steering.md` com diretrizes atualizadas (stack TypeScript, estrutura de pastas correta)
+
+- `GameScene._handleInput()`: removidos `_tickEnemies()` e `_resolveCombat()` — lógica migrada para `TurnManager`
+- `GameScene._setupInput()`: SPACE registrado como tecla de WAIT
+- Spec de Fog of War (`.kiro/specs/fog-of-war.spec.md`): 3 estados de visibilidade (`HIDDEN`, `VISIBLE`, `REVEALED`), raio Chebyshev, revelação de sala inteira, 10 cenários testáveis
+- Variantes de chão aleatórias por sessão: 14 frames do `Ground0.png` sorteados por partida
+- Reorganização de documentação: specs movidas de `.kiro/steering/` para `.kiro/specs/`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Veja o histórico completo de mudanças no [CHANGELOG.md](./CHANGELOG.md).
 - **Nome:** Rafael
   - 📧 Email: rafael_n_rosa@estudante.sesisenai.org.br
   - 💻 GitHub: https://github.com/andreagonzalez  
-  - 💻 Função: Paladina
+  - 💻 Função: Paladino
 
 
 

--- a/docs/fase_2_plano.md
+++ b/docs/fase_2_plano.md
@@ -1,0 +1,186 @@
+# Plano: Fase 2 — Sistema de Turnos e Combate
+
+## Contexto
+
+O projeto **Dungeon of Echoes** tem a Fase 1 completa: geração de dungeon BSP, movimento grid-based, sistema de combate, IA de inimigos e HUD. Contudo, o "turn-based" atual é simulado via cooldown de 150ms em `GameScene.update()` — o jogo avança em tempo real com throttle, não puramente por ação do jogador. A Fase 2 exige arquitetura de turno real: o jogo só avança quando o jogador age, e inimigos só agem após o turno do jogador.
+
+---
+
+## Conflito entre fase_2.md e .kiro/specs/combat.spec.md
+
+| Ponto | fase_2.md | .kiro/combat.spec.md |
+|---|---|---|
+| Chance de acerto | 80% (pode errar) | Sem aleatoriedade no MVP |
+
+**Decisão:** Seguir `fase_2.md` (instrução corrente). Implementar 80% hit chance no `CombatSystem`.
+
+---
+
+## Arquivos a modificar / criar
+
+| Arquivo | Ação |
+|---|---|
+| `src/systems/TurnManager.ts` | **CRIAR** — controla estado do turno |
+| `src/entities/Enemy.ts` | **CRIAR** — entidade pura Enemy |
+| `src/systems/CombatSystem.ts` | **ATUALIZAR** — adicionar 80% hit chance |
+| `src/scenes/GameScene.ts` | **REFATORAR** — delegar ao TurnManager, remover cooldown real-time |
+| `src/entities/Player.ts` | **ATUALIZAR** — ajustar hp=20, attack=5 base (se necessário) |
+
+---
+
+## Passo a Passo
+
+### 1. Criar `src/entities/Enemy.ts`
+
+Entidade pura, sem Phaser, sem sprite (sprite fica no GameScene):
+
+```ts
+export class Enemy {
+  id: string
+  gridX: number
+  gridY: number
+  hp: number
+  maxHp: number
+  attack: number
+  alive: boolean
+
+  constructor(gridX, gridY, hp = 10, attack = 3)
+  takeDamage(amount: number): void  // seta alive=false se hp <= 0
+  getPixelPos(): { x, y }           // gridX/Y * TILE_SIZE + offset
+}
+```
+
+> `EnemySystem.ts` atual tem lógica de IA acoplada à entidade. O `Enemy.ts` é a entidade pura; a IA permanece em `EnemySystem.ts` (ou migra para `TurnManager`).
+
+---
+
+### 2. Criar `src/systems/TurnManager.ts`
+
+Responsável pelo fluxo de turno. Não depende de Phaser.
+
+```ts
+type Action =
+  | { type: 'MOVE'; dx: number; dy: number }
+  | { type: 'ATTACK'; targetId: string }
+  | { type: 'WAIT' }
+
+export class TurnManager {
+  private playerTurn: boolean = true
+
+  isPlayerTurn(): boolean
+
+  processPlayerAction(
+    action: Action,
+    player: Player,
+    enemies: Enemy[],
+    dungeon: DungeonGenerator,
+    combatSystem: CombatSystem,
+    onEnemyTurn: (results: TurnResult[]) => void
+  ): TurnResult
+}
+```
+
+**Fluxo interno de `processPlayerAction`:**
+1. Se `!playerTurn` → ignora
+2. Resolve ação do player (MOVE, ATTACK ou WAIT)
+3. `playerTurn = false`
+4. Para cada inimigo vivo: executa turno (IA simples)
+5. `playerTurn = true`
+6. Retorna resultados agregados
+
+---
+
+### 3. Atualizar `src/systems/CombatSystem.ts`
+
+Adicionar `attack(attacker, defender)` com 80% hit chance:
+
+```ts
+attack(attacker: { attack: number }, defender: { hp: number }): CombatResult {
+  const hit = Math.random() < 0.80
+  if (hit) {
+    defender.hp -= attacker.attack
+    return { hit: true, damage: attacker.attack }
+  }
+  return { hit: false, damage: 0 }
+}
+```
+
+Manter `resolve(player, enemy)` existente para não quebrar testes.
+
+---
+
+### 4. IA dos Inimigos (dentro do TurnManager)
+
+Para cada inimigo vivo durante o turno de inimigos:
+
+```ts
+const dx = Math.sign(player.gridX - enemy.gridX)
+const dy = Math.sign(player.gridY - enemy.gridY)
+
+const distX = Math.abs(player.gridX - enemy.gridX)
+const distY = Math.abs(player.gridY - enemy.gridY)
+
+// Adjacente ao player → ataca
+if (distX + distY === 1) {
+  combatSystem.attack(enemy, player)
+} else {
+  // Move em 1 eixo por turno (prioriza o de maior distância)
+  if (distX >= distY && dungeon.isWalkable(enemy.gridX + dx, enemy.gridY)) {
+    enemy.gridX += dx
+  } else if (dungeon.isWalkable(enemy.gridX, enemy.gridY + dy)) {
+    enemy.gridY += dy
+  }
+}
+```
+
+---
+
+### 5. Refatorar `src/scenes/GameScene.ts`
+
+- **Remover** cooldown de 150ms e `Date.now()` do movimento
+- **Remover** loop de inimigos do `update()` (não mais em tempo real)
+- **Adicionar** `TurnManager` como propriedade da cena
+- No handler de input (teclado), chamar `turnManager.processPlayerAction(action, ...)`
+- Callbacks para atualizar sprites, HP bars, message log após cada turno
+- Morte do player: travar input (`playerTurn` fica false permanentemente), emitir `player-died`
+- Morte de inimigo: remover sprite e da lista
+
+---
+
+### 6. Spawn de Inimigos
+
+- Usar `createEnemies()` existente em `EnemySystem.ts` como referência
+- Spawnar 3–5 inimigos com `hp=10`, `attack=3` (valores da Fase 2 conforme fase_2.md: player hp=20, attack=5)
+- Posições aleatórias em `FLOOR` tiles, fora do spawn do player
+
+---
+
+### 7. Feedback Visual
+
+Exibir no message log existente (UIScene já tem 5 linhas scrolláveis via EventBus):
+
+- `"Você atacou e causou 5 de dano"`
+- `"Você errou o ataque"`
+- `"Inimigo atacou você por 3"`
+- `"Você morreu"` / `"Inimigo morreu"`
+
+---
+
+## Verificação
+
+1. `npm run dev` → iniciar o jogo
+2. Mover o player com WASD/Arrows → confirmar que inimigos só se movem após ação
+3. Colidir com inimigo → confirmar ATTACK (não MOVE)
+4. Aguardar Game Over → confirmar tela exibida
+5. Matar inimigo → confirmar remoção do mapa
+6. `npm test` → todos os testes existentes devem continuar passando; adicionar testes para `TurnManager` e `Enemy`
+
+---
+
+## Ordem de Implementação
+
+1. `Enemy.ts` (sem dependências)
+2. `CombatSystem.ts` (adicionar `attack()`)
+3. `TurnManager.ts` (usa Enemy, CombatSystem, Player, DungeonGenerator)
+4. `GameScene.ts` (usa TurnManager, atualiza sprites)
+5. Testes unitários para TurnManager e Enemy

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -349,6 +349,45 @@ Arquivos gerados/modificados: `dashboard/index.html`, `CHANGELOG.md`, `docs/prom
 
 ---
 
+## Prompt 11 — feat(turn-system): TurnManager, Enemy entity, combate com 80% hit chance
+Autor: Vitor
+Data: 2026-05-04
+
+Contexto:
+O jogo possuía um sistema "turno-based" simulado via cooldown de 150ms em `GameScene.update()`,
+usando `isDown` (input contínuo). Isso não é verdadeiramente turn-based: o jogo avançava em
+tempo real com throttle, não esperando a ação do jogador.
+
+Objetivo:
+Implementar a Fase 2 do roguelike com arquitetura de turno real, seguindo o documento `fase_2.md`:
+1. Criar `src/entities/Enemy.ts` — entidade pura sem Phaser (apenas dados e lógica de domínio)
+2. Adicionar `attack(attacker, defender)` ao `CombatSystem` com 80% chance de acerto (miss ou hit)
+3. Criar `src/systems/TurnManager.ts` — controla estado do turno, bloqueia input fora do turno do
+   jogador, processa ação do player, executa turno de todos os inimigos, retorna resultados
+4. Refatorar `src/scenes/GameScene.ts`:
+   - Substituir `isDown` (contínuo) por `JustDown` (um keypress = um turno)
+   - Remover `_tickEnemies()` e `_resolveCombat()` — lógica migrada para TurnManager
+   - Adicionar tecla SPACE para ação WAIT (passa o turno)
+   - Delegar todo fluxo de turno ao TurnManager
+
+Tipo de Ação (Action):
+```ts
+type Action =
+  | { type: 'MOVE'; dx: number; dy: number }
+  | { type: 'ATTACK'; target: EnemySystem }
+  | { type: 'WAIT' }
+```
+
+Regras arquiteturais mantidas:
+- TurnManager não importa Phaser diretamente
+- Sistemas nunca importam cenas
+- Feedback visual via EventBus (EVENTS.UI_LOG)
+
+Arquivos gerados/modificados: `src/entities/Enemy.ts` (novo), `src/systems/TurnManager.ts` (novo),
+`src/systems/CombatSystem.ts`, `src/scenes/GameScene.ts`, `docs/fase_2_plano.md` (novo)
+
+---
+
 ## Prompt 10 — fix(dashboard): fallback para /contributors quando /stats/contributors falha
 Autor: Vitor
 Data: 2026-05-03

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jogo-dungeon-of-echoes",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Dungeon of Echoes – RPG 2D tile-based com geração procedural",
   "scripts": {

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,0 +1,36 @@
+import { TILE_SIZE } from '../utils/constants';
+
+export class Enemy {
+  id: string;
+  gridX: number;
+  gridY: number;
+  hp: number;
+  maxHp: number;
+  attack: number;
+  alive: boolean;
+
+  constructor(id: string, gridX: number, gridY: number, hp = 10, attack = 3) {
+    this.id     = id;
+    this.gridX  = gridX;
+    this.gridY  = gridY;
+    this.hp     = hp;
+    this.maxHp  = hp;
+    this.attack = attack;
+    this.alive  = true;
+  }
+
+  takeDamage(amount: number): void {
+    if (!this.alive) return;
+    this.hp = Math.max(0, this.hp - amount);
+    if (this.hp <= 0) {
+      this.alive = false;
+    }
+  }
+
+  getPixelPos(): { x: number; y: number } {
+    return {
+      x: this.gridX * TILE_SIZE + TILE_SIZE / 2,
+      y: this.gridY * TILE_SIZE + TILE_SIZE / 2,
+    };
+  }
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -4,6 +4,7 @@ import { Player } from '../entities/Player';
 import { EnemySystem, createEnemies } from '../systems/EnemySystem';
 import { CombatSystem } from '../systems/CombatSystem';
 import { XPSystem } from '../systems/XPSystem';
+import { TurnManager } from '../systems/TurnManager';
 import { EventBus } from '../utils/EventBus';
 import {
   TILE_SIZE,
@@ -23,12 +24,14 @@ export class GameScene extends Phaser.Scene {
   private xpSystem!: XPSystem;
   private combatSystem!: CombatSystem;
   private gameState!: string;
+  private turnManager!: TurnManager;
 
   // Frame de chão sorteado para esta sessão
   private floorFrame!: number;
 
   private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
   private wasd!: Record<string, Phaser.Input.Keyboard.Key>;
+  private spaceKey!: Phaser.Input.Keyboard.Key;
 
   constructor() {
     super({ key: 'GameScene' });
@@ -66,10 +69,11 @@ export class GameScene extends Phaser.Scene {
     this.dungeon = new DungeonGenerator();
     this.dungeon.generate();
 
-    this.xpSystem    = new XPSystem(emitter);
-    this.player      = new Player(this, this.dungeon.startPos.x, this.dungeon.startPos.y);
-    this.enemies     = createEnemies(this.dungeon, ENEMY.COUNT, this.dungeon.startPos);
+    this.xpSystem     = new XPSystem(emitter);
+    this.player       = new Player(this, this.dungeon.startPos.x, this.dungeon.startPos.y);
+    this.enemies      = createEnemies(this.dungeon, ENEMY.COUNT, this.dungeon.startPos);
     this.combatSystem = new CombatSystem(emitter, this.xpSystem);
+    this.turnManager  = new TurnManager();
   }
 
   private _emitInitialUIState(): void {
@@ -153,80 +157,56 @@ export class GameScene extends Phaser.Scene {
       left:  Phaser.Input.Keyboard.KeyCodes.A,
       right: Phaser.Input.Keyboard.KeyCodes.D,
     }) as Record<string, Phaser.Input.Keyboard.Key>;
+    this.spaceKey = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
   }
 
-  private _handleInput(time: number): void {
-    // isDown permite movimento contínuo ao segurar a tecla.
-    // Player.tryMove tem cooldown interno (150ms) que controla a cadência.
+  private _handleInput(_time: number): void {
+    if (!this.turnManager.isPlayerTurn()) return;
+
+    const JD = Phaser.Input.Keyboard.JustDown;
     let dx = 0;
     let dy = 0;
 
-    if      (this.cursors.up.isDown    || this.wasd.up.isDown)    dy = -1;
-    else if (this.cursors.down.isDown  || this.wasd.down.isDown)  dy =  1;
-    else if (this.cursors.left.isDown  || this.wasd.left.isDown)  dx = -1;
-    else if (this.cursors.right.isDown || this.wasd.right.isDown) dx =  1;
+    if      (JD(this.cursors.up)    || JD(this.wasd.up))    dy = -1;
+    else if (JD(this.cursors.down)  || JD(this.wasd.down))  dy =  1;
+    else if (JD(this.cursors.left)  || JD(this.wasd.left))  dx = -1;
+    else if (JD(this.cursors.right) || JD(this.wasd.right)) dx =  1;
 
-    if (dx === 0 && dy === 0) return;
+    const isWait = JD(this.spaceKey);
+    if (dx === 0 && dy === 0 && !isWait) return;
 
-    const result = this.player.tryMove(dx, dy, this.dungeon, this.enemies, time);
+    const tx = this.player.gridX + dx;
+    const ty = this.player.gridY + dy;
+    const targetEnemy = !isWait && this.enemies.find(
+      (e) => e.alive && e.gridX === tx && e.gridY === ty,
+    );
 
-    if (result.moved) {
-      this._tickEnemies();
-    } else if (result.enemy) {
-      this._resolveCombat(result.enemy as EnemySystem);
-      this._tickEnemies();
-    }
-  }
+    const action = isWait
+      ? { type: 'WAIT' as const }
+      : targetEnemy
+        ? { type: 'ATTACK' as const, target: targetEnemy }
+        : { type: 'MOVE' as const, dx, dy };
 
-  // ─── Turno dos Inimigos ──────────────────────────────────────────────────
+    const result = this.turnManager.processPlayerAction(
+      action,
+      this.player,
+      this.enemies,
+      this.dungeon,
+      this.combatSystem,
+    );
 
-  private _tickEnemies(): void {
-    if (this.gameState !== GAME_STATE.PLAYING) return;
+    result.messages.forEach((msg) => EventBus.emit(EVENTS.UI_LOG, msg));
 
-    this.enemies.forEach((enemy) => {
-      if (!enemy.alive) return;
+    // Sincronizar sprites após o turno completo
+    this.enemies.forEach((e) => this._syncEnemySprite(e));
 
-      const result = enemy.update(
-        this.player.gridX,
-        this.player.gridY,
-        this.dungeon,
-        this.enemies,
-      );
-
-      if (result.attacked && result.damage > 0) {
-        this.player.takeDamage(result.damage);
-        this._showDamageText(this.player.getPixelPos(), result.damage, '#ff8800');
-        EventBus.emit(EVENTS.UI_LOG, `Inimigo atacou: -${result.damage} HP`);
-      }
-
-      this._syncEnemySprite(enemy);
+    result.enemiesDied.forEach((e) => {
+      EventBus.emit(EVENTS.UI_LOG, `+${e.xpReward} XP`);
+      this._removeEnemySprite(e);
     });
-  }
 
-  // ─── Combate (player → inimigo) ──────────────────────────────────────────
-
-  private _resolveCombat(enemy: EnemySystem): void {
-    const result = this.combatSystem.resolve(this.player, enemy);
-    if (!result) return;
-
-    if (result.playerDamage > 0) {
-      this._showDamageText(enemy.getPixelPos(), result.playerDamage, COLORS.DAMAGE_TEXT);
-      EventBus.emit(EVENTS.UI_LOG, `Atacou inimigo: -${result.playerDamage} HP`);
-    }
-
-    if (result.enemyDamage > 0) {
-      this._showDamageText(this.player.getPixelPos(), result.enemyDamage, '#ff8800');
-      EventBus.emit(EVENTS.UI_LOG, `Inimigo contra-atacou: -${result.enemyDamage} HP`);
-      // CombatSystem modifica player.hp diretamente; sincroniza UIScene manualmente
-      EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
-    }
-
-    if (result.enemyDied) {
-      this._removeEnemySprite(enemy);
-      EventBus.emit(EVENTS.UI_LOG, `Inimigo derrotado. +${ENEMY.XP_REWARD} XP`);
-    } else {
-      // FIX: atualiza a barra de HP do inimigo após sofrer dano
-      this._syncEnemySprite(enemy);
+    if (result.playerDied) {
+      this.events.emit(EVENTS.PLAYER_DIED);
     }
   }
 

--- a/src/systems/CombatSystem.ts
+++ b/src/systems/CombatSystem.ts
@@ -9,6 +9,11 @@ export interface CombatResult {
   playerDied: boolean;
 }
 
+export interface AttackResult {
+  hit: boolean;
+  damage: number;
+}
+
 export class CombatSystem {
   private emitter: Phaser.Events.EventEmitter;
   private xpSystem: XPSystem;
@@ -16,6 +21,17 @@ export class CombatSystem {
   constructor(emitter: Phaser.Events.EventEmitter, xpSystem: XPSystem) {
     this.emitter = emitter;
     this.xpSystem = xpSystem;
+  }
+
+  /** Ataque com 80% de chance de acerto. Não aplica dano — chamador é responsável. */
+  attack(
+    attacker: { attack: number },
+    _defender: { hp: number },
+  ): AttackResult {
+    const hit = Math.random() < 0.8;
+    return hit
+      ? { hit: true, damage: attacker.attack }
+      : { hit: false, damage: 0 };
   }
 
   resolve(

--- a/src/systems/TurnManager.ts
+++ b/src/systems/TurnManager.ts
@@ -1,0 +1,100 @@
+import { TILE_SIZE, EVENTS } from '../utils/constants';
+import { EventBus } from '../utils/EventBus';
+import type { Player } from '../entities/Player';
+import type { EnemySystem } from './EnemySystem';
+import type { CombatSystem } from './CombatSystem';
+import type { DungeonGenerator } from '../generators/DungeonGenerator';
+
+export type Action =
+  | { type: 'MOVE'; dx: number; dy: number }
+  | { type: 'ATTACK'; target: EnemySystem }
+  | { type: 'WAIT' };
+
+export interface TurnResult {
+  messages: string[];
+  playerMoved: boolean;
+  playerDied: boolean;
+  enemiesDied: EnemySystem[];
+}
+
+export class TurnManager {
+  private playerTurn = true;
+
+  isPlayerTurn(): boolean {
+    return this.playerTurn;
+  }
+
+  processPlayerAction(
+    action: Action,
+    player: Player,
+    enemies: EnemySystem[],
+    dungeon: DungeonGenerator,
+    combat: CombatSystem,
+  ): TurnResult {
+    const result: TurnResult = {
+      messages: [],
+      playerMoved: false,
+      playerDied: false,
+      enemiesDied: [],
+    };
+
+    if (!this.playerTurn) return result;
+
+    this.playerTurn = false;
+
+    // ─── Ação do jogador ────────────────────────────────────────────────────
+    if (action.type === 'MOVE') {
+      const tx = player.gridX + action.dx;
+      const ty = player.gridY + action.dy;
+      if (dungeon.isWalkable(tx, ty)) {
+        player.gridX = tx;
+        player.gridY = ty;
+        player.setPosition(tx * TILE_SIZE + TILE_SIZE / 2, ty * TILE_SIZE + TILE_SIZE / 2);
+        result.playerMoved = true;
+      }
+    } else if (action.type === 'ATTACK') {
+      const target = action.target;
+      const atk = combat.attack(player, target);
+      if (atk.hit) {
+        target.hp = Math.max(0, target.hp - atk.damage);
+        result.messages.push(`Você atacou e causou ${atk.damage} de dano`);
+        if (target.hp <= 0) {
+          target.alive = false;
+          result.enemiesDied.push(target);
+          result.messages.push('Inimigo morreu');
+          combat['xpSystem']?.addXP(player, target.xpReward);
+        }
+      } else {
+        result.messages.push('Você errou o ataque');
+      }
+    }
+    // WAIT: não faz nada
+
+    // ─── Turno dos inimigos ─────────────────────────────────────────────────
+    for (const enemy of enemies) {
+      if (!enemy.alive) continue;
+
+      const ai = enemy.update(player.gridX, player.gridY, dungeon, enemies);
+
+      if (ai.attacked) {
+        const atk = combat.attack(enemy, player);
+        if (atk.hit) {
+          player.hp = Math.max(0, player.hp - atk.damage);
+          EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: player.hp, maxHp: player.maxHp });
+          result.messages.push(`Inimigo atacou você por ${atk.damage}`);
+          if (player.hp <= 0) {
+            result.playerDied = true;
+            result.messages.push('Você morreu');
+          }
+        } else {
+          result.messages.push('Inimigo errou');
+        }
+      }
+
+      if (result.playerDied) break;
+    }
+
+    this.playerTurn = true;
+    return result;
+  }
+}

--- a/tests/combat.test.js
+++ b/tests/combat.test.js
@@ -108,3 +108,48 @@ describe('CombatSystem', () => {
     expect(player.hp).toBe(85);
   });
 });
+
+describe('CombatSystem.attack() — 80% hit chance', () => {
+  let combat, emitter, xpSystem;
+
+  beforeEach(() => {
+    emitter   = createEmitter();
+    xpSystem  = new XPSystem(emitter);
+    combat    = new CombatSystem(emitter, xpSystem);
+  });
+
+  it('retorna damage = attacker.attack quando acerta', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5); // < 0.8 → acerto
+    const result = combat.attack({ attack: 7 }, { hp: 30 });
+    expect(result.hit).toBe(true);
+    expect(result.damage).toBe(7);
+    vi.restoreAllMocks();
+  });
+
+  it('retorna damage = 0 quando erra', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.9); // ≥ 0.8 → erro
+    const result = combat.attack({ attack: 7 }, { hp: 30 });
+    expect(result.hit).toBe(false);
+    expect(result.damage).toBe(0);
+    vi.restoreAllMocks();
+  });
+
+  it('NÃO modifica o HP do defensor (responsabilidade do chamador)', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.1); // acerto garantido
+    const defender = { hp: 30 };
+    combat.attack({ attack: 10 }, defender);
+    expect(defender.hp).toBe(30); // inalterado
+    vi.restoreAllMocks();
+  });
+
+  it('taxa de acerto estatisticamente próxima de 80% em 1000 amostras', () => {
+    vi.restoreAllMocks(); // usar Math.random real
+    let hits = 0;
+    for (let i = 0; i < 1000; i++) {
+      if (combat.attack({ attack: 1 }, { hp: 99 }).hit) hits++;
+    }
+    // Aceitar desvio de ±5% (750–850 hits)
+    expect(hits).toBeGreaterThanOrEqual(750);
+    expect(hits).toBeLessThanOrEqual(850);
+  });
+});

--- a/tests/enemy.test.js
+++ b/tests/enemy.test.js
@@ -97,3 +97,62 @@ describe('createEnemies', () => {
     enemies.forEach((e) => expect(e.alive).toBe(true));
   });
 });
+
+// ─── Enemy.ts — entidade pura ──────────────────────────────────────────────
+
+import { Enemy } from '../src/entities/Enemy';
+import { TILE_SIZE } from '../src/utils/constants';
+
+describe('Enemy (entidade pura)', () => {
+  let enemy;
+
+  beforeEach(() => {
+    enemy = new Enemy('e0', 4, 6, 10, 3);
+  });
+
+  it('inicializa com os atributos fornecidos', () => {
+    expect(enemy.id).toBe('e0');
+    expect(enemy.gridX).toBe(4);
+    expect(enemy.gridY).toBe(6);
+    expect(enemy.hp).toBe(10);
+    expect(enemy.maxHp).toBe(10);
+    expect(enemy.attack).toBe(3);
+    expect(enemy.alive).toBe(true);
+  });
+
+  it('usa valores padrão hp=10 e attack=3 quando omitidos', () => {
+    const e = new Enemy('x', 0, 0);
+    expect(e.hp).toBe(10);
+    expect(e.attack).toBe(3);
+  });
+
+  it('takeDamage reduz hp corretamente', () => {
+    enemy.takeDamage(4);
+    expect(enemy.hp).toBe(6);
+    expect(enemy.alive).toBe(true);
+  });
+
+  it('hp nunca fica abaixo de 0', () => {
+    enemy.takeDamage(999);
+    expect(enemy.hp).toBe(0);
+  });
+
+  it('seta alive=false quando hp chega a 0', () => {
+    enemy.takeDamage(10);
+    expect(enemy.alive).toBe(false);
+  });
+
+  it('takeDamage em inimigo morto é ignorado silenciosamente', () => {
+    enemy.alive = false;
+    enemy.hp = 0;
+    enemy.takeDamage(5);
+    expect(enemy.hp).toBe(0); // não vai negativo
+    expect(enemy.alive).toBe(false);
+  });
+
+  it('getPixelPos calcula posição em pixels com TILE_SIZE=16', () => {
+    const pos = enemy.getPixelPos();
+    expect(pos.x).toBe(4 * TILE_SIZE + TILE_SIZE / 2);
+    expect(pos.y).toBe(6 * TILE_SIZE + TILE_SIZE / 2);
+  });
+});

--- a/tests/turn-manager.test.js
+++ b/tests/turn-manager.test.js
@@ -1,0 +1,329 @@
+/**
+ * turn-manager.test.js — Testes do TurnManager
+ * Valida o controle de turno, ações do player e turno dos inimigos.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TurnManager } from '../src/systems/TurnManager';
+import { TILE, TILE_SIZE } from '../src/utils/constants';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function createPlayer(gridX = 5, gridY = 5, hp = 20, attack = 5) {
+  return {
+    gridX,
+    gridY,
+    hp,
+    maxHp: hp,
+    attack,
+    setPosition: vi.fn(),
+  };
+}
+
+function createEnemy(gridX, gridY, hp = 10, attack = 3) {
+  return {
+    gridX,
+    gridY,
+    hp,
+    maxHp: hp,
+    attack,
+    xpReward: 25,
+    alive: true,
+    update: vi.fn().mockReturnValue({ attacked: false, damage: 0 }),
+  };
+}
+
+function createCombat(alwaysHit = true, damage = null) {
+  return {
+    attack: vi.fn().mockImplementation((attacker) => ({
+      hit: alwaysHit,
+      damage: alwaysHit ? (damage ?? attacker.attack) : 0,
+    })),
+    xpSystem: { addXP: vi.fn() },
+  };
+}
+
+function createDungeon(walkable = true) {
+  return {
+    isWalkable: vi.fn().mockReturnValue(walkable),
+    rooms: [],
+  };
+}
+
+// ─── Testes ──────────────────────────────────────────────────────────────────
+
+describe('TurnManager — estado de turno', () => {
+  it('isPlayerTurn() retorna true inicialmente', () => {
+    const tm = new TurnManager();
+    expect(tm.isPlayerTurn()).toBe(true);
+  });
+
+  it('retorna ao turno do player após processPlayerAction', () => {
+    const tm      = new TurnManager();
+    const player  = createPlayer();
+    const dungeon = createDungeon(true);
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [], dungeon, createCombat());
+
+    expect(tm.isPlayerTurn()).toBe(true);
+  });
+});
+
+describe('TurnManager — ação WAIT', () => {
+  it('não move o player', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(5, 5);
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [], createDungeon(), createCombat());
+
+    expect(player.gridX).toBe(5);
+    expect(player.gridY).toBe(5);
+    expect(player.setPosition).not.toHaveBeenCalled();
+  });
+
+  it('inimigos agem mesmo no WAIT', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(5, 5);
+    const enemy  = createEnemy(6, 5);
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [enemy], createDungeon(), createCombat());
+
+    expect(enemy.update).toHaveBeenCalledOnce();
+  });
+});
+
+describe('TurnManager — ação MOVE', () => {
+  it('atualiza gridX/Y do player quando tile é walkable', () => {
+    const tm      = new TurnManager();
+    const player  = createPlayer(5, 5);
+    const dungeon = createDungeon(true);
+
+    tm.processPlayerAction({ type: 'MOVE', dx: 1, dy: 0 }, player, [], dungeon, createCombat());
+
+    expect(player.gridX).toBe(6);
+    expect(player.gridY).toBe(5);
+  });
+
+  it('chama setPosition com coordenadas em pixels corretas', () => {
+    const tm      = new TurnManager();
+    const player  = createPlayer(5, 5);
+    const dungeon = createDungeon(true);
+
+    tm.processPlayerAction({ type: 'MOVE', dx: 0, dy: 1 }, player, [], dungeon, createCombat());
+
+    const expectedX = 5 * TILE_SIZE + TILE_SIZE / 2;
+    const expectedY = 6 * TILE_SIZE + TILE_SIZE / 2;
+    expect(player.setPosition).toHaveBeenCalledWith(expectedX, expectedY);
+  });
+
+  it('não move quando tile não é walkable', () => {
+    const tm      = new TurnManager();
+    const player  = createPlayer(5, 5);
+    const dungeon = createDungeon(false);
+
+    tm.processPlayerAction({ type: 'MOVE', dx: 1, dy: 0 }, player, [], dungeon, createCombat());
+
+    expect(player.gridX).toBe(5);
+    expect(player.setPosition).not.toHaveBeenCalled();
+  });
+
+  it('playerMoved = true no resultado quando move com sucesso', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(5, 5);
+
+    const result = tm.processPlayerAction(
+      { type: 'MOVE', dx: 1, dy: 0 }, player, [], createDungeon(true), createCombat(),
+    );
+
+    expect(result.playerMoved).toBe(true);
+  });
+
+  it('playerMoved = false quando bloqueado', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(5, 5);
+
+    const result = tm.processPlayerAction(
+      { type: 'MOVE', dx: 1, dy: 0 }, player, [], createDungeon(false), createCombat(),
+    );
+
+    expect(result.playerMoved).toBe(false);
+  });
+});
+
+describe('TurnManager — ação ATTACK (player → inimigo)', () => {
+  it('chama combat.attack com player e inimigo', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer();
+    const enemy  = createEnemy(6, 5);
+    const combat = createCombat(true, 5);
+
+    tm.processPlayerAction({ type: 'ATTACK', target: enemy }, player, [enemy], createDungeon(), combat);
+
+    expect(combat.attack).toHaveBeenCalledWith(player, enemy);
+  });
+
+  it('reduz HP do inimigo quando acerta', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(20, 5, 20, 5);
+    const enemy  = createEnemy(6, 5, 10, 3);
+    const combat = createCombat(true, 5);
+
+    tm.processPlayerAction({ type: 'ATTACK', target: enemy }, player, [enemy], createDungeon(), combat);
+
+    expect(enemy.hp).toBe(5);
+  });
+
+  it('não reduz HP do inimigo quando erra', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer();
+    const enemy  = createEnemy(6, 5, 10);
+    const combat = createCombat(false);
+
+    tm.processPlayerAction({ type: 'ATTACK', target: enemy }, player, [enemy], createDungeon(), combat);
+
+    expect(enemy.hp).toBe(10);
+  });
+
+  it('seta enemy.alive=false quando hp ≤ 0', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer();
+    const enemy  = createEnemy(6, 5, 5);
+    const combat = createCombat(true, 10); // dano 10 > hp 5
+
+    tm.processPlayerAction({ type: 'ATTACK', target: enemy }, player, [enemy], createDungeon(), combat);
+
+    expect(enemy.alive).toBe(false);
+    expect(result => result); // alive foi setado diretamente
+  });
+
+  it('inclui o inimigo em enemiesDied quando morrer', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer();
+    const enemy  = createEnemy(6, 5, 5);
+    const combat = createCombat(true, 10);
+
+    const result = tm.processPlayerAction(
+      { type: 'ATTACK', target: enemy }, player, [enemy], createDungeon(), combat,
+    );
+
+    expect(result.enemiesDied).toContain(enemy);
+  });
+
+  it('mensagem de acerto incluída no resultado', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(20, 5, 20, 5);
+    const enemy  = createEnemy(6, 5, 20);
+    const combat = createCombat(true, 5);
+
+    const result = tm.processPlayerAction(
+      { type: 'ATTACK', target: enemy }, player, [enemy], createDungeon(), combat,
+    );
+
+    expect(result.messages.some((m) => m.includes('5'))).toBe(true);
+  });
+
+  it('mensagem de miss incluída no resultado', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer();
+    const enemy  = createEnemy(6, 5, 20);
+    const combat = createCombat(false);
+
+    const result = tm.processPlayerAction(
+      { type: 'ATTACK', target: enemy }, player, [enemy], createDungeon(), combat,
+    );
+
+    expect(result.messages.some((m) => m.toLowerCase().includes('errou'))).toBe(true);
+  });
+});
+
+describe('TurnManager — turno dos inimigos', () => {
+  it('chama update() de cada inimigo vivo', () => {
+    const tm      = new TurnManager();
+    const player  = createPlayer(5, 5);
+    const enemy1  = createEnemy(3, 5);
+    const enemy2  = createEnemy(7, 5);
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [enemy1, enemy2], createDungeon(), createCombat());
+
+    expect(enemy1.update).toHaveBeenCalledOnce();
+    expect(enemy2.update).toHaveBeenCalledOnce();
+  });
+
+  it('não chama update() de inimigos mortos', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer();
+    const enemy  = createEnemy(3, 5);
+    enemy.alive  = false;
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [enemy], createDungeon(), createCombat());
+
+    expect(enemy.update).not.toHaveBeenCalled();
+  });
+
+  it('reduz HP do player quando inimigo acerta', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(5, 5, 20, 5);
+    const enemy  = createEnemy(6, 5, 10, 3);
+    enemy.update = vi.fn().mockReturnValue({ attacked: true, damage: 3 });
+    const combat = createCombat(true, 3); // inimigo acerta
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [enemy], createDungeon(), combat);
+
+    expect(player.hp).toBe(17);
+  });
+
+  it('não reduz HP do player quando inimigo erra', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(5, 5, 20, 5);
+    const enemy  = createEnemy(6, 5);
+    enemy.update = vi.fn().mockReturnValue({ attacked: true, damage: 5 });
+    const combat = createCombat(false); // inimigo erra
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [enemy], createDungeon(), combat);
+
+    expect(player.hp).toBe(20);
+  });
+
+  it('playerDied=true quando player morre no turno inimigo', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer(5, 5, 3, 5); // hp=3
+    const enemy  = createEnemy(6, 5);
+    enemy.update = vi.fn().mockReturnValue({ attacked: true, damage: 3 });
+    const combat = createCombat(true, 5); // dano 5 > hp 3
+
+    const result = tm.processPlayerAction(
+      { type: 'WAIT' }, player, [enemy], createDungeon(), combat,
+    );
+
+    expect(result.playerDied).toBe(true);
+    expect(player.hp).toBe(0);
+  });
+
+  it('para de processar inimigos após morte do player', () => {
+    const tm      = new TurnManager();
+    const player  = createPlayer(5, 5, 1, 5); // hp=1, vai morrer no 1º inimigo
+    const enemy1  = createEnemy(6, 5);
+    const enemy2  = createEnemy(4, 5);
+    enemy1.update = vi.fn().mockReturnValue({ attacked: true, damage: 1 });
+    enemy2.update = vi.fn().mockReturnValue({ attacked: true, damage: 1 });
+    const combat  = createCombat(true, 5);
+
+    tm.processPlayerAction({ type: 'WAIT' }, player, [enemy1, enemy2], createDungeon(), combat);
+
+    expect(enemy2.update).not.toHaveBeenCalled();
+  });
+
+  it('mensagem de miss do inimigo incluída no resultado', () => {
+    const tm     = new TurnManager();
+    const player = createPlayer();
+    const enemy  = createEnemy(6, 5);
+    enemy.update = vi.fn().mockReturnValue({ attacked: true, damage: 5 });
+    const combat = createCombat(false);
+
+    const result = tm.processPlayerAction(
+      { type: 'WAIT' }, player, [enemy], createDungeon(), combat,
+    );
+
+    expect(result.messages.some((m) => m.toLowerCase().includes('errou'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Descrição

Implementa a Fase 2 do roguelike: sistema de turnos real via `TurnManager`, entidade `Enemy` pura, combate com 80% de chance de acerto e refatoração do input para `JustDown`. O jogo agora só avança quando o jogador age — sem mais cooldown de 150ms em tempo real.

---

## Tipo de mudança

- [x] `feat` — nova funcionalidade
- [x] `refactor` — refatoração sem mudança de comportamento

---

## O que foi feito

- Criado `src/systems/TurnManager.ts`: controla o fluxo de turno (player age → inimigos agem → aguarda próxima ação), bloqueia input fora do turno do jogador e retorna resultados agregados para a cena
- Criado `src/entities/Enemy.ts`: entidade pura sem dependência de Phaser com `takeDamage()` e `getPixelPos()`
- Adicionado `CombatSystem.attack()`: resolve um ataque com 80% de chance de acerto — miss não aplica dano
- Refatorado `GameScene`: input migrado de `isDown` para `JustDown`, `_tickEnemies()` e `_resolveCombat()` removidos e substituídos por chamadas ao `TurnManager`, tecla `SPACE` registrada para ação `WAIT`
- Adicionados 33 novos testes (82 total, 0 falhas): `CombatSystem.attack()`, `Enemy.ts` e `TurnManager` completo

---

## Como testar

1. `npm install`
2. `npm run dev` e abrir `http://localhost:3000`
3. Mover com WASD/setas — confirmar que os inimigos só se movem **após** cada tecla pressionada (não em tempo real)
4. Mover em direção a um inimigo — confirmar que o player ataca sem avançar o tile
5. Pressionar `SPACE` — confirmar que o turno avança e inimigos se movem sem o player se mover
6. Aguardar HP zerar — confirmar tela de Game Over
7. `npm test` — 82 testes passando

---

## Evidências
Test Files  8 passed (8)
Tests  82 passed (82)
Duration  691ms


---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/Vitor.md` (Prompt 11)
- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser

---

## Observações

- `CombatSystem.resolve()` foi mantido intacto para não quebrar os testes existentes; o novo `attack()` é usado pelo `TurnManager` para player e inimigos
- `Enemy.ts` coexiste com `EnemySystem.ts`: a entidade pura separa dados de domínio da lógica de IA e sprite, que permanecem no `EnemySystem`
- O acesso ao `xpSystem` dentro do `TurnManager` ocorre via `combat['xpSystem']` — ponto de atenção para refatoração futura (passar `xpSystem` explicitamente ao `TurnManager`)
