### PR TITLE
Feature/melhorias gerais 2

### DIFF
--- a/.kiro/specs/product.md
+++ b/.kiro/specs/product.md
@@ -33,23 +33,52 @@ Input do jogador → Resolve ação → Atualiza visão (FOG) → Turno dos inim
 ### Sistemas Implementados
 | Sistema | Responsabilidade |
 |---------|-----------------|
-| PlayerSystem | Atributos, HP/Mana, posição, movimento |
+| PlayerSystem | Atributos, HP/Mana, gold, bônus de equipamento acumulados em `_equipmentBonuses`; `recalcStats()` como fonte de verdade |
 | DungeonSystem | Geração procedural BSP, tiles, FOG of War |
 | EnemySystem | Spawn, estados de IA (IDLE/CHASING/ATTACKING) |
 | CombatSystem | Resolução de ataque, dano, morte |
 | XPSystem | Ganho de XP, cálculo de nível, level up |
+| InventorySystem | 20 slots, roguelike identification, `useItem()`, `addItem()`, `removeItem()` |
+| EquipmentSystem | 6 slots (helmet/shield/sword/pants/boots/amulet); equip/unequip com eventos; armazena IDs |
+| ShopSystem | Compra/venda catalog-driven; `buildViewModel()` + `buildSellItems()` para UI; sem lógica de cena |
+| InputModeManager | Stack-based: GAMEPLAY / INVENTORY / SHOP / DIALOG — `push()` / `pop()` / `is()` |
+| CityLayoutProcessor | Pipeline TOWN_CONFIG → ProcessedTownLayout; atribui biomas e resolve tile visuals |
+| TileVariantResolver | Seleção determinística de frame por posição + bioma (hash xorshift + peso) |
+| NPCController | FSM Idle → Wander para NPCs da cidade; `customWanderBounds` por NPC |
+| InteractiveObjectSystem | Detecta proximidade player↔NPC; respeita `houseBounds`; dispara SHOP_OPENED ou DIALOG_OPENED |
+| CityDecorationSystem | Renderização de objetos do mundo com Y-sort automático |
 
 ### Funcionalidades do Jogador
 - 3 classes: Warrior, Mage, Rogue
 - 6 atributos: STR, INT, DEX, CON, WIS, CHA
-- HP e Mana derivados dos atributos
+- HP e Mana derivados dos atributos; stats recalculados ao equipar/desequipar
 - Movimento por teclado (setas ou WASD) no grid
+- Gold (começa com 500) exibido no HUD; atualizado em tempo real
+
+### Comércio e Equipamentos
+- **Loja do Mercador**: 2 abas (Comprar / Vender); navegação por teclado e mouse
+- **Catálogo**: 18 itens (espadas, capacetes, escudos, calças, botas, amuletos + poções)
+- **Bônus de stat**: itens equipáveis adicionam `attack`, `maxHp`, `con` etc. de forma reversível
+- **Inventário visual** (`I`): 3 colunas (slots de equipamento / lista de itens / detalhes); `E` equipa ou desequipa, `U` usa, `D` dropa
+
+### NPCs e Diálogos
+- **Mercador**: abre loja ao interagir (dentro do edifício)
+- **Guarda**: menu de ajuda com objetivos, controles e dicas
+- **Taberneiro**: menu de descanso — 20 ouros restauram HP e Mana ao máximo
+- **Gato**: vaga livremente pela cidade respeitando paredes
 
 ### Dungeon
 - Geração por BSP (Binary Space Partitioning) com corredores L-shaped
 - FOG of War: tiles não visitados escuros, visitados em cinza, visíveis em destaque
 - Escadas de entrada e saída em cada andar
 - Temas visuais por faixa de andares (caverna, ruínas, cripta)
+
+### Cidade (Town)
+- Layout fixo processado por `CityLayoutProcessor`: biomas por região (urban, natural, interior, transition)
+- Tiles de chão com variantes visuais determinísticas por posição (sem magic frame numbers no código)
+- NPCs com comportamento de wander configurável (`wanderBounds`); Guard é estático
+- Objetos interativos (portas, signs) com prompt de interação por proximidade
+- Objetos do mundo (árvores, barris) com Y-sort automático para profundidade correta
 
 ### Inimigos
 - Inimigos com estados de IA: IDLE → ALERTED → CHASING → ATTACKING → FLEEING
@@ -66,11 +95,9 @@ Input do jogador → Resolve ação → Atualiza visão (FOG) → Turno dos inim
 
 Estas features **não estão no escopo atual** mas o código deve ser estruturado para suportá-las:
 
-- Inventário com slots de equipamento e itens no chão
 - Sistema de magia com slots e custo de mana
-- Identificação de itens (poções, pergaminhos, anéis)
+- Identificação de itens (pergaminhos, anéis)
 - IA generativa para descrições de itens épicos e variantes de inimigos elite
-- Múltiplos andares com progressão de dificuldade
 - Árvore de habilidades por classe
 - Sistema de save / placar local
 

--- a/.kiro/specs/sprites.spec.md
+++ b/.kiro/specs/sprites.spec.md
@@ -40,10 +40,23 @@ Todos carregados com `frameWidth: 16, frameHeight: 16`.
 
 ### Tiles de Floor (`Ground0.png`)
 
-| Uso             | Frame | Descrição                    |
-|-----------------|-------|------------------------------|
+| Uso             | Resolução de Frame | Descrição |
+|-----------------|-------------------|-----------|
 | Floor dungeon   | variante aleatória por sala | Frame sorteado em `_floorFrame` |
-| Floor cidade    | `TOWN.FLOOR_FRAME` = 16     | Frame fixo para TownMap       |
+| Floor cidade    | `TileVariantResolver` | Frame determinístico por posição + bioma (não mais frame fixo) |
+
+#### Biome Atlas — `FLOOR_ATLAS` (`src/config/sprites-config.ts`)
+
+Cada bioma mapeia para uma lista de variantes com peso relativo. `TileVariantResolver` usa hash xorshift por `(x, y, sessionSeed)` para selecionar o frame de forma determinística:
+
+| BiomeType     | Variantes (frame + weight) |
+|---------------|---------------------------|
+| `urban`       | calçada, paralelepípedo (pesos definidos em `FLOOR_ATLAS`) |
+| `natural`     | grama, terra, flores (pesos definidos em `FLOOR_ATLAS`) |
+| `interior`    | madeira, pedra polida (pesos definidos em `FLOOR_ATLAS`) |
+| `transition`  | mistura urban/natural (pesos definidos em `FLOOR_ATLAS`) |
+
+> Para os frame numbers exatos, consultar `src/config/sprites-config.ts` — a spec não repete magic numbers que vivem no config.
 
 ### Tiles de Wall (`Wall.png`)
 
@@ -78,7 +91,9 @@ Itens no chão usam `this.add.sprite()` (não retângulos):
 | `potion_poison` | `SPRITES.POTION`| `DAWNLIKE_FRAMES.POTION_POISON` (7) |
 | `gold`          | `SPRITES.MONEY` | `DAWNLIKE_FRAMES.GOLD`         (0) |
 
-Profundidade dos sprites de item: `depth = 3`.
+Itens equipáveis (espadas, capacetes, etc.) do catálogo da loja são representados no inventário pelo `item.type` e não necessitam de sprite no mapa (não têm loot drop no chão).
+
+Profundidade dos sprites de item no mapa: `depth = 3`.
 
 ---
 
@@ -89,10 +104,23 @@ não retângulos coloridos. Lógica de mapeamento em `UIScene._getItemVisual(typ
 
 ---
 
+## Constantes de Layer (`src/config/sprites-config.ts`)
+
+| Constante | Valor (depth) | Uso |
+|-----------|---------------|-----|
+| `LAYER_GROUND` | — | Tiles de chão (groundTiles[y][x]) |
+| `LAYER_WORLD_BASE` | 100 | Base para objetos do mundo (árvores, barris, etc.) |
+| `LAYER_OVERHEAD` | — | Elementos que cobrem o player |
+| `LAYER_UI_LABELS` | — | Labels de nome de NPC e prompts de interação |
+
+Objetos do mundo usam depth = `LAYER_WORLD_BASE + gridY * 10` para Y-sort correto (entidades mais ao sul aparecem à frente).
+
 ## Regras
 
 - R1: Sprites são **estáticos** — sem animação de frame swap entre turnos
 - R2: `pixelArt: true` e `roundPixels: true` configurados em `main.ts` para nitidez
-- R3: Nenhuma cena calcula frames diretamente — sempre via `DAWNLIKE_FRAMES.*`
+- R3: Nenhuma cena calcula frames diretamente — cenas usam `DAWNLIKE_FRAMES.*` ou `TileVariantResolver`
 - R4: `BootScene` carrega todos os assets antes de iniciar `GameScene` (loading screen)
 - R5: Easter egg Platino usa `SPRITES.PLAYER` com frame diferente (verificar `_spawnPlatino()`)
+- R6: Tiles de chão da cidade não têm frame fixo — `CityLayoutProcessor` resolve via `TileVariantResolver` usando o bioma do tile e a seed da sessão
+- R7: Magic numbers de frame pertencem a `sprites-config.ts` — não espalhar frame literals no código de cenas ou sistemas

--- a/.kiro/specs/structure.md
+++ b/.kiro/specs/structure.md
@@ -4,52 +4,79 @@
 
 ```
 dungeon-of-echoes/
-├── index.html                  ← Entry point HTML (Vite)
-├── vite.config.js              ← Configuração do build
+├── index.html
+├── vite.config.js
 ├── package.json
-├── commitlint.config.js        ← Regras de commit semântico
+├── commitlint.config.js
 │
 ├── .kiro/
-│   ├── product.md              ← Visão de produto e funcionalidades
-│   ├── structure.md            ← Este arquivo
-│   ├── tech.md                 ← Stack e decisões técnicas
-│   ├── steering/
-│   │   └── game-steering.md    ← Diretrizes estratégicas do projeto
-│   └── specs/                  ← Especificações funcionais por sistema
-│       ├── player.spec.md
-│       ├── dungeon.spec.md
-│       ├── enemy.spec.md
-│       ├── combat.spec.md
-│       ├── xp.spec.md
-│       ├── input.spec.md
-│       └── gameloop.spec.md
+│   ├── product.md, structure.md, tech.md
+│   ├── steering/game-steering.md
+│   └── specs/                  ← Uma spec por sistema
 │
 ├── src/
-│   ├── main.js                 ← Bootstrap do Phaser + configuração global
+│   ├── main.ts
 │   │
 │   ├── config/
-│   │   └── constants.js        ← TILE_SIZE, GRID_W, GRID_H, cores, etc.
+│   │   ├── constants.ts        ← EVENTS, SHOP, TAVERN, TILE, COLORS, UI, INVENTORY…
+│   │   ├── town.config.ts      ← TownNPCDef[], TownBuildingDef[], TownConfig
+│   │   ├── sprites-config.ts   ← FLOOR_ATLAS, LAYER_*, DAWNLIKE_FRAMES
+│   │   └── shop.catalog.ts     ← SHOP_CATALOG[], createItemFromCatalogEntry(), buildBonusText()
 │   │
-│   ├── scenes/                 ← Cenas Phaser (apresentação)
-│   │   ├── BootScene.js        ← Carrega assets, inicializa RNG
-│   │   ├── GameScene.js        ← Cena principal do jogo
-│   │   └── GameOverScene.js    ← Resumo de partida / permadeath
+│   ├── types/
+│   │   ├── town.ts             ← NPCInstanceDef, ProcessedTownLayout, DialogMenuOption
+│   │   ├── equipment.ts        ← EquipmentSlotId, StatBonuses, EQUIPMENT_SLOT_ORDER/LABELS
+│   │   ├── viewmodels.ts       ← InventoryViewModel, ShopViewModel, SellItemViewModel…
+│   │   └── input.ts            ← InputMode ('GAMEPLAY'|'INVENTORY'|'SHOP'|'DIALOG'|…)
 │   │
-│   └── systems/                ← Lógica de jogo (domínio)
-│       ├── PlayerSystem.js     ← Atributos, HP/Mana, movimento
-│       ├── DungeonSystem.js    ← Geração BSP, tiles, FOG of War
-│       ├── EnemySystem.js      ← Spawn, IA de inimigos, turno
-│       ├── CombatSystem.js     ← Resolução de ataque e dano
-│       └── XPSystem.js         ← Ganho de XP, level up
+│   ├── generators/
+│   │   ├── DungeonGenerator.ts
+│   │   ├── TileVariantResolver.ts
+│   │   └── CityLayoutProcessor.ts
+│   │
+│   ├── scenes/
+│   │   ├── BootScene.ts        ← Pré-carregamento de assets
+│   │   ├── GameScene.ts        ← Orquestra sistemas; sem lógica de domínio
+│   │   ├── UIScene.ts          ← HUD e painéis via dirty flag; sem lógica de domínio
+│   │   └── GameOverScene.ts
+│   │
+│   ├── entities/
+│   │   ├── Player.ts           ← gold, _equipmentBonuses, recalcStats(), applyEquipmentBonuses()
+│   │   └── Item.ts             ← ItemType, slotId?, bonuses?, price?, rarity?
+│   │
+│   ├── systems/
+│   │   ├── TurnManager.ts
+│   │   ├── CombatSystem.ts
+│   │   ├── EnemySystem.ts
+│   │   ├── XPSystem.ts
+│   │   ├── LootSystem.ts
+│   │   ├── WorldSystem.ts
+│   │   ├── InventorySystem.ts
+│   │   ├── EquipmentSystem.ts  ← equip/unequip, 6 slots, emite ITEM_EQUIPPED/UNEQUIPPED
+│   │   ├── ShopSystem.ts       ← buyItem(), sellItem(), buildViewModel(), buildSellItems()
+│   │   ├── InputModeManager.ts ← stack: push()/pop()/is(); emite INPUT_MODE_CHANGED
+│   │   ├── LogSystem.ts
+│   │   ├── NPCController.ts    ← spawn, wander FSM, customWanderBounds, isTileOccupied()
+│   │   ├── InteractiveObjectSystem.ts
+│   │   ├── CityDecorationSystem.ts
+│   │   ├── MapTransitionSystem.ts
+│   │   ├── DungeonFloorManager.ts
+│   │   └── DifficultyScalingSystem.ts
+│   │
+│   └── ui/
+│       ├── InventoryPanel.ts   ← 3 colunas: slots / itens / detalhes; dirty flag
+│       ├── ShopPanel.ts        ← 2 abas buy/sell, mouse interativo, pool de linhas
+│       ├── DialogPanel.ts      ← menu de opções genérico (Guard, Taberneiro)
+│       ├── LogPanel.ts         ← renderização bottom-up por text.height real
+│       └── ActionBarPanel.ts
 │
-├── tests/                      ← Testes unitários (Vitest)
+├── tests/
 │   ├── combat.test.js
 │   ├── dungeon.test.js
-│   └── xp.test.js
+│   ├── xp.test.js
+│   └── shop.test.js            ← 17 testes: catalog, buy, sell, bonuses, viewmodel
 │
-└── docs/                       ← Documentação auxiliar
-    ├── spec.md
-    └── steering.md
+└── docs/
 ```
 
 ## Separação de Responsabilidades
@@ -59,24 +86,49 @@ Cenas Phaser que gerenciam o ciclo de vida visual do jogo. Não contêm lógica 
 
 | Arquivo | Responsabilidade |
 |---------|-----------------|
-| `BootScene.js` | Pré-carregamento de assets, inicialização do RNG, transição para GameScene |
-| `GameScene.js` | Loop principal: captura input, chama sistemas, renderiza estado |
-| `GameOverScene.js` | Exibe resumo da partida (andar, inimigos, causa da morte) |
+| `BootScene.ts` | Pré-carregamento de assets, inicialização do RNG, transição para GameScene |
+| `GameScene.ts` | Loop principal; captura input via `InputModeManager`; delega para sistemas; sem lógica de domínio |
+| `UIScene.ts` | HUD persistente + painéis (inventory, shop, dialog, log, action bar); dirty flag por painel |
+| `GameOverScene.ts` | Exibe resumo da partida (andar, XP, nível) |
 
-**Regra:** Cenas orquestram, sistemas executam. Uma cena nunca calcula dano ou gera dungeon diretamente.
+**Regra:** Cenas orquestram, sistemas executam. Uma cena nunca calcula dano ou gera dungeon.  
+**Regra de estado:** `INVENTORY_OPENED` é o único evento que mostra o painel de inventário — nunca `INVENTORY_STATE_RESPONSE` diretamente.
 
 ### Camada de Domínio — `/src/systems/`
-Módulos de lógica pura. Cada sistema é responsável por um único domínio do jogo.
 
 | Arquivo | Responsabilidade |
 |---------|-----------------|
-| `PlayerSystem.js` | Estado do jogador: atributos, HP, Mana, posição, movimento no grid |
-| `DungeonSystem.js` | Geração procedural (BSP), mapa de tiles, FOG of War, escadas |
-| `EnemySystem.js` | Criação de inimigos, máquina de estados de IA, execução de turno |
-| `CombatSystem.js` | Fórmula de ataque, cálculo de dano, aplicação de dano, morte |
-| `XPSystem.js` | Acúmulo de XP, cálculo de nível, distribuição de atributos no level up |
+| `TurnManager.ts` | Controle de turno; processa ações MOVE/ATTACK/WAIT/USE_ITEM |
+| `CombatSystem.ts` | Fórmula de ataque (80% hit), cálculo de dano, morte |
+| `EnemySystem.ts` | Criação de inimigos, IA (IDLE/CHASING/ATTACKING), turno |
+| `XPSystem.ts` | Acúmulo de XP, fórmula de nível, level up |
+| `InventorySystem.ts` | 20 slots, roguelike identification, `useItem()`, `addItem()`, `removeItem()` |
+| `EquipmentSystem.ts` | 6 slots; `equip()`, `unequip()`, `getEquippedId()`, `isEquipped()` |
+| `ShopSystem.ts` | `buyItem()`, `sellItem()`, `buildViewModel()`, `buildSellItems()` — sem acoplamento à UI |
+| `InputModeManager.ts` | Stack-based mode: `push()` / `pop()` / `is()` / `set()`; emite `INPUT_MODE_CHANGED` |
+| `LootSystem.ts` | Drop de itens na morte de inimigos |
+| `WorldSystem.ts` | Persiste estado da dungeon entre transições na sessão |
+| `NPCController.ts` | Spawn, FSM idle→wander, `customWanderBounds`, `isTileOccupied()` |
+| `InteractiveObjectSystem.ts` | Adjacência player↔NPC; `houseBounds` para check de posição; emite SHOP_OPENED ou DIALOG_OPENED |
+| `CityDecorationSystem.ts` | Renderiza `WorldObjectDef[]` com Y-sort (`LAYER_WORLD_BASE + gridY*10`) |
 
-**Regra:** Sistemas não importam uns aos outros diretamente. Comunicação via parâmetros explícitos ou eventos Phaser 4 emitidos pela cena (`this.events.emit` / `this.events.on`).
+**Regra:** Sistemas comunicam via EventBus (`src/utils/EventBus.ts`) — nunca importam cenas. Cenas passam dados como parâmetros ou ouvem eventos.
+
+### Geração e Processamento — `/src/generators/`
+
+| Arquivo | Responsabilidade |
+|---------|-----------------|
+| `DungeonGenerator.ts` | Geração BSP de dungeon; base para `TownMap` |
+| `TileVariantResolver.ts` | Hash xorshift determinístico por posição (seed de sessão); seleciona frame ponderado por bioma |
+| `CityLayoutProcessor.ts` | Lê `TOWN_CONFIG`, atribui biomas, resolve visuais, produz `ProcessedTownLayout` |
+
+### Configuração — `/src/config/`
+
+| Arquivo | Conteúdo |
+|---------|---------|
+| `constants.js` | `TILE_SIZE`, `GRID_W`, `GRID_H`, `VISION_RADIUS`, `XP_BASE`, etc. |
+| `town.config.ts` | `TownConfig` com layout fixo da cidade e `biomeOverrides?` por tile key |
+| `sprites-config.ts` | `FLOOR_ATLAS` (bioma→frames+pesos), `OBJECT_ATLAS`, `NPC_ATLAS`; constantes `LAYER_GROUND`, `LAYER_WORLD_BASE`, `LAYER_OVERHEAD`, `LAYER_UI_LABELS` |
 
 ### Configuração — `/src/config/`
 Constantes globais que evitam magic numbers espalhados pelo código.

--- a/.kiro/specs/tech.md
+++ b/.kiro/specs/tech.md
@@ -7,7 +7,7 @@
 | Engine de jogo | Phaser 4 | ^4.x |
 | Linguagem | JavaScript (ES Modules) | ES2022+ |
 | Build / Dev server | Vite | ^5.x |
-| Testes unitários | Vitest | ^1.x (futuro) |
+| Testes unitários | Vitest | ^1.x |
 | Qualidade de commits | Husky + Commitlint | — |
 | Runtime | Navegador moderno (Chrome, Firefox, Edge) | — |
 
@@ -35,11 +35,13 @@ Para um RPG tile-based, Phaser 4 elimina a necessidade de implementar loop de jo
 - `roundPixels` agora é `false` por padrão — definir explicitamente no config se necessário para pixel art
 - FX e Masks foram unificados no sistema de Filters (não afeta o MVP)
 
-### JavaScript com ES Modules
-- Sem transpilação obrigatória para o MVP (Vite serve ESM nativamente)
-- Sintaxe de `import/export` nativa mantém o código modular e rastreável
-- Sem overhead de TypeScript no estágio inicial — legibilidade e velocidade de iteração são prioridade
-- Compatível com todos os ambientes-alvo (navegador moderno)
+### TypeScript
+O projeto migrou para TypeScript. Novos sistemas (`NPCController.ts`, `InteractiveObjectSystem.ts`, `CityLayoutProcessor.ts`, `TileVariantResolver.ts`) e tipos (`src/types/town.ts`) são escritos em `.ts`. Arquivos `.js` legados permanecem enquanto não forem refatorados.
+
+Benefícios diretos para este projeto:
+- Interfaces tipadas para `ProcessedTownLayout`, `WorldObjectDef`, `NPCInstanceDef`, `InteractiveObjectDef`, `BiomeType`
+- Verificação estática de contratos entre `CityLayoutProcessor` e `GameScene`
+- Configuração Vite suporta TypeScript nativamente sem etapa extra de build
 
 ### Vite
 - Dev server com HMR (Hot Module Replacement) instantâneo
@@ -47,11 +49,12 @@ Para um RPG tile-based, Phaser 4 elimina a necessidade de implementar loop de jo
 - Configuração mínima para projetos Phaser (sem webpack boilerplate)
 - Suporte nativo a ES Modules sem configuração adicional
 
-### Vitest (futuro)
+### Vitest
 - API compatível com Jest — curva de aprendizado mínima
 - Integração nativa com Vite (mesmo pipeline de transformação)
 - Suporte a ES Modules sem configuração extra
 - Execução rápida por aproveitar o cache do Vite
+- Suíte atual: `combat`, `dungeon`, `xp`, `shop` — 17+ testes passando
 
 ### Husky + Commitlint
 - Husky: executa hooks de git (pre-commit, commit-msg) sem configuração manual
@@ -63,27 +66,51 @@ Para um RPG tile-based, Phaser 4 elimina a necessidade de implementar loop de jo
 ### Arquitetura em Camadas
 
 ```
-┌─────────────────────────────────────┐
-│         PRESENTATION LAYER          │
-│   Phaser Scenes (Boot, Game, Over)  │
-│   Responsável por: render, input    │
-└──────────────┬──────────────────────┘
-               │ chama funções / passa dados
-┌──────────────▼──────────────────────┐
-│          GAME LOGIC LAYER           │
-│   Systems: Player, Dungeon, Enemy,  │
-│            Combat, XP               │
-│   Responsável por: regras do jogo   │
-└──────────────┬──────────────────────┘
-               │ lê/escreve
-┌──────────────▼──────────────────────┐
-│           CONFIG LAYER              │
-│   constants.js                      │
-│   Responsável por: valores globais  │
-└─────────────────────────────────────┘
+┌─────────────────────────────────────────────────────┐
+│                 PRESENTATION LAYER                  │
+│   GameScene (orquestra), UIScene (painéis/HUD)      │
+│   BootScene, GameOverScene                          │
+│   Responsável por: render, input, orquestração      │
+└──────────────┬──────────────────────────────────────┘
+               │ EventBus (EVENTS.*) + parâmetros
+┌──────────────▼──────────────────────────────────────┐
+│               GAME LOGIC LAYER                      │
+│   TurnManager, CombatSystem, EnemySystem, XPSystem  │
+│   InventorySystem, EquipmentSystem, ShopSystem      │
+│   InputModeManager, LootSystem, WorldSystem         │
+│   NPCController, InteractiveObjectSystem            │
+│   CityDecorationSystem, LogSystem                   │
+│   Responsável por: regras do jogo                   │
+└──────────────┬──────────────────────────────────────┘
+               │ lê / passa dados
+┌──────────────▼──────────────────────────────────────┐
+│              GENERATORS LAYER                       │
+│   DungeonGenerator, CityLayoutProcessor,            │
+│   TileVariantResolver, DungeonFloorManager          │
+└──────────────┬──────────────────────────────────────┘
+               │ lê
+┌──────────────▼──────────────────────────────────────┐
+│                CONFIG / TYPES LAYER                 │
+│   constants.ts (EVENTS, SHOP, TAVERN…)              │
+│   town.config.ts, sprites-config.ts, shop.catalog.ts│
+│   types/town.ts, types/equipment.ts                 │
+│   types/viewmodels.ts, types/input.ts               │
+└─────────────────────────────────────────────────────┘
 ```
 
-**Regra fundamental:** Dependências fluem de cima para baixo. Sistemas não conhecem cenas; cenas orquestram sistemas.
+**Regra fundamental:** Dependências fluem de cima para baixo. Sistemas não conhecem cenas; cenas orquestram sistemas.  
+**Comunicação entre camadas:** via `EventBus` (`src/utils/EventBus.ts`) — sistemas emitem, cenas ouvem. Nunca o contrário.
+
+### InputModeManager — Controle de Input
+`InputModeManager` implementa uma stack de modos:
+- `push(mode)`: salva modo atual e troca para novo
+- `pop()`: restaura modo anterior
+- `is(mode)`: verifica modo atual
+
+Modos: `GAMEPLAY | INVENTORY | SHOP | DIALOG | MODAL | DEBUG`
+
+**Regra de UI:** Enquanto qualquer modo ativo ≠ GAMEPLAY, o personagem não se move. Cada painel registra/fecha seu modo ao ser aberto/fechado.  
+**Regra de show/hide de painel:** `INVENTORY_OPENED` é o único evento que autoriza `_inventoryPanel.show()`. `INVENTORY_STATE_RESPONSE` apenas atualiza dados — nunca abre o painel.
 
 ### Sistemas como Módulos Funcionais
 No MVP, sistemas são coleções de funções exportadas (não classes), mantendo o código simples e testável:
@@ -116,6 +143,8 @@ Para eventos que precisam cruzar múltiplos sistemas de forma desacoplada, usar 
 
 ### Geração Procedural com Seed
 O `DungeonSystem` usa um RNG seedable (baseado em timestamp ou semente explícita) para garantir que dungeons sejam reproduzíveis durante debug, mas únicos em cada partida normal.
+
+`TileVariantResolver` usa o mesmo princípio para tiles da cidade: um hash xorshift por `(x, y, sessionSeed)` produz seleção ponderada de frame determinística — a mesma sessão gera sempre o mesmo visual de cidade, mas sessões diferentes têm variação.
 
 ### Estruturas de Dados Nativas
 Phaser 4 removeu `Phaser.Struct.Set` e `Phaser.Struct.Map`. Usar diretamente `Set` e `Map` nativos do JavaScript — mais simples, sem dependência de API proprietária:
@@ -168,9 +197,8 @@ O MVP não usa:
 
 O código deve ser estruturado para suportar, sem reescrita, as seguintes adições:
 
-- **IA generativa**: `AIService.js` em `/src/ai/` com fallback obrigatório — o jogo funciona 100% sem conectividade com LLM
-- **Inventário**: `InventorySystem.js` em `/src/systems/` seguindo o mesmo padrão modular
-- **Magia**: `MagicSystem.js` com lista de spells em `/src/data/spells.json`
-- **Múltiplos andares**: `DungeonSystem` já deve suportar parâmetro `floor` e `seed`; considerar `TilemapGPULayer` do Phaser 4 para performance em andares maiores
-- **Pathfinding A\***: `/src/utils/pathfinding.js` isolado, chamado pelo `EnemySystem`
+- **IA generativa**: `AIService.ts` em `/src/ai/` com fallback obrigatório — o jogo funciona 100% sem conectividade com LLM
+- **Magia**: `MagicSystem.ts` com lista de spells em `/src/data/spells.json`
+- **Múltiplos andares**: `DungeonFloorManager` já implementado; considerar `TilemapGPULayer` para andares maiores
+- **Pathfinding A\***: `/src/utils/pathfinding.ts` isolado, chamado pelo `EnemySystem`
 - **Testes**: estrutura de `/tests/` já existe; adicionar casos conforme sistemas amadurecem

--- a/.kiro/specs/world.spec.md
+++ b/.kiro/specs/world.spec.md
@@ -23,6 +23,44 @@ O WorldSystem gerencia o estado do mundo entre transições de área dentro de u
 - Saída para dungeon: tile `(12, 18)` — marcado com retângulo laranja `[ DUNGEON ]`
 - Implementado como subclasse de `DungeonGenerator` para compatibilidade com `TurnManager` e `EnemySystem` sem alterar suas assinaturas
 
+### Pipeline de Geração da Cidade
+
+O layout da cidade segue um pipeline de dados antes de ser renderizado:
+
+```
+TOWN_CONFIG (town.config.ts)
+  → CityLayoutProcessor.process()
+      - Lê biomeOverrides do config (opcional)
+      - Atribui biomas por região: urban / natural / interior / transition
+      - Resolve visuais via TileVariantResolver (frame determinístico por posição)
+      - Produz ProcessedTownLayout { groundTiles[][], worldObjects[], npcs[], interactive[] }
+  → GameScene._loadTown()
+      - Renderiza groundTiles[y][x] com frame resolvido (sem magic numbers)
+      - Instancia NPCController para cada NPC do layout
+      - Instancia InteractiveObjectSystem com objetos interativos
+```
+
+`TownConfig` aceita `biomeOverrides?: Record<string, BiomeType>` para sobrescrever o bioma de regiões específicas por tile key (`"x,y"`).
+
+### Sistemas da Cidade
+
+| Sistema | Arquivo | Responsabilidade |
+|---------|---------|-----------------|
+| `CityLayoutProcessor` | `src/generators/CityLayoutProcessor.ts` | Lê TOWN_CONFIG, atribui biomas, resolve tiles, produz `ProcessedTownLayout` |
+| `TileVariantResolver` | `src/generators/TileVariantResolver.ts` | Hash xorshift por posição + seleção ponderada de frame (determinístico por sessão) |
+| `NPCController` | `src/systems/NPCController.ts` | FSM Idle → Wander; move NPCs 1 tile/step dentro de `wanderBounds` |
+| `InteractiveObjectSystem` | `src/systems/InteractiveObjectSystem.ts` | Detecta adjacência do player a portas/signs; exibe/oculta prompt "[E] Interagir" |
+| `CityDecorationSystem` | `src/systems/CityDecorationSystem.ts` | Renderiza `WorldObjectDef[]` e `TownLabelDef[]`; depth = `LAYER_WORLD_BASE + gridY * 10` |
+
+### NPCs e Objetos
+
+- **Guarda**: sem `wanderBounds` → estático; `interaction.type = 'menu'` → abre `DialogPanel` com 4 opções de ajuda (objetivos, como jogar, controles, dicas)
+- **Mercador**: `wanderBounds` ±2 tiles; `interaction.type = 'shop'` → abre loja com 2 abas (Comprar/Vender); requer player dentro de `houseBounds` da taverna
+- **Taberneiro** (ex-Estalajadeiro): `wanderBounds`; `interaction.type = 'menu'` → menu de descanso; "Repousar (20 ouros)" restaura HP+Mana ao máximo se player tiver ouro suficiente
+- **Gato**: `customWanderBounds` dedicado (tile (3,9), área sul da praça); FSM wander livre; não atravessa paredes
+- `NPCController.update(delta, grid)` é chamado em `GameScene.update()` a cada frame
+- `InteractiveObjectSystem._canInteract()`: NPCs com `houseBounds` exigem player dentro dos bounds; demais usam adjacência ortogonal (4 direções)
+
 ---
 
 ## WorldSystem (singleton)
@@ -72,7 +110,7 @@ Dungeon → Cidade:
 - R1: `WorldSystem.clearDungeon()` é chamado em `GameScene.create()` — garante fresh start
 - R2: Inimigos NÃO são salvos no `DungeonState` — sempre respawnam ao entrar na dungeon
 - R3: Itens coletados (no inventário) têm `gridX === null` — não são salvos no estado do chão
-- R4: Sprites de tiles e entidades são destruídos/recriados a cada troca de área (`_cleanup()`)
+- R4: Sprites de tiles e entidades são destruídos/recriados a cada troca de área (`_cleanup()`); `NPCController` e `InteractiveObjectSystem` também são destruídos em `_cleanup()`
 - R5: Player (stats, inventário, HP) persiste entre áreas pois `GameScene` não reinicia
 - R6: `_canExitDungeon` começa `false` ao entrar na dungeon; torna-se `true` após o player mover-se para fora do `startPos`
 

--- a/.kiro/steering/game-steering.md
+++ b/.kiro/steering/game-steering.md
@@ -31,9 +31,9 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 | Camada | Tecnologia |
 |--------|-----------|
 | Engine | Phaser 4 |
-| Linguagem | TypeScript (ES Modules) |
+| Linguagem | TypeScript (novos sistemas) + JavaScript legado |
 | Build | Vite |
-| Testes | Vitest (108 testes) |
+| Testes | Vitest (17+ testes) |
 | Qualidade | Husky + Commitlint |
 | Assets | Dawnlike 16×16 tileset (CC-BY) |
 
@@ -44,23 +44,36 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 - **Sem servidor backend** — jogo 100% client-side
 - **Sem animações complexas** — sprites estáticos (frame fixo por entidade)
 - **Sem save persistente** — cada sessão começa do zero; estado da dungeon persiste *dentro* da sessão via `WorldSystem`
-- **Sistemas nunca importam Scenes** — comunicação via EventBus
+- **Sistemas nunca importam Scenes** — comunicação via EventBus (`EVENTS.*`)
 - **Scenes nunca calculam lógica de domínio** — delegam a Systems
+- **Magic frame numbers pertencem a `sprites-config.ts`** — não espalhar literais de frame em cenas ou sistemas
+- **Biomas e variantes de tile resolvidos por `CityLayoutProcessor` + `TileVariantResolver`** — `GameScene` apenas consome `ProcessedTownLayout`, não decide frames
+- **NPCs com `wanderBounds` undefined são estáticos** (Guard); com bounds wandam (`customWanderBounds` para o Gato)
+- **InputModeManager** controla qual painel recebe input — `push()` ao abrir, `pop()` ao fechar; em modo ≠ GAMEPLAY o personagem não se move
+- **`INVENTORY_OPENED` é o único evento que autoriza `_inventoryPanel.show()`** — `INVENTORY_STATE_RESPONSE` apenas atualiza dados; nunca abre o painel
+- **Bônus de equipamento são reversíveis** — `Player.applyEquipmentBonuses()` / `removeEquipmentBonuses()` acumulam em `_equipmentBonuses`; `recalcStats()` é a fonte de verdade dos stats derivados
 
 ## Estrutura de Pastas
 
 ```
 /src
   /scenes       → Cenas Phaser (Boot, Game, GameOver, UI)
-  /systems      → Lógica de jogo (TurnManager, CombatSystem, EnemySystem,
-                   XPSystem, InventorySystem, LootSystem, WorldSystem)
-  /entities     → Entidades puras (Player, Item)
-  /generators   → Geração procedural (DungeonGenerator)
-  /utils        → Constantes, EventBus
+  /systems      → Lógica de jogo:
+                   TurnManager, CombatSystem, EnemySystem, XPSystem
+                   InventorySystem, EquipmentSystem, ShopSystem
+                   InputModeManager, LootSystem, WorldSystem, LogSystem
+                   NPCController, InteractiveObjectSystem, CityDecorationSystem
+                   MapTransitionSystem, DungeonFloorManager, DifficultyScalingSystem
+  /entities     → Entidades puras (Player — gold, equipmentBonuses; Item — slotId, bonuses)
+  /generators   → DungeonGenerator, CityLayoutProcessor, TileVariantResolver
+  /config       → constants.ts, town.config.ts, sprites-config.ts, shop.catalog.ts
+  /types        → town.ts, equipment.ts, viewmodels.ts, input.ts
+  /utils        → EventBus
+  /ui           → InventoryPanel, ShopPanel, DialogPanel, LogPanel, ActionBarPanel
 .kiro/
   /steering     → Diretrizes do projeto (este arquivo)
   /specs        → Especificações de cada sistema
-/tests          → Testes unitários (Vitest)
+/tests          → Testes unitários (Vitest): combat, dungeon, xp, shop
 /public/assets/dawnlike → Tileset Dawnlike 16×16 (CC-BY)
 ```
 
@@ -78,7 +91,6 @@ Estes sistemas NÃO fazem parte do MVP atual mas o código deve ser estruturado 
 
 - **Fog of War**: visibilidade por tile (spec pronta em `.kiro/specs/fog-of-war.spec.md`)
 - **Minimap**: overlay com estado de exploração (spec em `.kiro/specs/minimap.spec.md`)
-- **Múltiplos andares**: escadas, progressão vertical de dungeon
 - **Habilidades**: árvore de habilidades por classe
 - **IA de Inimigos**: pathfinding A*, comportamentos variados por tipo
-- **Narrativa por IA**: lores geradas por LLM — Claude Haiku (preparar hooks)
+- **Narrativa por IA**: lores geradas por LLM — Claude Haiku (hooks preparados em `AIService.ts`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,53 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ### Added
 
+#### Sistema de Comércio e Equipamentos
+
+- **`ShopSystem`**: lógica de compra e venda catalog-driven; `buyItem()` e `sellItem()` retornam resultado tipado; `buildViewModel()` e `buildSellItems()` constroem ViewModel sem acoplamento à UI
+- **`EquipmentSystem`**: 6 slots (capacete, escudo, espada, calça, botas, amuleto); `equip()`, `unequip()`, `getEquippedId()`, `getAllEquipped()` — armazena IDs, `InventorySystem` permanece dono dos objetos
+- **`Player.applyEquipmentBonuses()` / `removeEquipmentBonuses()`**: bônus de equipamento acumulados em `_equipmentBonuses`; `recalcStats()` recalcula `maxHp` e `attack` a partir dos bônus — 100% reversível ao desequipar
+- **`shop.catalog.ts`**: 18 itens (3 por slot + poções); `createItemFromCatalogEntry()` instancia `Item` com `slotId`, `bonuses`, `price`, `rarity`; `buildBonusText()` formata texto de atributo
+- **`ShopPanel`**: painel de 2 abas (Comprar / Vender); mouse hover + click selecionam item; pool de 20 linhas reutilizáveis; detalhes de raridade, bônus e preço
+- **Loja do Mercador**: interagir com o Mercador na cidade abre `ShopPanel`; aba Comprar navega catálogo (`↑↓`), compra com `E`/`Enter`; aba Vender mostra inventário (`←→` troca aba), venda com `V`
+- **Gold no HUD**: `player.gold = 500` inicial; label `Ouro: N` atualizado em tempo real via `PLAYER_GOLD_CHANGED`
+
+#### Sistema de Diálogo (`DialogPanel`)
+
+- **`DialogPanel`**: painel genérico de menu com lista de opções à esquerda e área de conteúdo à direita; mouse `pointerdown` seleciona opção; hint `[↑↓] Navegar  [Enter/E] Selecionar  [ESC] Fechar`
+- **Guarda** (cidade): interação abre menu com 4 opções informativas (Objetivos, Como jogar, Controles, Dicas)
+- **Taberneiro** (renomeado de Estalajadeiro): interação abre menu; opção "Repousar (20 ouros)" deduz 20 moedas e restaura HP e Mana ao máximo; opção "Até mais" fecha
+
+#### NPCs — Gato Vagante
+
+- `NPCController.update()` reativado: FSM `idle → wander` percorre tiles FLOOR dentro de `wanderBounds`; paredes e edifícios respeitados automaticamente
+- Gato movido para posição (3, 9) (tile FLOOR) com `customWanderBounds` dedicado — elimina posicionamento anterior em tile de parede
+
+#### Correções de Log e Foco
+
+- **`LogPanel`** reescrito para renderização bottom-up: `text.height` real após `setText()` determina posição — mensagens com quebra de linha não se sobrepõem mais
+- **Foco de teclado**: `BLUR`/`FOCUS` do jogo chamam `keyboard.resetKeys()` — previne teclas "presas" ao voltar da aba/janela após alt+tab
+
+### Fixed
+
+#### Crash `vm.items is undefined` após compra
+
+- `ShopSystem.buyItem()` e `sellItem()` emitiam `EVENTS.SHOP_UPDATED` com `{}` vazio; `ShopPanel.render()` acessava `vm.items[i]` → crash
+- Removidos os emits vazios; `GameScene._emitShopState()` sempre constrói `ShopViewModel` completo após qualquer operação
+
+#### Inventário fantasma / input travado após compra
+
+- `UIScene`: handler `INVENTORY_STATE_RESPONSE` chamava `_inventoryPanel.show()` incondicionalmente — inventário abria em modo SHOP quando `_emitInventoryState()` era chamado durante compra
+- **Fix**: `INVENTORY_OPENED` é o único evento autorizado a chamar `show()`; `INVENTORY_STATE_RESPONSE` só atualiza dados e marca dirty se o painel já estiver visível
+- Removidas chamadas `_emitInventoryState()` das operações de compra/venda na loja
+- `set('GAMEPLAY')` trocado por `pop()` no fechamento de INVENTORY e SHOP — stack do `InputModeManager` limpa corretamente
+
+#### Desequipar itens
+
+- Pressionar `E` em item já equipado agora o desequipa; novo método `_unequipSelectedItem()` reverte bônus via `player.removeEquipmentBonuses()` e emite `PLAYER_HP_CHANGED`
+- Painel de detalhes do inventário exibe `[E] Desequipar` para itens equipados, `[E] Equipar` para os demais
+
+---
+
 #### Múltiplos Andares de Dungeon (`DungeonFloorManager`)
 - `DungeonFloorManager`: cache de andares por sessão — andares já visitados preservam inimigos mortos e itens coletados
 - `DungeonFeatureGenerator`: gera `stairUp` e `stairDown` em salas diferentes, com distância mínima de 5 tiles entre elas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,40 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ### Added
 
+#### Múltiplos Andares de Dungeon (`DungeonFloorManager`)
+- `DungeonFloorManager`: cache de andares por sessão — andares já visitados preservam inimigos mortos e itens coletados
+- `DungeonFeatureGenerator`: gera `stairUp` e `stairDown` em salas diferentes, com distância mínima de 5 tiles entre elas
+- `DifficultyScalingSystem`: scaling de inimigos data-driven via `FLOOR_DIFFICULTY_TABLE` — HP e ATK aumentam por andar, base stats nunca mutados
+- Descida: player nasce no `stairUp` do andar destino; subida: player nasce no `stairDown` do andar de origem
+- Retorno à cidade via `stairUp` com `targetFloor = 'town'` — sem heurística de `startPos`
+- Labels visuais nas escadas: `▲ CIDADE` (floor 1), `▲ SUBIR` (demais floors), `▼ DESCER`
+
+#### Tela de Inventário Visual (`InventoryPanel` + `EquipmentSystem`)
+- `InventoryPanel`: grid de itens com 6 slots de equipamento (capacete, escudo, espada, calça, botas, amuleto)
+- `EquipmentSystem`: armazena IDs de itens equipados — `InventorySystem` permanece o dono dos objetos
+- Tecla `I` abre/fecha o painel de inventário; `InputModeManager` bloqueia movimento enquanto aberto
+- Comunicação UIScene ↔ GameScene via protocolo EventBus request/response (`INVENTORY_STATE_REQUESTED → INVENTORY_STATE_RESPONSE`)
+
+#### Log Panel dedicado (`LogPanel` + `LogSystem`)
+- `LogSystem`: buffer de até 50 mensagens, desacoplado do painel — comunica via `LogViewModel`
+- `LogPanel`: Container Phaser próprio ocupando 1/3 esquerdo da tela, pool fixo de textos com dirty flag
+- `LogPanel.layout()` aceita `reservedBottomHeight` — log não cobre a action bar
+
+#### Action Bar separada (`ActionBarPanel`)
+- `ActionBarPanel`: componente independente com Container próprio, 36px de altura, fundo visualmente distinto do log
+- Delegação de `setItem()` / `clearItem()` a partir de eventos `ITEM_PICKED_UP` e `ITEM_USED`
+
+#### Sistemas de suporte
+- `MapTransitionSystem`: SpawnPoints e TransitionPoints registráveis — GameScene executa, sistema resolve lógica
+- `InputModeManager`: máquina de estados (GAMEPLAY | INVENTORY | MODAL | DEBUG) com push/pop de modo
+
+### Fixed
+- Spawn de retorno à cidade: player nasce próximo à saída da dungeon (`EXIT_Y - 1`), não no centro
+- `createEnemies` refatorada para `(dungeon, playerPos, difficulty?)` — scaling aplicado no spawn, constantes base preservadas
+- `tests/enemy.test.js` atualizado para nova assinatura de `createEnemies`
+
+---
+
 #### Feedback Visual de Dano (`visual-damage-feedback`)
 - Números flutuantes animados ao receber dano: vermelho (`-N`) sobre o player, amarelo sobre inimigos
 - Flash vermelho no sprite atingido (pisca uma vez em ~160ms) para reforçar o impacto do golpe

--- a/docs/guia-sprites.md
+++ b/docs/guia-sprites.md
@@ -1,0 +1,146 @@
+# Guia: Como Ajustar Sprites de Chão, Parede e Tiles
+
+## Como os Frames Funcionam
+
+Todos os spritesheets são carregados com `frameWidth: 16, frameHeight: 16`.
+O frame `0` é o canto superior esquerdo, incrementa da esquerda pra direita, depois próxima linha.
+
+**Ground0.png — 8 colunas × 7 linhas = 56 frames:**
+
+```
+ 0  1  2  3  4  5  6  7   ← pedra/cinza
+ 8  9 10 11 12 13 14 15   ← terra/marrom
+16 17 18 19 20 21 22 23   ← grama/verde
+24 25 26 27 28 29 30 31   ← areia
+32 33 34 35 36 37 38 39   ← lama
+40 41 42 43 44 45 46 47   ← neve
+48 49 50 51 52 53 54 55   ← vulcânico
+```
+
+`Wall.png` segue o mesmo padrão mas só para paredes.
+
+---
+
+## Onde Ajustar Cada Sprite
+
+### Dungeon — chão e parede
+**`src/utils/constants.ts`** — seção `DAWNLIKE_FRAMES`
+
+```typescript
+FLOOR_VARIANTS: [0, 1, 2, 3, 8, 9, 10, 16, 17, 24, 25, 32, 40, 48],
+FLOOR: 3,    // fallback fixo — frame 3 do Ground0.png
+WALL: 3,     // frame 3 do Wall.png
+```
+
+- **Chão:** edite `FLOOR_VARIANTS` (lista sorteada por andar) ou `FLOOR` (fallback)
+- **Parede:** edite `WALL`
+
+### Cidade — chão por bioma
+**`src/config/sprites-config.ts`** — objeto `FLOOR_ATLAS`
+
+Cada bioma agora usa a interface `VisualDef` com `imageFile`, `textureKey`, `frames`, `weights` e `description`:
+
+```typescript
+natural: {
+  imageFile:   'Ground0.png',   // arquivo real em assets/dawnlike/
+  textureKey:  'ground',        // chave registrada no Phaser
+  frames:      [16, 17, 18],
+  weights:     [0.60, 0.30, 0.10],
+  description: 'Grama verde — linha 2 do Ground0.png (áreas abertas)',
+},
+```
+
+| Bioma | Onde aparece | `imageFile` | Frames |
+|---|---|---|---|
+| `urban` | Calçada e rua | `Ground0.png` | 0–3 (linha 0, cinza) |
+| `natural` | Grama aberta | `Ground0.png` | 16–18 (linha 2, verde) |
+| `interior` | Dentro dos edifícios | `Ground0.png` | 0–1 (linha 0, pedra) |
+| `transition` | Beira do caminho | `Ground0.png` | 8–10 (linha 1, terra) |
+
+`weights` controla a frequência de cada frame — a soma deve ser `1.0`.
+
+Para trocar o arquivo fonte de um bioma inteiro, altere `imageFile` **e** `textureKey` juntos.
+
+### Caminho central da cidade
+**`src/utils/constants.ts`** → `TOWN.STONE_PATH_FRAME`
+
+```typescript
+STONE_PATH_FRAME: 2,   // frame 2 do Ground0.png
+```
+
+### Paredes da cidade
+Usam `DAWNLIKE_FRAMES.WALL` do `constants.ts` (sprite `Wall.png`).
+
+### Decorações
+**`src/config/sprites-config.ts`** — objeto `OBJECT_ATLAS`
+
+```typescript
+barrel: {
+  imageFile:   'Decor0.png',
+  textureKey:  'decor0',
+  frames:      [1, 2],
+  weights:     [0.70, 0.30],
+  description: 'Barril de madeira — frames 1 e 2 do Decor0.png',
+},
+tree: {
+  imageFile:   'Tree0.png',
+  textureKey:  'tree0',
+  frames:      [0, 8, 16],
+  weights:     [0.60, 0.30, 0.10],
+  description: 'Árvore — 3 variantes de copa (linhas 0, 1 e 2 do Tree0.png)',
+},
+```
+
+### NPCs
+**`src/config/sprites-config.ts`** — objeto `NPC_ATLAS`
+
+NPCs têm `frame` único (não lista), mas seguem a mesma estrutura `VisualDef`:
+
+```typescript
+merchant:  { imageFile: 'Humanoid0.png', textureKey: 'humanoid0', frame: 0,  description: '...' },
+innkeeper: { imageFile: 'Humanoid0.png', textureKey: 'humanoid0', frame: 8,  description: '...' },
+guard:     { imageFile: 'Humanoid0.png', textureKey: 'humanoid0', frame: 16, description: '...' },
+cat:       { imageFile: 'Cat0.png',      textureKey: 'cat0',      frame: 0,  description: '...' },
+```
+
+---
+
+## Tabela Resumo
+
+| O que mudar | Arquivo | Campo |
+|---|---|---|
+| Chão da dungeon | `src/utils/constants.ts` | `DAWNLIKE_FRAMES.FLOOR_VARIANTS` |
+| Parede da dungeon | `src/utils/constants.ts` | `DAWNLIKE_FRAMES.WALL` |
+| Chão cidade por bioma | `src/config/sprites-config.ts` | `FLOOR_ATLAS[bioma].frames` |
+| Arquivo fonte de um bioma | `src/config/sprites-config.ts` | `FLOOR_ATLAS[bioma].imageFile` + `.textureKey` |
+| Caminho de pedra central | `src/utils/constants.ts` | `TOWN.STONE_PATH_FRAME` |
+| Parede da cidade | `src/utils/constants.ts` | `DAWNLIKE_FRAMES.WALL` |
+| Barris, caixas, etc. | `src/config/sprites-config.ts` | `OBJECT_ATLAS[objeto].frames` |
+| NPCs | `src/config/sprites-config.ts` | `NPC_ATLAS[npc].frame` |
+
+---
+
+## Dica: Ver Todos os Frames na Tela
+
+Com `npm run dev` rodando, adicione temporariamente no início de `_loadTown()` ou `_loadDungeonFloor()` em `src/scenes/GameScene.ts`:
+
+```typescript
+// DEBUG — remover depois
+for (let f = 0; f < 64; f++) {
+  this.add.image(f % 8 * 18 + 8, Math.floor(f / 8) * 18 + 8, 'ground', f)
+    .setDepth(999).setScrollFactor(0);
+}
+```
+
+Use o `textureKey` do `FLOOR_ATLAS` ou `OBJECT_ATLAS` para inspecionar qualquer spritesheet:
+
+| `textureKey` | `imageFile` |
+|---|---|
+| `'ground'` | `Ground0.png` — tiles de chão |
+| `'wall'` | `Wall.png` — tiles de parede |
+| `'tree0'` | `Tree0.png` — árvores |
+| `'decor0'` | `Decor0.png` — barris, tochas, móveis |
+| `'humanoid0'` | `Humanoid0.png` — NPCs humanoides |
+| `'cat0'` | `Cat0.png` — gato |
+
+Salvar o arquivo já atualiza a tela (Vite HMR) — tweake o frame e veja o resultado na hora.

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -498,3 +498,66 @@ Arquitetura de transição:
 Arquivos gerados/modificados: `src/systems/WorldSystem.ts` (novo), `src/scenes/GameScene.ts`,
 `src/scenes/UIScene.ts`, `src/utils/constants.ts`, `.kiro/specs/world.spec.md` (novo),
 `.kiro/specs/gameloop.spec.md`, `.kiro/specs/input.spec.md`, `.kiro/steering/game-steering.md`
+
+---
+
+## Prompt 15 — feat: melhorias gerais e adaptação roguelike (múltiplos andares, inventário visual, log panel, correção de escadas)
+Autor: Vitor
+Data: 2026-05-07
+
+Contexto:
+O jogo possuía transição de área funcional (cidade ↔ dungeon) mas apenas um único andar de dungeon,
+sem sistema de escadas funcional, sem painel de log dedicado e com a action bar fundida visualmente
+ao fundo do log.
+
+Objetivo:
+Implementar quatro melhorias estruturais de acordo com restrições arquiteturais definidas (R1–R15):
+
+1. **Correção do spawn de retorno à cidade** — player nasce próximo à saída da dungeon, não no centro da cidade
+2. **Log panel dedicado** — LogPanel em Container próprio, ocupando 1/3 esquerdo da tela estilo console RPG
+3. **Múltiplos andares de dungeon** — DungeonFloorManager com cache por andar, DifficultyScalingSystem com tabela de dados, DungeonFeatureGenerator com escadas (stairUp/stairDown) em salas diferentes
+4. **Tela de inventário visual** — InventoryPanel com 6 slots de equipamento (capacete, escudo, espada, calça, botas, amuleto) via EquipmentSystem
+
+Restrições arquiteturais aplicadas:
+- GameScene só executa — MapTransitionSystem resolve lógica de transição
+- Sem singletons excessivos — sistemas instanciados como campos da cena
+- DungeonFloorState apenas serializado — sem lógica
+- Dificuldade data-driven via FLOOR_DIFFICULTY_TABLE
+- UIScene recebe apenas ViewModels (nunca sistemas diretamente)
+- EquipmentSystem armazena IDs, não itens
+- Container raiz único com dirty flags por painel
+- InputModeManager centralizado (GAMEPLAY | INVENTORY | MODAL | DEBUG)
+- LogSystem desacoplado do LogPanel via ViewModel
+- Payloads padronizados no EventBus com timestamp
+- Scaling de inimigos apenas no spawn
+
+Problemas adicionais corrigidos (UX):
+- Action bar visualmente separada do log: novo ActionBarPanel com Container próprio, 36px de altura, fundo distinto
+- LogPanel.layout() recebe reservedBottomHeight para não cobrir a hotbar
+- Sistema de escadas corrigido: stairUp e stairDown sempre em salas diferentes, distância mínima de 5 tiles
+- Spawn ao descer: player nasce no stairUp do andar destino (não em startPos)
+- Spawn ao subir: player nasce no stairDown do andar anterior
+- Retorno à cidade via stairUp explícito (targetFloor = 'town') — sem heurística de startPos
+- tests/enemy.test.js atualizado para nova assinatura de createEnemies(dungeon, playerPos, difficulty?)
+
+Arquivos gerados/modificados:
+- `src/types/dungeon.ts` — StairConnection, FloorConnectionData
+- `src/types/equipment.ts` — EquipmentSlotId, EQUIPMENT_SLOT_ORDER, EQUIPMENT_SLOT_LABELS
+- `src/types/input.ts` — InputMode
+- `src/types/transitions.ts` — SpawnPoint, TransitionPoint, TransitionResolution
+- `src/types/viewmodels.ts` — LogViewModel, InventoryViewModel
+- `src/config/difficulty.config.ts` — FLOOR_DIFFICULTY_TABLE, getFloorDifficulty()
+- `src/generators/DungeonFeatureGenerator.ts` — geração de stairUp/stairDown com distância mínima
+- `src/systems/InputModeManager.ts` — máquina de estados de input
+- `src/systems/LogSystem.ts` — buffer de log desacoplado do painel
+- `src/systems/MapTransitionSystem.ts` — SpawnPoints e TransitionPoints registráveis
+- `src/systems/DungeonFloorManager.ts` — cache de andares, saveFloorConnections/getFloorConnections
+- `src/systems/DifficultyScalingSystem.ts` — scaling data-driven
+- `src/systems/EquipmentSystem.ts` — equipamento por ID de item
+- `src/ui/LogPanel.ts` — Container próprio, dirty flag, pool de texto, reservedBottomHeight
+- `src/ui/InventoryPanel.ts` — grid de inventário + slots de equipamento
+- `src/ui/ActionBarPanel.ts` (novo) — hotbar compacta visualmente separada
+- `src/scenes/UIScene.ts` — refatorado para ViewModels, compõe ActionBarPanel + LogPanel
+- `src/scenes/GameScene.ts` — _loadDungeonFloor com spawn posicional, _checkAreaTransition via features
+- `src/systems/EnemySystem.ts` — createEnemies com nova assinatura (playerPos, difficulty?)
+- `tests/enemy.test.js` — atualizado para nova API de createEnemies

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -561,3 +561,143 @@ Arquivos gerados/modificados:
 - `src/scenes/GameScene.ts` — _loadDungeonFloor com spawn posicional, _checkAreaTransition via features
 - `src/systems/EnemySystem.ts` — createEnemies com nova assinatura (playerPos, difficulty?)
 - `tests/enemy.test.js` — atualizado para nova API de createEnemies
+
+---
+
+## Prompt 16 — feat(commerce): sistema de comércio, equipamentos com bônus e loja do mercador
+Autor: Vitor
+Data: 2026-05-08
+
+Contexto:
+O jogo possuía inventário visual e slots de equipamento, mas sem lógica de comércio, sem itens
+equipáveis com stats e sem interação funcional com o Mercador da cidade.
+
+Objetivo:
+Implementar o sistema completo de comércio e equipamentos seguindo arquitetura EventBus/UIScene/GameScene:
+
+1. Itens equipáveis com bônus de stat (`StatBonuses`: attack, maxHp, con, str, dex)
+2. `Player.applyEquipmentBonuses()` / `removeEquipmentBonuses()` — bônus reversíveis acumulados em `_equipmentBonuses`; `recalcStats()` como fonte de verdade (nunca muta stats base)
+3. `shop.catalog.ts` — 18 itens (3 por slot + poções); `createItemFromCatalogEntry()` e `buildBonusText()`
+4. `ShopSystem` — `buyItem()`, `sellItem()`, `buildViewModel()`, `buildSellItems()` sem acoplamento à UI
+5. `ShopPanel` — 2 abas (Comprar / Vender); mouse hover + click; pool de 20 linhas; detalhes de raridade/bônus/preço
+6. `EquipmentSystem` integrado ao inventário: `E` equipa item selecionado, stats atualizados em tempo real
+7. Gold no HUD (começa com 500); `PLAYER_GOLD_CHANGED` atualiza label em tempo real
+8. Loja do Mercador: `InteractiveObjectSystem` emite `SHOP_OPENED` ao interagir (dentro de `houseBounds`); `GameScene` empilha modo SHOP via `InputModeManager`
+9. `InputModeManager` estendido com modo SHOP
+
+Restrições arquiteturais aplicadas:
+- `ShopSystem` nunca emite `SHOP_UPDATED` — `GameScene._emitShopState()` constrói ViewModel completo
+- Bônus reversíveis: `removeEquipmentBonuses()` subtrai; `recalcStats()` recalcula do zero
+- `EquipmentSystem` armazena IDs; `InventorySystem` é dono dos objetos
+- Comunicação UIScene ↔ GameScene exclusivamente via EventBus
+
+Testes gerados:
+- `tests/shop.test.js` — 17 testes: `createItemFromCatalogEntry`, `buildBonusText`, `ShopSystem.buyItem()` (3 cenários), `ShopSystem.sellItem()` (3 cenários), bônus de equipamento (5 cenários), `buildViewModel` (2 cenários)
+
+Arquivos gerados/modificados:
+- `src/config/shop.catalog.ts` (novo)
+- `src/types/equipment.ts` — StatBonuses, novos EquippableItemTypes
+- `src/types/viewmodels.ts` — ShopItemViewModel, ShopViewModel
+- `src/types/town.ts` — houseBounds, interaction type 'shop'
+- `src/types/input.ts` — adicionado 'SHOP' ao InputMode
+- `src/entities/Item.ts` — slotId?, bonuses?, price?, rarity?, name?
+- `src/entities/Player.ts` — gold, _equipmentBonuses, recalcStats(), applyEquipmentBonuses(), removeEquipmentBonuses()
+- `src/systems/ShopSystem.ts` (novo)
+- `src/systems/InteractiveObjectSystem.ts` — houseBounds, SHOP_OPENED
+- `src/systems/NPCController.ts` — getAllNPCs()
+- `src/config/town.config.ts` — Mercador com shop interaction e houseBounds
+- `src/generators/CityLayoutProcessor.ts` — pass-through de houseBounds/interaction
+- `src/scenes/GameScene.ts` — _handleShopInput(), _equipSelectedItem(), _emitShopState(), SHOP_OPENED listener
+- `src/scenes/UIScene.ts` — ShopPanel, _goldLabel, SHOP_OPENED/UPDATED/CLOSED handlers
+- `src/ui/ShopPanel.ts` (novo)
+- `src/utils/constants.ts` — SHOP_OPENED, SHOP_CLOSED, SHOP_UPDATED, PLAYER_GOLD_CHANGED, INVENTORY_SELECTION_CHANGED, SHOP constant
+- `tests/shop.test.js` (novo)
+
+---
+
+## Prompt 17 — feat(city): evolução cidade/NPCs/comércio — abas loja, diálogos, gato vagante, fix log
+Autor: Vitor
+Data: 2026-05-08
+
+Contexto:
+Após o sistema de comércio básico, necessidade de evoluir a cidade com mais interatividade:
+loja com abas de compra e venda, sistema de diálogo genérico para NPCs, gato vagante
+pela cidade e correção de sobreposição de mensagens longas no log.
+
+Objetivo:
+1. **Fix crash `vm.items undefined`**: `ShopSystem.buyItem/sellItem` emitiam `SHOP_UPDATED: {}` vazio — removidos; `GameScene._emitShopState()` sempre constrói ViewModel completo
+2. **Enter key compra** na loja (além de E); **V key vende** (separado de U para uso de item)
+3. **Duas abas na loja** — Comprar (catálogo) / Vender (inventário filtrado); `←→` troca aba; `ShopViewModel` estendido com `tab`, `buyItems`, `sellItems`, `SellItemViewModel`
+4. **Mouse na loja** — `setInteractive()` em cada item, `SHOP_ITEM_HOVERED` / `SHOP_ITEM_SELECTED` via EventBus; `GameScene` ouve e atualiza seleção
+5. **Fix foco de teclado** — `BLUR`/`FOCUS` do jogo chamam `keyboard.resetKeys()` — previne teclas "presas" após alt+tab
+6. **Gato vagante** — posição corrigida de (4,13) para (3,9); `customWanderBounds` em `TownNPCDef`; `NPCController.update()` FSM reativado
+7. **`DialogPanel`** (novo) — painel genérico com lista de opções e área de conteúdo; mouse `pointerdown` seleciona; `[↑↓ Enter/E ESC]`
+8. **Guarda** — `interaction.type: 'menu'` com 4 opções informativas (objetivos, como jogar, controles, dicas)
+9. **Taberneiro** (renomeado de Estalajadeiro) — `type: 'menu'`; "Repousar (20 ouros)" restaura HP+Mana; `TAVERN.REST_COST = 20`
+10. **Fix log multiline** — `LogPanel.render()` reescrito bottom-up usando `text.height` real após `setText()`
+
+Arquivos gerados/modificados:
+- `src/utils/constants.ts` — SHOP_ITEM_HOVERED, SHOP_ITEM_SELECTED, DIALOG_OPENED, DIALOG_CLOSED, DIALOG_OPTION_SELECTED, TAVERN
+- `src/types/viewmodels.ts` — SellItemViewModel, ShopViewModel com tab/buyItems/sellItems
+- `src/types/town.ts` — interaction type 'menu', menuOptions, DialogMenuOption
+- `src/types/input.ts` — adicionado 'DIALOG'
+- `src/config/town.config.ts` — cat fix (3,9), Taberneiro rename, Guard menu, Taberneiro menu, customWanderBounds
+- `src/systems/ShopSystem.ts` — removidos emits vazios, buildSellItems()
+- `src/generators/CityLayoutProcessor.ts` — customWanderBounds support
+- `src/systems/InteractiveObjectSystem.ts` — type 'menu' → DIALOG_OPENED
+- `src/systems/NPCController.ts` — wander FSM reativado
+- `src/scenes/GameScene.ts` — enterKey, vKey, _shopTab, _handleDialogInput(), _emitShopState() atualizado, DIALOG_OPENED/SHOP_ITEM_SELECTED listeners, focus fix
+- `src/ui/LogPanel.ts` — renderização bottom-up dinâmica
+- `src/ui/ShopPanel.ts` — abas buy/sell, mouse interativo
+- `src/ui/DialogPanel.ts` (novo)
+- `src/scenes/UIScene.ts` — DialogPanel integrado, novos listeners
+
+---
+
+## Prompt 18 — fix(ui): inventário fantasma, input travado, desequipar e ações corretas por item
+Autor: Vitor
+Data: 2026-05-08
+
+Contexto:
+Após as implementações de comércio, o inventário abria automaticamente ao comprar um item
+na loja. Com o inventário visível e o GameScene em modo GAMEPLAY, os direcionais moviam o
+personagem em vez de navegar o inventário, tornando-o inutilizável.
+
+Causa raiz identificada:
+`UIScene.INVENTORY_STATE_RESPONSE` chamava `_inventoryPanel.show()` incondicionalmente.
+`GameScene._handleShopInput()` chamava `_emitInventoryState()` após compra/venda, disparando
+o evento acima enquanto o modo ainda era SHOP. Resultado: inventário aberto + modo GAMEPLAY
+após ESC fechar a loja.
+
+Correções implementadas:
+
+1. **Fix crítico — separar show de update (UIScene)**:
+   - `INVENTORY_OPENED` é o único evento autorizado a chamar `_inventoryPanel.show()`
+   - `INVENTORY_STATE_RESPONSE` apenas atualiza dados e chama `markDirty()` se o painel já estiver visível
+
+2. **Fix crítico — remover `_emitInventoryState()` das operações de loja (GameScene)**:
+   - `_handleShopInput()` não emite mais estado de inventário após compra/venda
+   - Inventário sempre atualizado quando aberto via `I` (que chama `_emitInventoryState()` diretamente)
+
+3. **Fix de stack — usar `pop()` no fechamento de modos (GameScene)**:
+   - ESC em INVENTORY e SHOP agora usa `inputMode.pop()` em vez de `inputMode.set('GAMEPLAY')`
+   - Stack do `InputModeManager` limpa corretamente
+
+4. **Desequipar (GameScene)**:
+   - `E` em item já equipado agora o desequipa (toggle)
+   - Novo método `_unequipSelectedItem()`: chama `equipmentSystem.unequip()`, `player.removeEquipmentBonuses()`, emite `PLAYER_HP_CHANGED`
+
+5. **Ações corretas por tipo de item (UIScene + InventoryPanel)**:
+   - `_buildInventoryViewModel()` detecta `item.slotId` e passa `hasSlot` para o ViewModel
+   - Painel de detalhes exibe `[E] Equipar` para não equipados, `[E] Desequipar` para equipados, `[U] Usar` / `[D] Dropar` para consumíveis
+   - `InventoryDetailViewModel.actions` estendido com `'unequip'`
+
+Fluxo correto pós-fix:
+Comprar item → inventário NÃO abre → ESC fecha loja → GAMEPLAY → I abre inventário →
+E equipa/desequipa → ESC fecha inventário → player pode mover
+
+Arquivos gerados/modificados:
+- `src/scenes/UIScene.ts` — Fix 1 e Fix 5
+- `src/scenes/GameScene.ts` — Fix 2, Fix 3, Fix 4
+- `src/types/viewmodels.ts` — InventoryDetailViewModel com 'unequip'
+- `src/ui/InventoryPanel.ts` — actionMap com '[E] Desequipar'

--- a/src/config/difficulty.config.ts
+++ b/src/config/difficulty.config.ts
@@ -1,0 +1,28 @@
+export interface FloorDifficulty {
+  floor: number;
+  enemyHpMultiplier: number;
+  enemyAtkMultiplier: number;
+  enemyCount: number;
+  lootQualityBonus: number;
+}
+
+export const FLOOR_DIFFICULTY_TABLE: Record<number, FloorDifficulty> = {
+  1: { floor: 1, enemyHpMultiplier: 1.00, enemyAtkMultiplier: 1.00, enemyCount: 6,  lootQualityBonus: 0 },
+  2: { floor: 2, enemyHpMultiplier: 1.15, enemyAtkMultiplier: 1.10, enemyCount: 7,  lootQualityBonus: 0 },
+  3: { floor: 3, enemyHpMultiplier: 1.30, enemyAtkMultiplier: 1.20, enemyCount: 8,  lootQualityBonus: 1 },
+  4: { floor: 4, enemyHpMultiplier: 1.50, enemyAtkMultiplier: 1.30, enemyCount: 9,  lootQualityBonus: 1 },
+  5: { floor: 5, enemyHpMultiplier: 1.75, enemyAtkMultiplier: 1.45, enemyCount: 10, lootQualityBonus: 2 },
+};
+
+export function getFloorDifficulty(floor: number): FloorDifficulty {
+  if (FLOOR_DIFFICULTY_TABLE[floor]) return FLOOR_DIFFICULTY_TABLE[floor];
+  const base = FLOOR_DIFFICULTY_TABLE[5];
+  const extra = floor - 5;
+  return {
+    floor,
+    enemyHpMultiplier:  base.enemyHpMultiplier  + extra * 0.20,
+    enemyAtkMultiplier: base.enemyAtkMultiplier + extra * 0.10,
+    enemyCount: Math.min(base.enemyCount + extra, 20),
+    lootQualityBonus: base.lootQualityBonus + Math.floor(extra / 2),
+  };
+}

--- a/src/config/shop.catalog.ts
+++ b/src/config/shop.catalog.ts
@@ -1,0 +1,61 @@
+import { Item } from '../entities/Item';
+import type { EquipmentSlotId, StatBonuses, ItemRarity, EquippableItemType } from '../types/equipment';
+
+export interface ShopItemDef {
+  id: string;
+  name: string;
+  type: EquippableItemType | 'potion_heal';
+  slotId: EquipmentSlotId | null;
+  price: number;
+  rarity: ItemRarity;
+  bonuses: StatBonuses;
+}
+
+export const SHOP_CATALOG: ShopItemDef[] = [
+  // Espadas
+  { id: 'sword_iron_1',    name: 'Espada de Ferro',   type: 'sword_iron',   slotId: 'sword',  price: 120, rarity: 'common',   bonuses: { attack: 3 } },
+  { id: 'sword_steel_1',   name: 'Espada de Aço',     type: 'sword_steel',  slotId: 'sword',  price: 250, rarity: 'uncommon', bonuses: { attack: 6 } },
+  { id: 'sword_silver_1',  name: 'Espada de Prata',   type: 'sword_silver', slotId: 'sword',  price: 500, rarity: 'rare',     bonuses: { attack: 12 } },
+  // Capacetes
+  { id: 'helmet_leather_1',name: 'Elmo de Couro',     type: 'helmet_leather', slotId: 'helmet', price: 80,  rarity: 'common',   bonuses: { con: 1 } },
+  { id: 'helmet_bronze_1', name: 'Elmo de Bronze',    type: 'helmet_bronze',  slotId: 'helmet', price: 180, rarity: 'uncommon', bonuses: { con: 2 } },
+  { id: 'helmet_iron_1',   name: 'Elmo de Ferro',     type: 'helmet_iron',    slotId: 'helmet', price: 350, rarity: 'rare',     bonuses: { con: 3, maxHp: 10 } },
+  // Escudos
+  { id: 'shield_wood_1',   name: 'Escudo de Madeira', type: 'shield_wood',  slotId: 'shield', price: 70,  rarity: 'common',   bonuses: { con: 1 } },
+  { id: 'shield_iron_1',   name: 'Escudo de Ferro',   type: 'shield_iron',  slotId: 'shield', price: 160, rarity: 'uncommon', bonuses: { con: 2, maxHp: 5 } },
+  { id: 'shield_steel_1',  name: 'Escudo de Aço',     type: 'shield_steel', slotId: 'shield', price: 320, rarity: 'rare',     bonuses: { con: 3, maxHp: 15 } },
+  // Calças
+  { id: 'pants_leather_1', name: 'Calça de Couro',    type: 'pants_leather', slotId: 'pants', price: 60,  rarity: 'common',   bonuses: { dex: 1 } },
+  { id: 'pants_iron_1',    name: 'Calça de Malha',    type: 'pants_iron',    slotId: 'pants', price: 150, rarity: 'uncommon', bonuses: { dex: 2, con: 1 } },
+  // Botas
+  { id: 'boots_leather_1', name: 'Botas de Couro',    type: 'boots_leather', slotId: 'boots', price: 60,  rarity: 'common',   bonuses: { dex: 1 } },
+  { id: 'boots_iron_1',    name: 'Botas de Ferro',    type: 'boots_iron',    slotId: 'boots', price: 140, rarity: 'uncommon', bonuses: { dex: 2 } },
+  // Amuletos
+  { id: 'amulet_stone_1',  name: 'Amuleto de Pedra',  type: 'amulet_stone',  slotId: 'amulet', price: 100, rarity: 'common',   bonuses: { str: 1 } },
+  { id: 'amulet_silver_1', name: 'Amuleto de Prata',  type: 'amulet_silver', slotId: 'amulet', price: 220, rarity: 'uncommon', bonuses: { str: 2, attack: 2 } },
+  { id: 'amulet_gold_1',   name: 'Amuleto de Ouro',   type: 'amulet_gold',   slotId: 'amulet', price: 450, rarity: 'rare',     bonuses: { str: 3, attack: 5, maxHp: 5 } },
+  // Poções
+  { id: 'potion_heal_shop', name: 'Poção de Cura',    type: 'potion_heal',   slotId: null,     price: 30,  rarity: 'common',   bonuses: {} },
+];
+
+export function createItemFromCatalogEntry(entry: ShopItemDef): Item {
+  const item = new Item(`${entry.id}_${Date.now()}`, entry.type as Item['type'], null, null);
+  item.name    = entry.name;
+  item.slotId  = entry.slotId ?? undefined;
+  item.bonuses = Object.keys(entry.bonuses).length > 0 ? { ...entry.bonuses } : undefined;
+  item.price   = entry.price;
+  item.rarity  = entry.rarity;
+  // Poções de cura compradas chegam já identificadas
+  if (entry.type === 'potion_heal') item.identified = true;
+  return item;
+}
+
+export function buildBonusText(bonuses: StatBonuses): string {
+  const parts: string[] = [];
+  if (bonuses.attack) parts.push(`+${bonuses.attack} ATK`);
+  if (bonuses.maxHp)  parts.push(`+${bonuses.maxHp} HP`);
+  if (bonuses.con)    parts.push(`+${bonuses.con} CON`);
+  if (bonuses.str)    parts.push(`+${bonuses.str} STR`);
+  if (bonuses.dex)    parts.push(`+${bonuses.dex} DEX`);
+  return parts.length > 0 ? parts.join(', ') : '—';
+}

--- a/src/config/sprites-config.ts
+++ b/src/config/sprites-config.ts
@@ -1,0 +1,167 @@
+// Créditos: DragonDePlatino — Dawnlike 16×16 (CC-BY 4.0)
+import type { BiomeType } from '../types/town';
+
+// ─── Definição Visual Unificada ───────────────────────────────────────────────
+
+export interface VisualDef {
+  imageFile:   string;   // nome real do arquivo (ex: 'Ground0.png')
+  subfolder:   string;   // pasta dentro de assets/dawnlike/ (ex: 'Objects')
+  textureKey:  string;   // chave registrada no Phaser (this.load.spritesheet)
+  frames:      number[];
+  weights:     number[]; // soma deve ser 1.0; um elemento = peso fixo 1.0
+  description: string;
+}
+
+// ─── Biomas de Chão ───────────────────────────────────────────────────────────
+// Ground0.png — 8 colunas × 7 linhas
+// linha 0 (frames  0– 7): pedra/cinza
+// linha 1 (frames  8–15): terra/marrom
+// linha 2 (frames 16–23): grama/verde
+// linha 3 (frames 24–31): areia
+// linha 4 (frames 32–39): lama
+// linha 5 (frames 40–47): neve
+// linha 6 (frames 48–55): vulcânico
+
+export const FLOOR_ATLAS: Record<BiomeType, VisualDef> = {
+  urban: {
+    imageFile:   'Floor.png',
+    subfolder:   'Objects',
+    textureKey:  'floor_urban', 
+    // Pedra cinza da linha 1 (IDs reais do Floor.png fatiado em 16x16)
+    frames:      [21, 22, 23], 
+    weights:     [1.0],
+    description: 'Caminho de pedra cinza',
+  },
+  natural: {
+    imageFile:   'Floor.png',
+    subfolder:   'Objects',
+    textureKey:  'floor_urban',
+    // Grama verde da linha 6 (IDs reais do Floor.png)
+    frames:      [126, 127], 
+    weights:     [0.80, 0.20],
+    description: 'Grama verde vibrante',
+  },
+  interior: {
+    imageFile:   'Ground0.png',
+    subfolder:   'Objects',
+    textureKey:  'ground', // Chave diferente para não confundir o Phaser
+    // Tijolos clássicos da dungeon (IDs baixos para Ground0.png)
+    frames:      [0, 1, 2], 
+    weights:     [0.70, 0.30, 0.10],
+    description: 'Piso da dungeon (Tijolo cinza)',
+  },
+  transition: {
+    imageFile:   'Ground0.png',
+    subfolder:   'Objects',
+    textureKey:  'ground',
+    // Terra/Areia da linha 1 do Ground0.png
+    frames:      [17, 18], 
+    weights:     [0.50, 0.50],
+    description: 'Terra de transição',
+  },
+};
+// ─── Objetos do Mundo ─────────────────────────────────────────────────────────
+// Tree0.png   — 8 colunas, cada variante de árvore ocupa 8 frames por linha
+// Decor0.png  — objetos decorativos variados (barris, caixas, sinais, portas)
+
+export const OBJECT_ATLAS: Record<string, VisualDef> = {
+  tree: {
+    imageFile:   'Tree0.png',
+    subfolder:   'Objects',
+    textureKey:  'tree0',
+    frames:      [0, 8, 16],
+    weights:     [0.60, 0.30, 0.10],
+    description: 'Árvore — 3 variantes de copa (linhas 0, 1 e 2 do Tree0.png)',
+  },
+  barrel: {
+    imageFile:   'Decor0.png',
+    subfolder:   'Objects',
+    textureKey:  'decor0',
+    frames:      [1, 2],
+    weights:     [0.70, 0.30],
+    description: 'Barril de madeira — frames 1 e 2 do Decor0.png',
+  },
+  crate: {
+    imageFile:   'Decor0.png',
+    subfolder:   'Objects',
+    textureKey:  'decor0',
+    frames:      [3, 4],
+    weights:     [0.60, 0.40],
+    description: 'Caixote — frames 3 e 4 do Decor0.png',
+  },
+  decor_plaza: {
+    imageFile:   'Decor0.png',
+    subfolder:   'Objects',
+    textureKey:  'decor0',
+    frames:      [32, 33],
+    weights:     [0.50, 0.50],
+    description: 'Decoração de praça — frames 32 e 33 do Decor0.png',
+  },
+  door_wood: {
+    imageFile:   'Decor0.png',
+    subfolder:   'Objects',
+    textureKey:  'decor0',
+    frames:      [8],
+    weights:     [1.0],
+    description: 'Porta de madeira — frame 8 do Decor0.png',
+  },
+  sign: {
+    imageFile:   'Decor0.png',
+    subfolder:   'Objects',
+    textureKey:  'decor0',
+    frames:      [40],
+    weights:     [1.0],
+    description: 'Placa de madeira — frame 40 do Decor0.png',
+  },
+};
+
+// ─── NPCs ─────────────────────────────────────────────────────────────────────
+// Humanoid0.png — cada conjunto de 8 frames é uma classe de personagem
+// Cat0.png      — sprite do gato
+
+export type NPCVisualDef = Omit<VisualDef, 'frames' | 'weights'> & { frame: number };
+
+export const NPC_ATLAS: Record<string, NPCVisualDef> = {
+  merchant: {
+    imageFile:   'Humanoid0.png',
+    subfolder:   'Characters',
+    textureKey:  'humanoid0',
+    frame:       0,
+    description: 'Mercador — primeiro conjunto (frames 0–7) do Humanoid0.png',
+  },
+  innkeeper: {
+    imageFile:   'Humanoid0.png',
+    subfolder:   'Characters',
+    textureKey:  'humanoid0',
+    frame:       8,
+    description: 'Estalajadeiro — segundo conjunto (frames 8–15) do Humanoid0.png',
+  },
+  guard: {
+    imageFile:   'Humanoid0.png',
+    subfolder:   'Characters',
+    textureKey:  'humanoid0',
+    frame:       16,
+    description: 'Guarda — terceiro conjunto (frames 16–23) do Humanoid0.png',
+  },
+  townsperson: {
+    imageFile:   'Humanoid0.png',
+    subfolder:   'Characters',
+    textureKey:  'humanoid0',
+    frame:       24,
+    description: 'Citadino genérico — quarto conjunto (frames 24–31) do Humanoid0.png',
+  },
+  cat: {
+    imageFile:   'Cat0.png',
+    subfolder:   'Characters',
+    textureKey:  'cat0',
+    frame:       0,
+    description: 'Gato — frame 0 do Cat0.png',
+  },
+};
+
+// ─── Constantes de Profundidade (Depth Layers) ────────────────────────────────
+
+export const LAYER_GROUND     = 0;
+export const LAYER_WORLD_BASE = 100;  // + gridY * 10 para Y-sort
+export const LAYER_OVERHEAD   = 500;
+export const LAYER_UI_LABELS  = 600;

--- a/src/config/town.config.ts
+++ b/src/config/town.config.ts
@@ -1,0 +1,214 @@
+import { SPRITES, TILE, TOWN } from '../utils/constants';
+import type { BiomeType, DialogMenuOption } from '../types/town';
+
+// ─── Tipos ───────────────────────────────────────────────────────────────────
+
+export interface TownTileVisual {
+  sprite: string;
+  frame:  number;
+}
+
+export interface TownPropDef {
+  x:      number;
+  y:      number;
+  sprite: string;
+  frame:  number;
+  depth:  number;
+}
+
+export interface TownNPCDef {
+  x:           number;
+  y:           number;
+  sprite:      string;
+  frame:       number;
+  name:        string;
+  houseBounds?: { x: number; y: number; w: number; h: number };
+  customWanderBounds?: { minX: number; maxX: number; minY: number; maxY: number };
+  interaction?: { type: 'dialogue' | 'shop' | 'menu'; message: string; menuOptions?: DialogMenuOption[] };
+}
+
+export interface TownLabelDef {
+  x:     number;
+  y:     number;
+  text:  string;
+  color: string;
+  depth: number;
+}
+
+export interface TownConfig {
+  width:  number;
+  height: number;
+  startX: number;
+  startY: number;
+  exitX:  number;
+  exitY:  number;
+  /** Grid de colisão: 0 = sólido (WALL), 1 = caminhável (FLOOR) */
+  grid: number[][];
+  /** Visuais alternativos por posição "x,y" — sobrescreve tile padrão */
+  tileVisuals: Record<string, TownTileVisual>;
+  /** Substituições de bioma por posição "x,y" — sobrescreve detecção automática */
+  biomeOverrides?: Record<string, BiomeType>;
+  props:  TownPropDef[];
+  npcs:   TownNPCDef[];
+  labels: TownLabelDef[];
+}
+
+// ─── Grid de Colisão (24 × 20) ───────────────────────────────────────────────
+// 0 = WALL (sólido), 1 = FLOOR (caminhável)
+// Edifícios: paredes externas = 0, interior = 1, portas = 1
+// Árvores: marcadas como 0 na grid (sólidas), mas com visual override de Tree0
+//
+// Layout:
+//   Norte: Loja (x 2-7, y 2-6) | Centro aberto | Pousada (x 16-21, y 2-6)
+//   Central: praça + caminho de pedra (cols 11-12)
+//   Sul: Taverna (x 2-7, y 10-13) | Caminho | Casa (x 16-21, y 10-13)
+//   Saída dungeon: (12, 18)
+
+const W = TILE.WALL;
+const F = TILE.FLOOR;
+
+const GRID: number[][] = [
+  // x: 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+  [  W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W ], // y=0  border
+  [  W, W, F, F, F, F, F, F, F, W, F, F, F, F, W, F, F, F, F, F, F, F, W, W ], // y=1  árvores em (1),(9),(14),(22)
+  [  W, F, W, W, W, W, W, W, W, F, F, F, F, F, F, W, W, W, W, W, W, W, F, W ], // y=2  fachadas shop+inn
+  [  W, F, W, F, F, F, F, F, W, F, F, F, F, F, F, W, F, F, F, F, F, W, F, W ], // y=3  interiores
+  [  W, F, W, F, F, F, F, F, W, F, F, F, F, F, F, W, F, F, F, F, F, W, F, W ], // y=4
+  [  W, F, W, F, F, F, F, F, W, F, F, F, F, F, F, W, F, F, F, F, F, W, F, W ], // y=5
+  [  W, F, W, W, W, F, W, W, W, F, F, F, F, F, F, W, W, W, F, W, W, W, F, W ], // y=6  portas: (5,6) e (18,6)
+  [  W, W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W, W ], // y=7  praça — árvores em (1),(22)
+  [  W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W ], // y=8  SPAWN (12,8)
+  [  W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W ], // y=9
+  [  W, F, W, W, W, W, W, W, F, F, F, F, F, F, F, F, W, W, W, W, W, W, F, W ], // y=10 fachadas taverna+casa
+  [  W, F, W, F, F, F, F, W, F, F, F, F, F, F, F, F, W, F, F, F, F, W, F, W ], // y=11 interiores
+  [  W, F, W, F, F, F, F, W, F, F, F, F, F, F, F, F, W, F, F, F, F, W, F, W ], // y=12
+  [  W, F, W, W, W, F, W, W, F, F, F, F, F, F, F, F, W, W, F, W, W, W, F, W ], // y=13 portas: (5,13) e (18,13)
+  [  W, W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W, W ], // y=14 árvores em (1),(22)
+  [  W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W ], // y=15
+  [  W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W ], // y=16
+  [  W, W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W, W ], // y=17 árvores em (1),(22)
+  [  W, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, W ], // y=18 EXIT (12,18)
+  [  W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W, W ], // y=19 border
+];
+
+// ─── Posições de árvores (sólidas — WALL na grid acima) ───────────────────
+const TREE_POSITIONS = [
+  // Bordas norte e sul da praça
+  { x: 1,  y: 1  }, { x: 22, y: 1  },
+  { x: 9,  y: 1  }, { x: 14, y: 1  },
+  // Lados da praça central
+  { x: 1,  y: 7  }, { x: 22, y: 7  },
+  // Flancos do caminho sul
+  { x: 1,  y: 14 }, { x: 22, y: 14 },
+  { x: 9,  y: 14 }, { x: 14, y: 14 },
+  // Flancos da saída para dungeon
+  { x: 1,  y: 17 }, { x: 22, y: 17 },
+];
+
+// ─── Visual Overrides ────────────────────────────────────────────────────────
+
+function buildTileVisuals(): Record<string, TownTileVisual> {
+  const visuals: Record<string, TownTileVisual> = {};
+
+  // Caminho de pedra central (cols 11–12, rows 7–18)
+  for (let y = 7; y <= 18; y++) {
+    for (const x of [11, 12]) {
+      visuals[`${x},${y}`] = { sprite: SPRITES.FLOOR, frame: TOWN.STONE_PATH_FRAME };
+    }
+  }
+
+  // Árvores: posições marcadas como WALL na grid mas com visual de árvore
+  for (const pos of TREE_POSITIONS) {
+    visuals[`${pos.x},${pos.y}`] = { sprite: SPRITES.TREE0, frame: 0 };
+  }
+
+  return visuals;
+}
+
+// ─── Props decorativos ───────────────────────────────────────────────────────
+
+const PROPS: TownPropDef[] = [
+  // Barris fora da loja (lado leste da fachada)
+  { x: 8, y: 3, sprite: SPRITES.DECOR0, frame: 1,  depth: 3 },
+  { x: 8, y: 4, sprite: SPRITES.DECOR0, frame: 1,  depth: 3 },
+  // Barris fora da pousada (lado oeste)
+  { x: 15, y: 3, sprite: SPRITES.DECOR0, frame: 1, depth: 3 },
+  { x: 15, y: 4, sprite: SPRITES.DECOR0, frame: 1, depth: 3 },
+  // Decoração central da praça (entre cols 10-13, row 7)
+  { x: 10, y: 7, sprite: SPRITES.DECOR0, frame: 32, depth: 3 },
+  { x: 13, y: 7, sprite: SPRITES.DECOR0, frame: 32, depth: 3 },
+];
+
+// ─── NPCs ─────────────────────────────────────────────────────────────────────
+
+const NPCS: TownNPCDef[] = [
+  // Mercador — centro do interior da loja (x:3-7, y:3-5)
+  {
+    x: 5, y: 4,
+    sprite: SPRITES.HUMANOID0, frame: 0, name: 'Mercador',
+    houseBounds: { x: 3, y: 3, w: 5, h: 3 },
+    interaction: { type: 'shop', message: 'Bem-vindo à minha loja! O que deseja?' },
+  },
+  // Taberneiro — centro do interior da pousada (x:17-20, y:3-5)
+  {
+    x: 18, y: 4,
+    sprite: SPRITES.HUMANOID0, frame: 8, name: 'Taberneiro',
+    houseBounds: { x: 17, y: 3, w: 4, h: 3 },
+    interaction: {
+      type: 'menu',
+      message: 'Bem-vindo à pousada!',
+      menuOptions: [
+        { id: 'rest', label: 'Repousar (20 ouros)', content: 'Recupera toda sua vida e mana por 20 moedas de ouro.', action: 'rest', goldCost: 20 },
+        { id: 'bye', label: 'Até mais', content: 'Volte quando precisar descansar.' },
+      ],
+    },
+  },
+  // Guarda — centro da praça, ao norte do spawn (sem houseBounds — acessível externamente)
+  {
+    x: 12, y: 6,
+    sprite: SPRITES.HUMANOID0, frame: 16, name: 'Guarda',
+    interaction: {
+      type: 'menu',
+      message: 'Saudações, aventureiro.',
+      menuOptions: [
+        { id: 'objectives', label: 'Objetivos do jogo', content: 'Explore a dungeon, colete itens, suba de nível e sobreviva o máximo que puder.' },
+        { id: 'how_to_play', label: 'Como jogar', content: 'Use ↑↓←→ ou WASD para mover. Enfrente inimigos andando até eles. Colete itens andando sobre eles.' },
+        { id: 'controls', label: 'Controles', content: '[I] Inventário  [E] Equipar/Comprar  [U] Usar  [D] Dropar  [T] Interagir  [ESC] Fechar' },
+        { id: 'tips', label: 'Dicas iniciais', content: 'Visite o Mercador para equipamentos. Descanse na Taverna para recuperar HP/MP. Cuidado com o andar 3+.' },
+      ],
+    },
+  },
+  // Gato — lado sul da cidade (sem houseBounds — acessível externamente)
+  {
+    x: 3, y: 9,
+    sprite: SPRITES.CAT0, frame: 0, name: 'Gato',
+    customWanderBounds: { minX: 1, maxX: 6, minY: 7, maxY: 12 },
+    interaction: { type: 'dialogue', message: 'Miau.' },
+  },
+];
+
+// ─── Labels de texto ─────────────────────────────────────────────────────────
+
+const LABELS: TownLabelDef[] = [
+  { x: 4,  y: 2,  text: '[ Loja ]',    color: '#ffd700', depth: 4 },
+  { x: 18, y: 2,  text: '[ Pousada ]', color: '#ffd700', depth: 4 },
+  { x: 4,  y: 10, text: '[ Taverna ]', color: '#ffd700', depth: 4 },
+  { x: 18, y: 10, text: '[ Casa ]',    color: '#ffd700', depth: 4 },
+  { x: 12, y: 17, text: '▼ DUNGEON',   color: '#ff8800', depth: 4 },
+];
+
+// ─── Exportação ──────────────────────────────────────────────────────────────
+
+export const TOWN_CONFIG: TownConfig = {
+  width:  TOWN.WIDTH,
+  height: TOWN.HEIGHT,
+  startX: TOWN.START_X,
+  startY: TOWN.START_Y,
+  exitX:  TOWN.EXIT_X,
+  exitY:  TOWN.EXIT_Y,
+  grid:   GRID,
+  tileVisuals: buildTileVisuals(),
+  props:  PROPS,
+  npcs:   NPCS,
+  labels: LABELS,
+};

--- a/src/entities/Item.ts
+++ b/src/entities/Item.ts
@@ -1,22 +1,17 @@
-/**
- * Item.ts — Entidade de item do jogo
- * Fase 3: Sistema de Inventário, Itens e Identificação
- *
- * Itens podem ser desconhecidos até serem usados (roguelike clássico).
- * O nome exibido depende do estado de identificação do player.
- */
+import type { EquipmentSlotId, StatBonuses, ItemRarity, EquippableItemType } from '../types/equipment';
 
-export type ItemType = 'potion_heal' | 'potion_poison' | 'gold';
+export type ConsumableItemType = 'potion_heal' | 'potion_poison' | 'gold';
+export type ItemType = ConsumableItemType | EquippableItemType;
 
-/** Mapa de nomes genéricos (desconhecidos) por tipo */
-export const UNKNOWN_NAMES: Record<ItemType, string> = {
+/** Mapa de nomes genéricos (desconhecidos) por tipo consumível */
+export const UNKNOWN_NAMES: Record<ConsumableItemType, string> = {
   potion_heal:   'Poção Vermelha',
   potion_poison: 'Poção Azul',
   gold:          'Moeda de Ouro',
 };
 
-/** Mapa de nomes reais (após identificação) */
-export const REAL_NAMES: Record<ItemType, string> = {
+/** Mapa de nomes reais (após identificação) por tipo consumível */
+export const REAL_NAMES: Record<ConsumableItemType, string> = {
   potion_heal:   'Poção de Cura',
   potion_poison: 'Poção de Veneno',
   gold:          'Moeda de Ouro',
@@ -37,6 +32,13 @@ export class Item {
   /** Descrição gerada por IA (opcional, apenas para itens raros/especiais) */
   aiDescription: string | null = null;
 
+  // Campos opcionais para equipamentos
+  name?: string;
+  slotId?: EquipmentSlotId;
+  bonuses?: StatBonuses;
+  price?: number;
+  rarity?: ItemRarity;
+
   constructor(id: string, type: ItemType, gridX: number | null = null, gridY: number | null = null) {
     this.id         = id;
     this.type       = type;
@@ -47,13 +49,16 @@ export class Item {
 
   /**
    * Retorna o nome exibido ao jogador.
-   * Se identificado (ou tipo já identificado na partida), retorna nome real.
-   * Caso contrário, retorna nome genérico.
+   * Equipamentos retornam `name` diretamente.
+   * Consumíveis usam sistema de identificação.
    */
   getDisplayName(identifiedItems: Record<string, boolean>): string {
-    if (this.identified || identifiedItems[this.type]) {
-      return REAL_NAMES[this.type];
+    if (this.name) return this.name;
+    const type = this.type as ConsumableItemType;
+    if (!(type in UNKNOWN_NAMES)) return this.type;
+    if (this.identified || identifiedItems[type]) {
+      return REAL_NAMES[type];
     }
-    return UNKNOWN_NAMES[this.type];
+    return UNKNOWN_NAMES[type];
   }
 }

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -3,6 +3,7 @@ import { PLAYER, TILE_SIZE, SPRITES, DAWNLIKE_FRAMES, EVENTS, BASE_STATS } from 
 import { EventBus } from '../utils/EventBus';
 import { InventorySystem } from '../systems/InventorySystem';
 import type { DungeonGenerator } from '../generators/DungeonGenerator';
+import type { StatBonuses } from '../types/equipment';
 
 export class Player extends Phaser.GameObjects.Sprite {
   // Posição no grid (tile-based)
@@ -30,8 +31,12 @@ export class Player extends Phaser.GameObjects.Sprite {
   inventory: InventorySystem;
   identifiedItems: Record<string, boolean>;
 
+  // Moedas
+  gold: number;
+
   private _lastMoveTime: number;
   private _emitter: Phaser.Events.EventEmitter;
+  private _equipmentBonuses: StatBonuses;
 
   constructor(scene: Phaser.Scene, gridX: number, gridY: number) {
     const px = gridX * TILE_SIZE + TILE_SIZE / 2;
@@ -63,18 +68,39 @@ export class Player extends Phaser.GameObjects.Sprite {
     this.maxMana = this.wis * 4 + this.intel * 2;
     this.mana    = this.maxMana;
 
-    this._lastMoveTime = 0;
-    this._emitter = scene.events;
+    this._lastMoveTime    = 0;
+    this._emitter         = scene.events;
+    this._equipmentBonuses = {};
 
     // Inventário e identificação
     this.inventory       = new InventorySystem();
     this.identifiedItems = {};
+
+    this.gold = 500;
   }
 
-  /** Recalcula maxHp e maxMana a partir dos atributos base e nível atual. */
+  /** Recalcula maxHp, maxMana e attack a partir dos atributos base, nível e bônus de equipamento. */
   recalcStats(): void {
-    this.maxHp   = this.con * 5 + this.level * 3;
+    this.maxHp   = this.con * 5 + this.level * 3 + (this._equipmentBonuses.maxHp ?? 0);
     this.maxMana = this.wis * 4 + this.intel * 2;
+    this.attack  = PLAYER.ATTACK + (this._equipmentBonuses.attack ?? 0);
+    // hp e mana nunca ultrapassam o máximo
+    this.hp   = Math.min(this.hp,   this.maxHp);
+    this.mana = Math.min(this.mana, this.maxMana);
+  }
+
+  applyEquipmentBonuses(bonuses: StatBonuses): void {
+    for (const key of Object.keys(bonuses) as Array<keyof StatBonuses>) {
+      this._equipmentBonuses[key] = (this._equipmentBonuses[key] ?? 0) + (bonuses[key] ?? 0);
+    }
+    this.recalcStats();
+  }
+
+  removeEquipmentBonuses(bonuses: StatBonuses): void {
+    for (const key of Object.keys(bonuses) as Array<keyof StatBonuses>) {
+      this._equipmentBonuses[key] = (this._equipmentBonuses[key] ?? 0) - (bonuses[key] ?? 0);
+    }
+    this.recalcStats();
   }
 
   tryMove(
@@ -148,9 +174,11 @@ export class Player extends Phaser.GameObjects.Sprite {
 
     this._lastMoveTime = 0;
 
-    // Resetar inventário e identificação para nova partida
+    // Resetar inventário, identificação e bônus de equipamento
     this.inventory.reset();
-    this.identifiedItems = {};
+    this.identifiedItems   = {};
+    this._equipmentBonuses = {};
+    this.gold = 500;
 
     this.setPosition(
       gridX * TILE_SIZE + TILE_SIZE / 2,

--- a/src/generators/CityLayoutProcessor.ts
+++ b/src/generators/CityLayoutProcessor.ts
@@ -1,0 +1,203 @@
+import { TILE } from '../utils/constants';
+import { FLOOR_ATLAS } from '../config/sprites-config';
+import type { TownConfig } from '../config/town.config';
+import { TileVariantResolver } from './TileVariantResolver';
+import type {
+  BiomeType,
+  ProcessedTownLayout,
+  ResolvedTile,
+  WorldObjectDef,
+  NPCInstanceDef,
+  InteractiveObjectDef,
+} from '../types/town';
+
+// Building bounding boxes [x1,y1,x2,y2] (inclusive)
+const BUILDINGS = [
+  { x1: 2, y1: 2, x2: 7,  y2: 6  }, // Loja
+  { x1: 16, y1: 2, x2: 21, y2: 6  }, // Pousada
+  { x1: 2, y1: 10, x2: 7,  y2: 13 }, // Taverna
+  { x1: 16, y1: 10, x2: 21, y2: 13 }, // Casa
+];
+
+// Stone path columns
+const PATH_COLS = [11, 12];
+const PATH_ROW_START = 7;
+const PATH_ROW_END   = 18;
+
+export class CityLayoutProcessor {
+  constructor(private _resolver: TileVariantResolver) {}
+
+  process(config: TownConfig): ProcessedTownLayout {
+    const biomeMap    = this._buildBiomeMap(config);
+    const groundTiles = this._resolveGroundTiles(config, biomeMap);
+    const worldObjects = this._buildWorldObjects(config);
+    const npcs         = this._buildNPCs(config);
+    const interactive  = this._buildInteractive(config);
+    return {
+      width:  config.width,
+      height: config.height,
+      collisionGrid: config.grid.map(r => [...r]),
+      groundTiles,
+      worldObjects,
+      npcs,
+      interactive,
+      spawnPos: { x: config.startX, y: config.startY },
+      exitPos:  { x: config.exitX,  y: config.exitY  },
+    };
+  }
+
+  private _buildBiomeMap(config: TownConfig): BiomeType[][] {
+    const map: BiomeType[][] = [];
+    for (let y = 0; y < config.height; y++) {
+      map[y] = [];
+      for (let x = 0; x < config.width; x++) {
+        map[y][x] = this._biomeAt(x, y);
+      }
+    }
+    return map;
+  }
+
+  private _biomeAt(x: number, y: number): BiomeType {
+    // Stone path → urban
+    if (PATH_COLS.includes(x) && y >= PATH_ROW_START && y <= PATH_ROW_END) return 'urban';
+
+    // Inside a building → interior
+    for (const b of BUILDINGS) {
+      if (x >= b.x1 && x <= b.x2 && y >= b.y1 && y <= b.y2) return 'interior';
+    }
+
+    // Adjacent to path → transition
+    if (
+      (PATH_COLS.includes(x - 1) || PATH_COLS.includes(x + 1)) &&
+      y >= PATH_ROW_START && y <= PATH_ROW_END
+    ) return 'transition';
+
+    return 'natural';
+  }
+
+  private _resolveGroundTiles(config: TownConfig, biomeMap: BiomeType[][]): ResolvedTile[][] {
+    const tiles: ResolvedTile[][] = [];
+    for (let y = 0; y < config.height; y++) {
+      tiles[y] = [];
+      for (let x = 0; x < config.width; x++) {
+        const biome = biomeMap[y][x];
+        const set   = FLOOR_ATLAS[biome];
+        const frame = biome === 'urban'
+          ? this._resolveUrbanFrame(biomeMap, x, y)
+          : this._resolver.resolve(set, x, y);
+        tiles[y][x] = { sprite: set.textureKey, frame, biome };
+      }
+    }
+    return tiles;
+  }
+
+  // Frames de estrada por posição horizontal:
+  //   21 = início (borda esquerda)  — sem vizinho urban à esquerda
+  //   22 = meio (continuação)       — urban em ambos os lados
+  //   23 = fim (borda direita)      — sem vizinho urban à direita
+  private _resolveUrbanFrame(biomeMap: BiomeType[][], x: number, y: number): number {
+    const leftIsUrban  = biomeMap[y]?.[x - 1] === 'urban';
+    const rightIsUrban = biomeMap[y]?.[x + 1] === 'urban';
+    if (!leftIsUrban && rightIsUrban)  return 21; // início
+    if (leftIsUrban  && rightIsUrban)  return 22; // meio
+    return 23;                                    // fim (ou tile isolado)
+  }
+
+  private _buildWorldObjects(config: TownConfig): WorldObjectDef[] {
+    const objects: WorldObjectDef[] = [];
+
+    // Visual overrides from TOWN_CONFIG (trees, stone path visual, etc.)
+    for (const [key, visual] of Object.entries(config.tileVisuals)) {
+      const [xs, ys] = key.split(',');
+      const gx = parseInt(xs, 10);
+      const gy = parseInt(ys, 10);
+      // Only include tree overrides (WALL tiles) as solid world objects
+      if (config.grid[gy]?.[gx] === TILE.WALL) {
+        objects.push({
+          gridX: gx, gridY: gy,
+          sprite: visual.sprite,
+          frame: visual.frame,
+          solid: true,
+          layer: 'world',
+        });
+      }
+    }
+
+    // Decorative props from TOWN_CONFIG
+    for (const prop of config.props) {
+      objects.push({
+        gridX: prop.x,  gridY: prop.y,
+        sprite: prop.sprite, frame: prop.frame,
+        solid: false,
+        layer: 'world',
+      });
+    }
+
+    return objects;
+  }
+
+  private _buildNPCs(config: TownConfig): NPCInstanceDef[] {
+    return config.npcs.map((npc, i) => {
+      const def: NPCInstanceDef = {
+        id:     `npc_${i}`,
+        gridX:  npc.x,
+        gridY:  npc.y,
+        sprite: npc.sprite,
+        frame:  npc.frame,
+        name:   npc.name,
+        state:  'idle',
+      };
+      // NPCs com houseBounds não devem vagar (estão dentro de edifícios)
+      if (!npc.houseBounds && npc.name !== 'Guarda') {
+        if (npc.customWanderBounds) {
+          def.wanderBounds = { ...npc.customWanderBounds };
+        } else {
+          def.wanderBounds = {
+            minX: Math.max(1, npc.x - 2),
+            maxX: Math.min(config.width  - 2, npc.x + 2),
+            minY: Math.max(1, npc.y - 2),
+            maxY: Math.min(config.height - 2, npc.y + 2),
+          };
+        }
+      }
+      if (npc.houseBounds)  def.houseBounds  = npc.houseBounds;
+      if (npc.interaction)  def.interaction  = npc.interaction;
+      return def;
+    });
+  }
+
+  private _buildInteractive(config: TownConfig): InteractiveObjectDef[] {
+    const objects: InteractiveObjectDef[] = [];
+    const W = config.width;
+    const H = config.height;
+
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        if (config.grid[y][x] !== TILE.FLOOR) continue;
+        // Check if this floor tile is adjacent to a building wall
+        const neighbors = [
+          { dx: 0, dy: -1 }, { dx: 0, dy: 1 },
+          { dx: -1, dy: 0 }, { dx: 1, dy: 0 },
+        ];
+        let adjacentToBuilding = false;
+        for (const n of neighbors) {
+          const nx = x + n.dx;
+          const ny = y + n.dy;
+          if (nx < 0 || ny < 0 || nx >= W || ny >= H) continue;
+          if (config.grid[ny][nx] === TILE.WALL) {
+            for (const b of BUILDINGS) {
+              if (nx >= b.x1 && nx <= b.x2 && ny >= b.y1 && ny <= b.y2) {
+                adjacentToBuilding = true;
+              }
+            }
+          }
+        }
+        if (adjacentToBuilding) {
+          objects.push({ gridX: x, gridY: y, type: 'door', label: '[E] Entrar' });
+        }
+      }
+    }
+
+    return objects;
+  }
+}

--- a/src/generators/DungeonFeatureGenerator.ts
+++ b/src/generators/DungeonFeatureGenerator.ts
@@ -1,0 +1,125 @@
+import { DungeonGenerator } from './DungeonGenerator';
+import type { GridPos } from './DungeonGenerator';
+import { TILE } from '../utils/constants';
+import type { StairConnection, FloorConnectionData } from '../types/dungeon';
+
+export type FeatureType = 'stairDown' | 'stairUp' | 'trap' | 'shrine' | 'portal';
+
+export interface DungeonFeature {
+  type: FeatureType;
+  gridX: number;
+  gridY: number;
+  connection?: StairConnection;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FeatureOptions {
+  excludePositions?: GridPos[];
+}
+
+const MIN_STAIR_DISTANCE = 5;
+
+export class DungeonFeatureGenerator {
+  /**
+   * Gera features do andar. Sempre produz stairUp + stairDown.
+   * Floor 1: stairUp.targetFloor = 'town'
+   * Floor N>1: stairUp.targetFloor = N-1
+   * targetPosition é preenchido pela GameScene após o floor vizinho ser gerado.
+   */
+  generate(dungeon: DungeonGenerator, floor: number, options: FeatureOptions = {}): DungeonFeature[] {
+    const features: DungeonFeature[] = [];
+    const excluded = new Set<string>([
+      `${dungeon.startPos.x},${dungeon.startPos.y}`,
+      ...(options.excludePositions ?? []).map(p => `${p.x},${p.y}`),
+    ]);
+
+    // stairUp: preferencialmente em room diferente do stairDown
+    const upRoomIdx   = 0;
+    const downRoomIdx = dungeon.rooms.length > 1 ? dungeon.rooms.length - 1 : 0;
+
+    const upPos = this._findPositionInRoom(dungeon, upRoomIdx, excluded);
+    if (upPos) {
+      excluded.add(`${upPos.x},${upPos.y}`);
+      const upConn: StairConnection = {
+        targetFloor:    floor === 1 ? 'town' : floor - 1,
+        sourcePosition: { x: upPos.x, y: upPos.y },
+        targetPosition: { x: 0, y: 0 }, // preenchido depois
+      };
+      features.push({ type: 'stairUp', gridX: upPos.x, gridY: upPos.y, connection: upConn });
+    }
+
+    // stairDown: em room diferente, respeitando distância mínima
+    const downPos = this._findPositionInRoomWithMinDistance(
+      dungeon, downRoomIdx, excluded,
+      upPos ? [upPos] : [],
+    );
+    if (downPos) {
+      const downConn: StairConnection = {
+        targetFloor:    floor + 1,
+        sourcePosition: { x: downPos.x, y: downPos.y },
+        targetPosition: { x: 0, y: 0 }, // preenchido depois
+      };
+      features.push({ type: 'stairDown', gridX: downPos.x, gridY: downPos.y, connection: downConn });
+    }
+
+    return features;
+  }
+
+  /** Extrai FloorConnectionData das features geradas. */
+  extractConnections(features: DungeonFeature[]): FloorConnectionData {
+    const data: FloorConnectionData = {};
+    for (const f of features) {
+      if (f.type === 'stairUp'   && f.connection) data.stairsUp   = f.connection;
+      if (f.type === 'stairDown' && f.connection) data.stairsDown = f.connection;
+    }
+    return data;
+  }
+
+  private _findPositionInRoom(
+    dungeon: DungeonGenerator,
+    roomIdx: number,
+    excluded: Set<string>,
+  ): GridPos | null {
+    if (dungeon.rooms.length === 0) return null;
+    const room = dungeon.rooms[Math.min(roomIdx, dungeon.rooms.length - 1)];
+
+    for (let dy = 0; dy < room.height; dy++) {
+      for (let dx = 0; dx < room.width; dx++) {
+        const x = room.x + dx;
+        const y = room.y + dy;
+        if (!excluded.has(`${x},${y}`) && dungeon.getTile(x, y) === TILE.FLOOR) {
+          return { x, y };
+        }
+      }
+    }
+    return null;
+  }
+
+  private _findPositionInRoomWithMinDistance(
+    dungeon: DungeonGenerator,
+    roomIdx: number,
+    excluded: Set<string>,
+    mustBeDistantFrom: GridPos[],
+  ): GridPos | null {
+    if (dungeon.rooms.length === 0) return null;
+    const room = dungeon.rooms[Math.min(roomIdx, dungeon.rooms.length - 1)];
+
+    for (let dy = 0; dy < room.height; dy++) {
+      for (let dx = 0; dx < room.width; dx++) {
+        const x = room.x + dx;
+        const y = room.y + dy;
+        if (excluded.has(`${x},${y}`)) continue;
+        if (dungeon.getTile(x, y) !== TILE.FLOOR) continue;
+        const tooClose = mustBeDistantFrom.some(p => this._dist(p, { x, y }) < MIN_STAIR_DISTANCE);
+        if (!tooClose) return { x, y };
+      }
+    }
+
+    // Fallback: aceita qualquer tile walkable na room, ignorando distância mínima
+    return this._findPositionInRoom(dungeon, roomIdx, excluded);
+  }
+
+  private _dist(a: GridPos, b: GridPos): number {
+    return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
+  }
+}

--- a/src/generators/TileVariantResolver.ts
+++ b/src/generators/TileVariantResolver.ts
@@ -1,0 +1,27 @@
+import type { VisualDef } from '../config/sprites-config';
+
+export class TileVariantResolver {
+  private _seed: number;
+
+  constructor(seed = Date.now()) { this._seed = seed; }
+
+  resolve(set: VisualDef, x: number, y: number): number {
+    const r = this._hash(x, y);
+    return this._weightedPick(set.frames, set.weights, r);
+  }
+
+  private _hash(x: number, y: number): number {
+    let n = this._seed ^ (x * 374761393) ^ (y * 1103515245);
+    n = ((n >> 16) ^ n) * 0x45d9f3b;
+    return (n >>> 0) / 0xffffffff;
+  }
+
+  private _weightedPick(frames: number[], weights: number[], r: number): number {
+    let acc = 0;
+    for (let i = 0; i < weights.length; i++) {
+      acc += weights[i];
+      if (r < acc) return frames[i];
+    }
+    return frames[frames.length - 1];
+  }
+}

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,5 +1,6 @@
 import * as Phaser from 'phaser';
 import { SPRITES } from '../utils/constants';
+import { FLOOR_ATLAS, OBJECT_ATLAS, NPC_ATLAS } from '../config/sprites-config';
 
 export class BootScene extends Phaser.Scene {
   constructor() {
@@ -9,45 +10,39 @@ export class BootScene extends Phaser.Scene {
   preload(): void {
     const base = 'assets/dawnlike';
 
-    // Tiles de terreno (16×16 por frame)
-    this.load.spritesheet(SPRITES.FLOOR, `${base}/Objects/Ground0.png`, {
-      frameWidth: 16,
-      frameHeight: 16,
-    });
-    this.load.spritesheet(SPRITES.WALL, `${base}/Objects/Wall.png`, {
-      frameWidth: 16,
-      frameHeight: 16,
-    });
+    // ── Assets controlados por sprites-config.ts ──────────────────────────────
+    // Carrega automaticamente todos os spritesheets dos atlases, deduplicando
+    // por textureKey. Para adicionar um novo arquivo basta editar o config.
+    const loaded = new Set<string>();
 
-    // Sprites de personagens (16×16 por frame)
-    this.load.spritesheet(SPRITES.PLAYER, `${base}/Characters/Player0.png`, {
-      frameWidth: 16,
-      frameHeight: 16,
-    });
-    this.load.spritesheet(SPRITES.ENEMY, `${base}/Characters/Undead0.png`, {
-      frameWidth: 16,
-      frameHeight: 16,
-    });
+    const loadDef = (textureKey: string, subfolder: string, imageFile: string): void => {
+      if (loaded.has(textureKey)) return;
+      this.load.spritesheet(textureKey, `${base}/${subfolder}/${imageFile}`, {
+        frameWidth: 16,
+        frameHeight: 16,
+      });
+      loaded.add(textureKey);
+    };
 
-    // Itens — poções (Dawnlike Items/Potion.png, 8×5 frames de 16×16)
-    this.load.spritesheet(SPRITES.POTION, `${base}/Items/Potion.png`, {
-      frameWidth: 16,
-      frameHeight: 16,
-    });
+    for (const def of Object.values(FLOOR_ATLAS)) {
+      loadDef(def.textureKey, def.subfolder, def.imageFile);
+    }
+    for (const def of Object.values(OBJECT_ATLAS)) {
+      loadDef(def.textureKey, def.subfolder, def.imageFile);
+    }
+    for (const def of Object.values(NPC_ATLAS)) {
+      loadDef(def.textureKey, def.subfolder, def.imageFile);
+    }
 
-    // Itens — dinheiro (Dawnlike Items/Money.png, 8×8 frames de 16×16)
-    this.load.spritesheet(SPRITES.MONEY, `${base}/Items/Money.png`, {
-      frameWidth: 16,
-      frameHeight: 16,
-    });
+    // ── Assets fixos (parede, personagens, itens) ─────────────────────────────
+    // Estes não pertencem a biomas e permanecem hardcoded aqui intencionalmente.
+    this.load.spritesheet(SPRITES.WALL,    `${base}/Objects/Wall.png`,           { frameWidth: 16, frameHeight: 16 });
+    this.load.spritesheet(SPRITES.PLAYER,  `${base}/Characters/Player0.png`,     { frameWidth: 16, frameHeight: 16 });
+    this.load.spritesheet(SPRITES.ENEMY,   `${base}/Characters/Undead0.png`,     { frameWidth: 16, frameHeight: 16 });
+    this.load.spritesheet(SPRITES.POTION,  `${base}/Items/Potion.png`,           { frameWidth: 16, frameHeight: 16 });
+    this.load.spritesheet(SPRITES.MONEY,   `${base}/Items/Money.png`,            { frameWidth: 16, frameHeight: 16 });
+    this.load.spritesheet(SPRITES.PLATINO, `${base}/Characters/Reptile0.png`,    { frameWidth: 16, frameHeight: 16 });
 
-    // Easter egg — Platino (DragonDePlatino, CC-BY 4.0)
-    this.load.spritesheet(SPRITES.PLATINO, `${base}/Characters/Reptile0.png`, {
-      frameWidth: 16,
-      frameHeight: 16,
-    });
-
-    // Barra de progresso
     this._setupLoadingBar();
   }
 
@@ -72,7 +67,7 @@ export class BootScene extends Phaser.Scene {
     const cx = width / 2;
     const cy = height / 2 + 60;
 
-    const bg = this.add.rectangle(cx, cy, 300, 16, 0x222222).setOrigin(0.5);
+    const bg  = this.add.rectangle(cx, cy, 300, 16, 0x222222).setOrigin(0.5);
     const bar = this.add.rectangle(cx - 150, cy, 0, 14, 0x00aaff).setOrigin(0, 0.5);
 
     this.add

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -8,7 +8,15 @@ import { XPSystem } from '../systems/XPSystem';
 import { TurnManager } from '../systems/TurnManager';
 import { LootSystem } from '../systems/LootSystem';
 import { EventBus } from '../utils/EventBus';
-import { worldSystem, TownMap } from '../systems/WorldSystem';
+import { TownMap } from '../systems/WorldSystem';
+import { InputModeManager } from '../systems/InputModeManager';
+import { MapTransitionSystem } from '../systems/MapTransitionSystem';
+import { DungeonFloorManager } from '../systems/DungeonFloorManager';
+import { DifficultyScalingSystem } from '../systems/DifficultyScalingSystem';
+import { DungeonFeatureGenerator, type DungeonFeature } from '../generators/DungeonFeatureGenerator';
+import { EquipmentSystem } from '../systems/EquipmentSystem';
+import type { TransitionResolution } from '../types/transitions';
+import type { GridPos } from '../generators/DungeonGenerator';
 import {
   TILE_SIZE,
   TILE,
@@ -29,16 +37,30 @@ export class GameScene extends Phaser.Scene {
   private combatSystem!: CombatSystem;
   private turnManager!: TurnManager;
   private lootSystem!: LootSystem;
+  private inputMode!: InputModeManager;
+  private mapTransitionSystem!: MapTransitionSystem;
+  private floorManager!: DungeonFloorManager;
+  private difficultySystem!: DifficultyScalingSystem;
+  private featureGenerator!: DungeonFeatureGenerator;
+  private _dungeonFeatures: DungeonFeature[] = [];
+  private equipmentSystem!: EquipmentSystem;
   private gameState!: string;
+
+  // Cache de andares visitados (runtime — não serializado ainda)
+  private _dungeonCache = new Map<number, {
+    dungeon:    DungeonGenerator;
+    items:      Item[];
+    floorFrame: number;
+    features:   DungeonFeature[];
+  }>();
 
   // ─── Estado da área atual ─────────────────────────────────────────────────
   private _currentArea: 'town' | 'dungeon' = 'town';
-  private _currentMap!: DungeonGenerator;   // TownMap ou DungeonGenerator real
+  private _currentMap!: DungeonGenerator;
   private _dungeon: DungeonGenerator | null = null;
   private _enemies: EnemySystem[] = [];
   private _items: Item[] = [];
   private _floorFrame = 0;
-  private _canExitDungeon = false;
 
   // ─── GameObjects rastreados por área (destruídos no cleanup) ─────────────
   private _tileObjects: Phaser.GameObjects.Image[] = [];
@@ -63,14 +85,22 @@ export class GameScene extends Phaser.Scene {
   }
 
   create(): void {
-    worldSystem.clearDungeon(); // nova sessão = zero
     this.gameState = GAME_STATE.PLAYING;
+    this._dungeonCache.clear();
 
     // Sistemas criados uma vez — stats persistem entre áreas
     this.xpSystem     = new XPSystem(this.events);
     this.combatSystem = new CombatSystem(this.events, this.xpSystem);
     this.turnManager  = new TurnManager();
     this.lootSystem   = new LootSystem();
+    this.inputMode          = new InputModeManager();
+    this.mapTransitionSystem = new MapTransitionSystem();
+    this.floorManager       = new DungeonFloorManager();
+    this.difficultySystem   = new DifficultyScalingSystem();
+    this.featureGenerator   = new DungeonFeatureGenerator();
+    this.floorManager.reset();
+    this.equipmentSystem = new EquipmentSystem();
+    this._registerTransitions();
 
     // Player criado uma vez — moves between areas
     this.player = new Player(this, TOWN.START_X, TOWN.START_Y);
@@ -85,6 +115,7 @@ export class GameScene extends Phaser.Scene {
 
   shutdown(): void {
     EventBus.off(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
+    EventBus.off(EVENTS.INVENTORY_STATE_REQUESTED, undefined, this);
   }
 
   update(_time: number, _delta: number): void {
@@ -92,17 +123,52 @@ export class GameScene extends Phaser.Scene {
     this._handleInput(_time);
   }
 
+  // ─── Transições ──────────────────────────────────────────────────────────
+
+  private _registerTransitions(): void {
+    // SpawnPoints
+    this.mapTransitionSystem.registerSpawn({ id: 'town-main',          mapId: 'town',    gridX: TOWN.START_X, gridY: TOWN.START_Y });
+    this.mapTransitionSystem.registerSpawn({ id: 'town-near-exit',     mapId: 'town',    gridX: TOWN.EXIT_X,  gridY: TOWN.EXIT_Y - 1 });
+    this.mapTransitionSystem.registerSpawn({ id: 'dungeon-floor1-entry', mapId: 'dungeon', gridX: 0, gridY: 0 });
+
+    // TransitionPoints
+    this.mapTransitionSystem.registerTransition({
+      id: 'town-to-dungeon',
+      fromMapId: 'town', toMapId: 'dungeon',
+      fromGridX: TOWN.EXIT_X, fromGridY: TOWN.EXIT_Y,
+      targetSpawnId: 'dungeon-floor1-entry',
+    });
+    this.mapTransitionSystem.registerTransition({
+      id: 'dungeon-to-town',
+      fromMapId: 'dungeon', toMapId: 'town',
+      fromGridX: 0, fromGridY: 0,  // atualizado dinamicamente
+      targetSpawnId: 'town-near-exit',
+    });
+  }
+
+  private _executeTransition(resolution: TransitionResolution): void {
+    this._cleanup();
+    this.mapTransitionSystem.completeTransition(resolution);
+    if (resolution.targetMapId === 'town') {
+      this._currentArea = 'town';
+      this._loadTown(resolution.targetSpawn.gridX, resolution.targetSpawn.gridY);
+    } else {
+      this._currentArea = 'dungeon';
+      this._loadDungeonFloor(this.floorManager.currentFloor);
+    }
+    EventBus.emit(EVENTS.AREA_CHANGED, { area: this._currentArea, timestamp: Date.now() });
+  }
+
   // ─── Gestão de Áreas ─────────────────────────────────────────────────────
 
   private _loadArea(area: 'town' | 'dungeon'): void {
     this._cleanup();
-    this._currentArea    = area;
-    this._canExitDungeon = false;
+    this._currentArea = area;
 
     if (area === 'town') {
-      this._loadTown();
+      this._loadTown(TOWN.START_X, TOWN.START_Y);
     } else {
-      this._loadDungeon();
+      this._loadDungeonFloor(this.floorManager.currentFloor);
     }
 
     EventBus.emit(EVENTS.AREA_CHANGED, { area });
@@ -122,7 +188,7 @@ export class GameScene extends Phaser.Scene {
     this._enemies = [];
   }
 
-  private _loadTown(): void {
+  private _loadTown(spawnX = TOWN.START_X, spawnY = TOWN.START_Y): void {
     const townMap = new TownMap();
     this._currentMap = townMap;
 
@@ -148,25 +214,34 @@ export class GameScene extends Phaser.Scene {
       }).setOrigin(0.5, 1).setDepth(3),
     );
 
-    // Reposicionar player
-    this.player.gridX = TOWN.START_X;
-    this.player.gridY = TOWN.START_Y;
-    this.player.setPosition(TOWN.START_X * TILE_SIZE + TILE_SIZE / 2, TOWN.START_Y * TILE_SIZE + TILE_SIZE / 2);
+    // Reposicionar player na posição de spawn
+    this.player.gridX = spawnX;
+    this.player.gridY = spawnY;
+    this.player.setPosition(spawnX * TILE_SIZE + TILE_SIZE / 2, spawnY * TILE_SIZE + TILE_SIZE / 2);
 
     this.cameras.main.setBounds(0, 0, TOWN.WIDTH * TILE_SIZE, TOWN.HEIGHT * TILE_SIZE);
     this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
     this.cameras.main.setZoom(2);
 
-    EventBus.emit(EVENTS.UI_LOG, 'Bem-vindo à cidade. Vá para o sul para entrar na dungeon.');
+    const isReturn = spawnX === TOWN.EXIT_X && spawnY === TOWN.EXIT_Y - 1;
+    EventBus.emit(EVENTS.UI_LOG, isReturn
+      ? 'Você retornou à cidade.'
+      : 'Bem-vindo à cidade. Vá para o sul para entrar na dungeon.',
+    );
   }
 
-  private _loadDungeon(): void {
-    const saved = worldSystem.loadDungeon();
+  /**
+   * Carrega (ou gera) um andar de dungeon.
+   * spawnPos: posição onde o player nasce; omitir = usar startPos da dungeon (entrada da cidade).
+   */
+  private _loadDungeonFloor(floor: number, spawnPos?: GridPos): void {
+    const cached = this._dungeonCache.get(floor);
 
-    if (saved) {
-      this._dungeon    = saved.dungeon;
-      this._floorFrame = saved.floorFrame;
-      this._items      = saved.items;
+    if (cached) {
+      this._dungeon    = cached.dungeon;
+      this._floorFrame = cached.floorFrame;
+      this._items      = cached.items;
+      this._dungeonFeatures = cached.features;
     } else {
       this._dungeon = new DungeonGenerator();
       this._dungeon.generate();
@@ -174,9 +249,14 @@ export class GameScene extends Phaser.Scene {
       this._floorFrame = variants[Math.floor(Math.random() * variants.length)];
       this._items      = [];
       this._generateInitialItems();
+      // Gerar features e salvar conexões apenas uma vez (Math.random implica não-determinismo)
+      this._dungeonFeatures = this.featureGenerator.generate(this._dungeon, floor);
+      const connections = this.featureGenerator.extractConnections(this._dungeonFeatures);
+      this.floorManager.saveFloorConnections(floor, connections);
     }
 
-    this._currentMap = this._dungeon;
+    this._currentMap  = this._dungeon;
+    this._currentArea = 'dungeon';
 
     // Renderizar tiles
     const { width: W, height: H, grid } = this._dungeon;
@@ -201,34 +281,36 @@ export class GameScene extends Phaser.Scene {
       item.sprite = this.add.sprite(px, py, texture, frame).setDepth(3);
     }
 
-    // Gerar inimigos (sempre fresh — respawn ao retornar)
-    this._enemies = createEnemies(this._dungeon, ENEMY.COUNT, this._dungeon.startPos);
+    this._renderDungeonFeatures(floor);
+
+    // Gerar inimigos com scaling de dificuldade
+    const difficulty = this.difficultySystem.getFloorDifficulty(floor);
+    this._enemies = createEnemies(this._dungeon, this._dungeon.startPos, difficulty);
     this._createEnemySprites();
 
     // Easter egg Platino
     this._spawnPlatino();
 
-    // Marcador de retorno à cidade no startPos
-    const sp  = this._dungeon.startPos;
-    const spx = sp.x * TILE_SIZE + TILE_SIZE / 2;
-    const spy = sp.y * TILE_SIZE + TILE_SIZE / 2;
-    this._decorObjects.push(
-      this.add.rectangle(spx, spy, TILE_SIZE, TILE_SIZE, 0x4488ff, 0.6).setDepth(1),
-      this.add.text(spx, spy - TILE_SIZE - 2, '[ CIDADE ]', {
-        fontSize: '6px', color: '#aaddff', fontFamily: 'monospace',
-      }).setOrigin(0.5, 1).setDepth(3),
-    );
+    // Persistir cache deste andar
+    this._dungeonCache.set(floor, {
+      dungeon:    this._dungeon,
+      items:      this._items,
+      floorFrame: this._floorFrame,
+      features:   this._dungeonFeatures,
+    });
 
-    // Posicionar player no startPos da dungeon
-    this.player.gridX = sp.x;
-    this.player.gridY = sp.y;
-    this.player.setPosition(sp.x * TILE_SIZE + TILE_SIZE / 2, sp.y * TILE_SIZE + TILE_SIZE / 2);
+    // Posicionar player
+    const finalSpawn = spawnPos ?? this._dungeon.startPos;
+    this.player.gridX = finalSpawn.x;
+    this.player.gridY = finalSpawn.y;
+    this.player.setPosition(finalSpawn.x * TILE_SIZE + TILE_SIZE / 2, finalSpawn.y * TILE_SIZE + TILE_SIZE / 2);
 
     this.cameras.main.setBounds(0, 0, W * TILE_SIZE, H * TILE_SIZE);
     this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
     this.cameras.main.setZoom(2);
 
-    EventBus.emit(EVENTS.UI_LOG, saved ? 'Você retornou à dungeon.' : 'Você entrou na dungeon. Cuidado!');
+    EventBus.emit(EVENTS.AREA_CHANGED, { area: 'dungeon', floor, timestamp: Date.now() });
+    EventBus.emit(EVENTS.UI_LOG, cached ? `Você está no andar ${floor}.` : `Você desce para o andar ${floor}. Cuidado!`);
   }
 
   private _generateInitialItems(): void {
@@ -269,26 +351,71 @@ export class GameScene extends Phaser.Scene {
     this._items.push(item);
   }
 
+  private _renderDungeonFeatures(floor: number): void {
+    for (const feature of this._dungeonFeatures) {
+      const px = feature.gridX * TILE_SIZE + TILE_SIZE / 2;
+      const py = feature.gridY * TILE_SIZE + TILE_SIZE / 2;
+      if (feature.type === 'stairDown') {
+        this._decorObjects.push(
+          this.add.rectangle(px, py, TILE_SIZE, TILE_SIZE, 0xaa4400, 0.85).setDepth(2),
+          this.add.text(px, py - TILE_SIZE - 2, '▼ DESCER', {
+            fontSize: '5px', color: '#ffaa44', fontFamily: 'monospace',
+          }).setOrigin(0.5, 1).setDepth(3),
+        );
+      } else if (feature.type === 'stairUp') {
+        const label = floor === 1 ? '▲ CIDADE' : '▲ SUBIR';
+        this._decorObjects.push(
+          this.add.rectangle(px, py, TILE_SIZE, TILE_SIZE, 0x004488, 0.85).setDepth(2),
+          this.add.text(px, py - TILE_SIZE - 2, label, {
+            fontSize: '5px', color: '#44aaff', fontFamily: 'monospace',
+          }).setOrigin(0.5, 1).setDepth(3),
+        );
+      }
+    }
+  }
+
   private _checkAreaTransition(): void {
     if (this._currentArea === 'town') {
       if (this.player.gridX === TOWN.EXIT_X && this.player.gridY === TOWN.EXIT_Y) {
-        this._loadArea('dungeon');
+        const resolution = this.mapTransitionSystem.requestTransition('town-to-dungeon');
+        if (resolution) this._executeTransition(resolution);
       }
       return;
     }
 
-    // Dungeon: retornar à cidade quando chegar ao startPos após ter saído dele
-    const sp = this._dungeon!.startPos;
-    if (this.player.gridX === sp.x && this.player.gridY === sp.y) {
-      if (!this._canExitDungeon) return; // ainda no spawn, não sair
-      worldSystem.saveDungeon({
-        dungeon: this._dungeon!,
-        items:   this._items,
-        floorFrame: this._floorFrame,
-      });
-      this._loadArea('town');
-    } else {
-      this._canExitDungeon = true;
+    const px = this.player.gridX;
+    const py = this.player.gridY;
+
+    const stairDown = this._dungeonFeatures.find(f => f.type === 'stairDown' && f.gridX === px && f.gridY === py);
+    if (stairDown) {
+      this._cleanup();
+      this.floorManager.descend();
+      const nextFloor = this.floorManager.currentFloor;
+      this._loadDungeonFloor(nextFloor);
+      // Reposicionar no stairUp do novo andar (gerado por _loadDungeonFloor)
+      const conn = this.floorManager.getFloorConnections(nextFloor);
+      if (conn?.stairsUp) {
+        const s = conn.stairsUp.sourcePosition;
+        this.player.gridX = s.x;
+        this.player.gridY = s.y;
+        this.player.setPosition(s.x * TILE_SIZE + TILE_SIZE / 2, s.y * TILE_SIZE + TILE_SIZE / 2);
+      }
+      return;
+    }
+
+    const stairUp = this._dungeonFeatures.find(f => f.type === 'stairUp' && f.gridX === px && f.gridY === py);
+    if (stairUp?.connection) {
+      if (stairUp.connection.targetFloor === 'town') {
+        const resolution = this.mapTransitionSystem.requestTransition('dungeon-to-town');
+        if (resolution) this._executeTransition(resolution);
+      } else {
+        this._cleanup();
+        this.floorManager.ascend();
+        const prevFloor = this.floorManager.currentFloor;
+        const conn = this.floorManager.getFloorConnections(prevFloor);
+        const spawnPos = conn?.stairsDown?.sourcePosition;
+        this._loadDungeonFloor(prevFloor, spawnPos);
+      }
     }
   }
 
@@ -374,16 +501,24 @@ export class GameScene extends Phaser.Scene {
   }
 
   private _handleInput(_time: number): void {
-    if (!this.turnManager.isPlayerTurn()) return;
-
     const JD = Phaser.Input.Keyboard.JustDown;
 
-    // Tecla I: log do inventário (não consome turno)
+    // Tecla I: toggle inventário (não consome turno, funciona em qualquer modo)
     if (JD(this.iKey)) {
-      const lines = this.player.inventory.getInventoryLog(this.player.identifiedItems);
-      lines.forEach(l => { console.log(l); EventBus.emit(EVENTS.UI_LOG, l); });
+      if (this.inputMode.is('INVENTORY')) {
+        this.inputMode.set('GAMEPLAY');
+        EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
+      } else {
+        this.inputMode.push('INVENTORY');
+        EventBus.emit(EVENTS.INVENTORY_OPENED, { timestamp: Date.now() });
+        EventBus.emit(EVENTS.INVENTORY_STATE_REQUESTED, { timestamp: Date.now() });
+      }
       return;
     }
+
+    // Bloqueia todo o resto quando fora do modo GAMEPLAY
+    if (!this.inputMode.is('GAMEPLAY')) return;
+    if (!this.turnManager.isPlayerTurn()) return;
 
     // Teclas 1–9: usar item do slot
     for (let i = 0; i < this.numKeys.length; i++) {
@@ -543,5 +678,15 @@ export class GameScene extends Phaser.Scene {
     });
 
     EventBus.on(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
+
+    // Responde com estado do inventário quando UIScene solicitar
+    EventBus.on(EVENTS.INVENTORY_STATE_REQUESTED, () => {
+      EventBus.emit(EVENTS.INVENTORY_STATE_RESPONSE, {
+        items:           this.player.inventory.items,
+        equipped:        this.equipmentSystem.getAllEquipped(),
+        identifiedItems: this.player.identifiedItems,
+        timestamp:       Date.now(),
+      });
+    }, this);
   }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -9,12 +9,20 @@ import { TurnManager } from '../systems/TurnManager';
 import { LootSystem } from '../systems/LootSystem';
 import { EventBus } from '../utils/EventBus';
 import { TownMap } from '../systems/WorldSystem';
+import { CityDecorationSystem } from '../systems/CityDecorationSystem';
+import { NPCController } from '../systems/NPCController';
+import { InteractiveObjectSystem } from '../systems/InteractiveObjectSystem';
+import { CityLayoutProcessor } from '../generators/CityLayoutProcessor';
+import { TileVariantResolver } from '../generators/TileVariantResolver';
+import { TOWN_CONFIG } from '../config/town.config';
 import { InputModeManager } from '../systems/InputModeManager';
 import { MapTransitionSystem } from '../systems/MapTransitionSystem';
 import { DungeonFloorManager } from '../systems/DungeonFloorManager';
 import { DifficultyScalingSystem } from '../systems/DifficultyScalingSystem';
 import { DungeonFeatureGenerator, type DungeonFeature } from '../generators/DungeonFeatureGenerator';
 import { EquipmentSystem } from '../systems/EquipmentSystem';
+import { ShopSystem } from '../systems/ShopSystem';
+import { SHOP_CATALOG } from '../config/shop.catalog';
 import type { TransitionResolution } from '../types/transitions';
 import type { GridPos } from '../generators/DungeonGenerator';
 import {
@@ -28,7 +36,10 @@ import {
   GAME_STATE,
   INVENTORY,
   TOWN,
+  TAVERN,
 } from '../utils/constants';
+import type { DialogMenuOption } from '../types/town';
+import type { EquipmentSlotId } from '../types/equipment';
 
 export class GameScene extends Phaser.Scene {
   // ─── Sistemas persistentes (vivem durante toda a sessão) ─────────────────
@@ -44,6 +55,7 @@ export class GameScene extends Phaser.Scene {
   private featureGenerator!: DungeonFeatureGenerator;
   private _dungeonFeatures: DungeonFeature[] = [];
   private equipmentSystem!: EquipmentSystem;
+  private _shopSystem!: ShopSystem;
   private gameState!: string;
 
   // Cache de andares visitados (runtime — não serializado ainda)
@@ -66,12 +78,36 @@ export class GameScene extends Phaser.Scene {
   private _tileObjects: Phaser.GameObjects.Image[] = [];
   private _decorObjects: Phaser.GameObjects.GameObject[] = [];
 
+  // ─── Sistemas de cidade (recriados em cada _loadTown) ────────────────────
+  private _npcController: NPCController | null = null;
+  private _interactiveSystem: InteractiveObjectSystem | null = null;
+
   // ─── Input ────────────────────────────────────────────────────────────────
   private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
   private wasd!: Record<string, Phaser.Input.Keyboard.Key>;
   private spaceKey!: Phaser.Input.Keyboard.Key;
   private iKey!: Phaser.Input.Keyboard.Key;
+  private escKey!: Phaser.Input.Keyboard.Key;
+  private eKey!: Phaser.Input.Keyboard.Key;
+  private uKey!: Phaser.Input.Keyboard.Key;
+  private dKey!: Phaser.Input.Keyboard.Key;
+  private vKey!: Phaser.Input.Keyboard.Key;
+  private enterKey!: Phaser.Input.Keyboard.Key;
   private numKeys!: Phaser.Input.Keyboard.Key[];
+
+  // ─── Keyboard focus reset handler ────────────────────────────────────────
+  private _onWindowFocusReset!: () => void;
+
+  // ─── Estado de seleção de inventário / loja ───────────────────────────────
+  private _inventorySelectedIndex = 0;
+  private _shopSelectedIndex = 0;
+  private _shopTab: 'buy' | 'sell' = 'buy';
+
+  // ─── Estado de diálogo ────────────────────────────────────────────────────
+  private _dialogOptions: DialogMenuOption[] = [];
+  private _dialogSelectedIndex = 0;
+  private _dialogNpcId = '';
+  private _dialogTitle = '';
 
   // Handler estável para off() no shutdown
   private readonly _handleItemDropped = (data: { item: Item }) => {
@@ -100,6 +136,7 @@ export class GameScene extends Phaser.Scene {
     this.featureGenerator   = new DungeonFeatureGenerator();
     this.floorManager.reset();
     this.equipmentSystem = new EquipmentSystem();
+    this._shopSystem     = new ShopSystem(SHOP_CATALOG);
     this._registerTransitions();
 
     // Player criado uma vez — moves between areas
@@ -116,11 +153,25 @@ export class GameScene extends Phaser.Scene {
   shutdown(): void {
     EventBus.off(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
     EventBus.off(EVENTS.INVENTORY_STATE_REQUESTED, undefined, this);
+    EventBus.off(EVENTS.SHOP_OPENED, undefined, this);
+    EventBus.off(EVENTS.DIALOG_OPENED, undefined, this);
+    this.game.events.off(Phaser.Core.Events.BLUR,  this._onWindowFocusReset, this);
+    this.game.events.off(Phaser.Core.Events.FOCUS, this._onWindowFocusReset, this);
   }
 
-  update(_time: number, _delta: number): void {
+  update(_time: number, delta: number): void {
     if (this.gameState !== GAME_STATE.PLAYING) return;
     this._handleInput(_time);
+
+    // Atualizar NPCs com wandering (apenas na cidade)
+    if (this._currentArea === 'town' && this._npcController) {
+      this._npcController.update(delta, this._currentMap.grid);
+    }
+
+    // Atualizar prompt de interação baseado na posição do player
+    if (this._currentArea === 'town' && this._interactiveSystem) {
+      this._interactiveSystem.update(this.player.gridX, this.player.gridY);
+    }
   }
 
   // ─── Transições ──────────────────────────────────────────────────────────
@@ -181,6 +232,12 @@ export class GameScene extends Phaser.Scene {
     this._decorObjects.forEach(o => o.destroy());
     this._decorObjects = [];
 
+    this._npcController?.destroy();
+    this._npcController = null;
+
+    this._interactiveSystem?.destroy();
+    this._interactiveSystem = null;
+
     this._items.forEach(i => { i.sprite?.destroy(); i.sprite = null; });
     this._items = [];
 
@@ -188,45 +245,66 @@ export class GameScene extends Phaser.Scene {
     this._enemies = [];
   }
 
-  private _loadTown(spawnX = TOWN.START_X, spawnY = TOWN.START_Y): void {
+  private _loadTown(spawnX = TOWN_CONFIG.startX, spawnY = TOWN_CONFIG.startY): void {
+    // 1. Processar layout com biomas e variantes de tile
+    const resolver  = new TileVariantResolver();
+    const processor = new CityLayoutProcessor(resolver);
+    const layout    = processor.process(TOWN_CONFIG);
+
     const townMap = new TownMap();
     this._currentMap = townMap;
 
-    for (let y = 0; y < TOWN.HEIGHT; y++) {
-      for (let x = 0; x < TOWN.WIDTH; x++) {
-        const isFloor = townMap.grid[y][x] === TILE.FLOOR;
+    const W = layout.width;
+    const H = layout.height;
+
+    // 2. Tiles de chão usando groundTiles resolvidos por bioma
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
         const px = x * TILE_SIZE + TILE_SIZE / 2;
         const py = y * TILE_SIZE + TILE_SIZE / 2;
-        this._tileObjects.push(
-          this.add.image(px, py, isFloor ? SPRITES.FLOOR : SPRITES.WALL,
-            isFloor ? TOWN.FLOOR_FRAME : DAWNLIKE_FRAMES.WALL).setDepth(0),
-        );
+        const resolved = layout.groundTiles[y][x];
+        // Tiles WALL que não têm override visual são renderizados com sprite de parede
+        if (townMap.grid[y][x] === TILE.WALL && !TOWN_CONFIG.tileVisuals[`${x},${y}`]) {
+          this._tileObjects.push(
+            this.add.image(px, py, SPRITES.WALL, DAWNLIKE_FRAMES.WALL).setDepth(0),
+          );
+        } else {
+          this._tileObjects.push(
+            this.add.image(px, py, resolved.sprite, resolved.frame).setDepth(0),
+          );
+        }
       }
     }
 
-    // Marcador de saída para dungeon
-    const ex = TOWN.EXIT_X * TILE_SIZE + TILE_SIZE / 2;
-    const ey = TOWN.EXIT_Y * TILE_SIZE + TILE_SIZE / 2;
-    this._decorObjects.push(
-      this.add.rectangle(ex, ey, TILE_SIZE, TILE_SIZE, 0xff8800, 0.85).setDepth(2),
-      this.add.text(ex, ey - TILE_SIZE - 2, '[ DUNGEON ]', {
-        fontSize: '6px', color: '#ffdd00', fontFamily: 'monospace',
-      }).setOrigin(0.5, 1).setDepth(3),
-    );
+    // 3. Decorações (árvores, barris, labels de edifícios, marcador dungeon)
+    const deco = new CityDecorationSystem();
+    this._decorObjects.push(...deco.render(this, layout.worldObjects, TOWN_CONFIG.labels));
 
-    // Reposicionar player na posição de spawn
+    // 4. NPCs com wandering via NPCController
+    this._npcController = new NPCController();
+    const npcSprites = this._npcController.spawn(this, layout.npcs);
+    // Registrar sprites no _decorObjects apenas para limpeza de emergência (NPCController.destroy já lida)
+    // não adicionamos aqui para evitar double-destroy — cleanup chama _npcController.destroy()
+
+    // 5. Objetos interativos (detecção de portas)
+    this._interactiveSystem = new InteractiveObjectSystem();
+    this._interactiveSystem.load(this, layout.interactive, this._npcController!);
+
+    void npcSprites; // used by NPCController internally
+
+    // 6. Reposicionar player
     this.player.gridX = spawnX;
     this.player.gridY = spawnY;
     this.player.setPosition(spawnX * TILE_SIZE + TILE_SIZE / 2, spawnY * TILE_SIZE + TILE_SIZE / 2);
 
-    this.cameras.main.setBounds(0, 0, TOWN.WIDTH * TILE_SIZE, TOWN.HEIGHT * TILE_SIZE);
+    this.cameras.main.setBounds(0, 0, W * TILE_SIZE, H * TILE_SIZE);
     this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
     this.cameras.main.setZoom(2);
 
-    const isReturn = spawnX === TOWN.EXIT_X && spawnY === TOWN.EXIT_Y - 1;
+    const isReturn = spawnX === TOWN_CONFIG.exitX && spawnY === TOWN_CONFIG.exitY - 1;
     EventBus.emit(EVENTS.UI_LOG, isReturn
       ? 'Você retornou à cidade.'
-      : 'Bem-vindo à cidade. Vá para o sul para entrar na dungeon.',
+      : 'Bem-vindo à cidade. Siga o caminho ao sul para entrar na dungeon.',
     );
   }
 
@@ -485,8 +563,18 @@ export class GameScene extends Phaser.Scene {
       left:  Phaser.Input.Keyboard.KeyCodes.A,
       right: Phaser.Input.Keyboard.KeyCodes.D,
     }) as Record<string, Phaser.Input.Keyboard.Key>;
-    this.spaceKey = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
-    this.iKey     = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.I);
+    this.spaceKey  = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+    this.iKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.I);
+    this.escKey    = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+    this.eKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.E);
+    this.uKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.U);
+    this.dKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.D);
+    this.vKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.V);
+    this.enterKey  = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+
+    this._onWindowFocusReset = () => { this.input.keyboard?.resetKeys(); };
+    this.game.events.on(Phaser.Core.Events.BLUR,  this._onWindowFocusReset, this);
+    this.game.events.on(Phaser.Core.Events.FOCUS, this._onWindowFocusReset, this);
     this.numKeys  = [
       Phaser.Input.Keyboard.KeyCodes.ONE,
       Phaser.Input.Keyboard.KeyCodes.TWO,
@@ -503,20 +591,54 @@ export class GameScene extends Phaser.Scene {
   private _handleInput(_time: number): void {
     const JD = Phaser.Input.Keyboard.JustDown;
 
-    // Tecla I: toggle inventário (não consome turno, funciona em qualquer modo)
-    if (JD(this.iKey)) {
-      if (this.inputMode.is('INVENTORY')) {
-        this.inputMode.set('GAMEPLAY');
+    // 1. ESC — maior prioridade: fecha qualquer overlay
+    if (JD(this.escKey)) {
+      if (this.inputMode.is('DIALOG')) {
+        this.inputMode.pop();
+        EventBus.emit(EVENTS.DIALOG_CLOSED, {});
+      } else if (this.inputMode.is('INVENTORY')) {
+        this.inputMode.pop();
         EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
-      } else {
-        this.inputMode.push('INVENTORY');
-        EventBus.emit(EVENTS.INVENTORY_OPENED, { timestamp: Date.now() });
-        EventBus.emit(EVENTS.INVENTORY_STATE_REQUESTED, { timestamp: Date.now() });
+      } else if (this.inputMode.is('SHOP')) {
+        this.inputMode.pop();
+        EventBus.emit(EVENTS.SHOP_CLOSED, { timestamp: Date.now() });
       }
       return;
     }
 
-    // Bloqueia todo o resto quando fora do modo GAMEPLAY
+    // 1b. Modo DIALOG
+    if (this.inputMode.is('DIALOG')) {
+      this._handleDialogInput();
+      return;
+    }
+
+    // 2. I — toggle inventário (não consome turno)
+    if (JD(this.iKey)) {
+      if (this.inputMode.is('INVENTORY')) {
+        this.inputMode.pop();
+        EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
+      } else if (this.inputMode.is('GAMEPLAY')) {
+        this.inputMode.push('INVENTORY');
+        this._inventorySelectedIndex = 0;
+        EventBus.emit(EVENTS.INVENTORY_OPENED, { timestamp: Date.now() });
+        this._emitInventoryState();
+      }
+      return;
+    }
+
+    // 3. Modo SHOP
+    if (this.inputMode.is('SHOP')) {
+      this._handleShopInput();
+      return;
+    }
+
+    // 4. Modo INVENTORY
+    if (this.inputMode.is('INVENTORY')) {
+      this._handleInventoryInput();
+      return;
+    }
+
+    // 5. GAMEPLAY
     if (!this.inputMode.is('GAMEPLAY')) return;
     if (!this.turnManager.isPlayerTurn()) return;
 
@@ -550,6 +672,9 @@ export class GameScene extends Phaser.Scene {
     const ty = this.player.gridY + dy;
     const targetEnemy = !isWait && this._enemies.find(e => e.alive && e.gridX === tx && e.gridY === ty);
 
+    // Bloqueia movimento quando o tile de destino está ocupado por um NPC
+    if (!isWait && !targetEnemy && this._npcController?.isTileOccupied(tx, ty)) return;
+
     const action = isWait
       ? { type: 'WAIT' as const }
       : targetEnemy
@@ -582,6 +707,245 @@ export class GameScene extends Phaser.Scene {
     if (result.playerDied) {
       this.events.emit(EVENTS.PLAYER_DIED);
     }
+  }
+
+  private _handleInventoryInput(): void {
+    const JD = Phaser.Input.Keyboard.JustDown;
+    const inv = this.player.inventory;
+    const total = inv.items.filter(i => i !== null).length;
+
+    if (JD(this.cursors.up) || JD(this.wasd.up)) {
+      this._inventorySelectedIndex = Math.max(0, this._inventorySelectedIndex - 1);
+      this._emitInventorySelectionChanged();
+      return;
+    }
+    if (JD(this.cursors.down) || JD(this.wasd.down)) {
+      this._inventorySelectedIndex = Math.min(total - 1, this._inventorySelectedIndex + 1);
+      this._emitInventorySelectionChanged();
+      return;
+    }
+
+    const item = inv.getItem(this._inventorySelectedIndex);
+
+    if (JD(this.eKey)) {
+      if (!item) { EventBus.emit(EVENTS.UI_LOG, 'Nenhum item selecionado.'); return; }
+      if (!item.slotId) { EventBus.emit(EVENTS.UI_LOG, 'Este item não pode ser equipado.'); return; }
+      if (this.equipmentSystem.getEquippedId(item.slotId as EquipmentSlotId) === item.id) {
+        this._unequipSelectedItem();
+      } else {
+        this._equipSelectedItem();
+      }
+      return;
+    }
+
+    if (JD(this.uKey)) {
+      if (!item) { EventBus.emit(EVENTS.UI_LOG, 'Nenhum item selecionado.'); return; }
+      this._useSelectedItem();
+      return;
+    }
+
+    if (JD(this.dKey)) {
+      if (!item) { EventBus.emit(EVENTS.UI_LOG, 'Nenhum item selecionado.'); return; }
+      this._dropSelectedItem();
+      return;
+    }
+  }
+
+  private _handleShopInput(): void {
+    const JD = Phaser.Input.Keyboard.JustDown;
+
+    // Tab switch: left/right arrows
+    if (JD(this.cursors.left) || JD(this.wasd.left)) {
+      this._shopTab = 'buy';
+      this._shopSelectedIndex = 0;
+      this._clampShopSelection();
+      this._emitShopState();
+      return;
+    }
+    if (JD(this.cursors.right) || JD(this.wasd.right)) {
+      this._shopTab = 'sell';
+      this._shopSelectedIndex = 0;
+      this._emitShopState();
+      return;
+    }
+
+    if (this._shopTab === 'buy') {
+      const total = this._shopSystem.catalog.length;
+
+      if (JD(this.cursors.up) || JD(this.wasd.up)) {
+        this._shopSelectedIndex = Math.max(0, this._shopSelectedIndex - 1);
+        this._emitShopState();
+        return;
+      }
+      if (JD(this.cursors.down) || JD(this.wasd.down)) {
+        this._shopSelectedIndex = Math.min(total - 1, this._shopSelectedIndex + 1);
+        this._emitShopState();
+        return;
+      }
+
+      if (JD(this.eKey) || JD(this.enterKey)) {
+        const result = this._shopSystem.buyItem(this.player, this._shopSelectedIndex, this.player.inventory);
+        EventBus.emit(EVENTS.UI_LOG, result.message);
+        if (result.success) {
+          this._emitShopState();
+        }
+        return;
+      }
+    } else {
+      // sell tab
+      const equippedIds = new Set(Object.values(this.equipmentSystem.getAllEquipped()).filter(Boolean) as string[]);
+      const sellItems = this._shopSystem.buildSellItems({ inventory: this.player.inventory }, equippedIds, this._shopSelectedIndex);
+      const total = sellItems.length;
+
+      if (JD(this.cursors.up) || JD(this.wasd.up)) {
+        this._shopSelectedIndex = Math.max(0, this._shopSelectedIndex - 1);
+        this._emitShopState();
+        return;
+      }
+      if (JD(this.cursors.down) || JD(this.wasd.down)) {
+        this._shopSelectedIndex = Math.min(Math.max(0, total - 1), this._shopSelectedIndex + 1);
+        this._emitShopState();
+        return;
+      }
+
+      if (JD(this.vKey)) {
+        const entry = sellItems[this._shopSelectedIndex];
+        if (entry && entry.canSell) {
+          const result = this._shopSystem.sellItem(this.player, entry.inventoryIndex, this.player.inventory);
+          EventBus.emit(EVENTS.UI_LOG, result.message);
+          if (result.success) {
+            this._shopSelectedIndex = Math.max(0, this._shopSelectedIndex - 1);
+            this._emitShopState();
+          }
+        }
+        return;
+      }
+    }
+  }
+
+  private _equipSelectedItem(): void {
+    const item = this.player.inventory.getItem(this._inventorySelectedIndex);
+    if (!item?.slotId) return;
+
+    // Remover bônus do item anterior no mesmo slot
+    const prevId = this.equipmentSystem.getEquippedId(item.slotId);
+    if (prevId) {
+      const prevItem = this.player.inventory.items.find(i => i?.id === prevId);
+      if (prevItem?.bonuses) this.player.removeEquipmentBonuses(prevItem.bonuses);
+    }
+
+    this.equipmentSystem.equip(item.id, item.slotId);
+    if (item.bonuses) this.player.applyEquipmentBonuses(item.bonuses);
+
+    EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
+    EventBus.emit(EVENTS.UI_LOG, `Equipou ${item.name ?? item.type}.`);
+    this._emitInventoryState();
+  }
+
+  private _unequipSelectedItem(): void {
+    const item = this.player.inventory.getItem(this._inventorySelectedIndex);
+    if (!item?.slotId) return;
+    this.equipmentSystem.unequip(item.slotId as EquipmentSlotId);
+    if (item.bonuses) this.player.removeEquipmentBonuses(item.bonuses);
+    EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
+    EventBus.emit(EVENTS.UI_LOG, `Desequipou ${item.name ?? item.type}.`);
+    this._emitInventoryState();
+  }
+
+  private _useSelectedItem(): void {
+    const result = this.player.inventory.useItem(
+      this._inventorySelectedIndex,
+      this.player.identifiedItems,
+      this.player.hp,
+      this.player.maxHp,
+    );
+    result.messages.forEach(msg => EventBus.emit(EVENTS.UI_LOG, msg));
+
+    if (result.success && result.hpDelta !== 0) {
+      this.player.hp = Math.min(this.player.maxHp, this.player.hp + result.hpDelta);
+      EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
+    }
+
+    EventBus.emit(EVENTS.ITEM_USED, { itemIndex: this._inventorySelectedIndex });
+    this._clampInventorySelection();
+    this._emitInventoryState();
+  }
+
+  private _dropSelectedItem(): void {
+    if (this._currentArea !== 'dungeon') {
+      EventBus.emit(EVENTS.UI_LOG, 'Não é possível dropar itens na cidade.');
+      return;
+    }
+    const item = this.player.inventory.removeItem(this._inventorySelectedIndex);
+    if (!item) return;
+
+    const pos = this._findNearestFreeTile(this.player.gridX, this.player.gridY);
+    item.gridX = pos.x;
+    item.gridY = pos.y;
+
+    EventBus.emit(EVENTS.ITEM_DROPPED, { item });
+    EventBus.emit(EVENTS.UI_LOG, `Dropou ${item.name ?? item.getDisplayName(this.player.identifiedItems)}.`);
+    this._clampInventorySelection();
+    this._emitInventoryState();
+  }
+
+  private _findNearestFreeTile(fromX: number, fromY: number): { x: number; y: number } {
+    const dirs = [
+      { dx: 0, dy: 0 }, { dx: 1, dy: 0 }, { dx: -1, dy: 0 },
+      { dx: 0, dy: 1 }, { dx: 0, dy: -1 },
+      { dx: 1, dy: 1 }, { dx: -1, dy: 1 }, { dx: 1, dy: -1 }, { dx: -1, dy: -1 },
+    ];
+    for (const d of dirs) {
+      const tx = fromX + d.dx;
+      const ty = fromY + d.dy;
+      if (!this._currentMap.isWalkable(tx, ty)) continue;
+      if (this._enemies.some(e => e.alive && e.gridX === tx && e.gridY === ty)) continue;
+      if (this._items.some(i => i.gridX === tx && i.gridY === ty)) continue;
+      return { x: tx, y: ty };
+    }
+    return { x: fromX, y: fromY };
+  }
+
+  private _clampInventorySelection(): void {
+    const total = this.player.inventory.items.filter(i => i !== null).length;
+    this._inventorySelectedIndex = total > 0
+      ? Math.min(this._inventorySelectedIndex, total - 1)
+      : 0;
+  }
+
+  private _clampShopSelection(): void {
+    const total = this._shopSystem.catalog.length;
+    this._shopSelectedIndex = Math.min(this._shopSelectedIndex, Math.max(0, total - 1));
+  }
+
+  private _emitInventoryState(): void {
+    EventBus.emit(EVENTS.INVENTORY_STATE_RESPONSE, {
+      items:           this.player.inventory.items,
+      equipped:        this.equipmentSystem.getAllEquipped(),
+      identifiedItems: this.player.identifiedItems,
+      selectedIndex:   this._inventorySelectedIndex,
+      timestamp:       Date.now(),
+    });
+  }
+
+  private _emitInventorySelectionChanged(): void {
+    const item = this.player.inventory.getItem(this._inventorySelectedIndex);
+    EventBus.emit(EVENTS.INVENTORY_SELECTION_CHANGED, {
+      selectedIndex: this._inventorySelectedIndex,
+      item,
+    });
+  }
+
+  private _emitShopState(): void {
+    const equippedIds = new Set(Object.values(this.equipmentSystem.getAllEquipped()).filter(Boolean) as string[]);
+    const vm = this._shopSystem.buildViewModel(
+      this.player,
+      this._shopSelectedIndex,
+      this._shopTab,
+      this.player.inventory,
+      equippedIds,
+    );
+    EventBus.emit(EVENTS.SHOP_UPDATED, vm);
   }
 
   private _removeEnemySprite(enemy: EnemySystem): void {
@@ -642,6 +1006,7 @@ export class GameScene extends Phaser.Scene {
     EventBus.emit(EVENTS.PLAYER_MANA_CHANGED, { mana: p.mana, maxMana: p.maxMana });
     EventBus.emit(EVENTS.PLAYER_XP_CHANGED,   { xp: p.xp, xpNext: this.xpSystem.getXPToNextLevel(p.level) });
     EventBus.emit(EVENTS.PLAYER_LEVELED_UP,   { level: p.level, maxHp: p.maxHp, attack: p.attack });
+    EventBus.emit(EVENTS.PLAYER_GOLD_CHANGED, { gold: p.gold });
   }
 
   private _registerEvents(): void {
@@ -681,12 +1046,85 @@ export class GameScene extends Phaser.Scene {
 
     // Responde com estado do inventário quando UIScene solicitar
     EventBus.on(EVENTS.INVENTORY_STATE_REQUESTED, () => {
-      EventBus.emit(EVENTS.INVENTORY_STATE_RESPONSE, {
-        items:           this.player.inventory.items,
-        equipped:        this.equipmentSystem.getAllEquipped(),
-        identifiedItems: this.player.identifiedItems,
-        timestamp:       Date.now(),
-      });
+      this._emitInventoryState();
     }, this);
+
+    // Abre a loja quando o mercador é interagido
+    EventBus.on(EVENTS.SHOP_OPENED, () => {
+      if (!this.inputMode.is('GAMEPLAY')) return;
+      this.inputMode.push('SHOP');
+      this._shopTab = 'buy';
+      this._shopSelectedIndex = 0;
+      this._emitShopState();
+    }, this);
+
+    // Abre diálogo com NPC de menu
+    EventBus.on(EVENTS.DIALOG_OPENED, (data: { npcId: string; title: string; options: DialogMenuOption[] }) => {
+      if (!this.inputMode.is('GAMEPLAY')) return;
+      this._dialogNpcId = data.npcId;
+      this._dialogTitle = data.title;
+      this._dialogOptions = data.options;
+      this._dialogSelectedIndex = 0;
+      this.inputMode.push('DIALOG');
+      if (data.options.length > 0) {
+        EventBus.emit(EVENTS.DIALOG_OPTION_SELECTED, { index: 0, option: data.options[0] });
+      }
+    }, this);
+
+    // Mouse: selecionar item na loja
+    EventBus.on(EVENTS.SHOP_ITEM_SELECTED, (data: { index: number }) => {
+      if (!this.inputMode.is('SHOP')) return;
+      this._shopSelectedIndex = data.index;
+      this._emitShopState();
+    }, this);
+  }
+
+  private _handleDialogInput(): void {
+    const JD = Phaser.Input.Keyboard.JustDown;
+    const total = this._dialogOptions.length;
+
+    if (JD(this.cursors.up) || JD(this.wasd.up)) {
+      this._dialogSelectedIndex = Math.max(0, this._dialogSelectedIndex - 1);
+      EventBus.emit(EVENTS.DIALOG_OPTION_SELECTED, {
+        index: this._dialogSelectedIndex,
+        option: this._dialogOptions[this._dialogSelectedIndex],
+      });
+      return;
+    }
+    if (JD(this.cursors.down) || JD(this.wasd.down)) {
+      this._dialogSelectedIndex = Math.min(total - 1, this._dialogSelectedIndex + 1);
+      EventBus.emit(EVENTS.DIALOG_OPTION_SELECTED, {
+        index: this._dialogSelectedIndex,
+        option: this._dialogOptions[this._dialogSelectedIndex],
+      });
+      return;
+    }
+
+    if (JD(this.enterKey) || JD(this.eKey)) {
+      const option = this._dialogOptions[this._dialogSelectedIndex];
+      if (!option) return;
+
+      if (option.action === 'rest') {
+        const cost = option.goldCost ?? TAVERN.REST_COST;
+        if (this.player.gold < cost) {
+          EventBus.emit(EVENTS.UI_LOG, `Ouro insuficiente. Precisa de ${cost} moedas para descansar.`);
+        } else {
+          this.player.gold -= cost;
+          this.player.hp   = this.player.maxHp;
+          this.player.mana = this.player.maxMana;
+          EventBus.emit(EVENTS.PLAYER_GOLD_CHANGED, { gold: this.player.gold });
+          EventBus.emit(EVENTS.PLAYER_HP_CHANGED,   { hp: this.player.hp, maxHp: this.player.maxHp });
+          EventBus.emit(EVENTS.PLAYER_MANA_CHANGED, { mana: this.player.mana, maxMana: this.player.maxMana });
+          EventBus.emit(EVENTS.UI_LOG, `Descansou e recuperou toda a vida e mana por ${cost} ouros.`);
+          this.inputMode.pop();
+          EventBus.emit(EVENTS.DIALOG_CLOSED, {});
+        }
+      } else {
+        // No special action — just close
+        this.inputMode.pop();
+        EventBus.emit(EVENTS.DIALOG_CLOSED, {});
+      }
+      return;
+    }
   }
 }

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -1,30 +1,26 @@
 import * as Phaser from 'phaser';
-import { EVENTS, SPRITES, DAWNLIKE_FRAMES } from '../utils/constants';
+import { EVENTS, UI } from '../utils/constants';
 import { EventBus } from '../utils/EventBus';
-import { Item, ItemType } from '../entities/Item';
+import { Item } from '../entities/Item';
+import { LogSystem } from '../systems/LogSystem';
+import { LogPanel } from '../ui/LogPanel';
+import { InventoryPanel } from '../ui/InventoryPanel';
+import { ActionBarPanel } from '../ui/ActionBarPanel';
+import { EQUIPMENT_SLOT_ORDER, EQUIPMENT_SLOT_LABELS, type EquipmentSlotId } from '../types/equipment';
+import type { InventoryViewModel, InventoryItemViewModel, EquipmentSlotViewModel } from '../types/viewmodels';
 
-const BAR_W     = 120;
-const BAR_H     = 8;
-const PANEL_X   = 8;
-const PANEL_Y   = 8;
-const LOG_LINES = 5;
+const BAR_W    = 100;
+const BAR_H    = 8;
+const PANEL_X  = 8;
+const PANEL_Y  = 8;
+const DEPTH    = 200;
+
 const TEXT_STYLE: Phaser.Types.GameObjects.Text.TextStyle = {
   fontSize: '9px',
   color: '#e2e8f0',
   fontFamily: 'monospace',
 };
 
-// Action bar
-const SLOT_COUNT = 9;
-const SLOT_SIZE  = 24;
-const SLOT_GAP   = 4;
-const SLOT_DEPTH = 200;
-
-type SlotGraphics = {
-  bg:   Phaser.GameObjects.Rectangle;
-  icon: Phaser.GameObjects.Sprite;
-  key:  Phaser.GameObjects.Text;
-};
 
 export class UIScene extends Phaser.Scene {
   // HP bar
@@ -41,41 +37,118 @@ export class UIScene extends Phaser.Scene {
   private _levelLabel!: Phaser.GameObjects.Text;
   private _xpLabel!: Phaser.GameObjects.Text;
 
-  // Message log
-  private _logLines: Phaser.GameObjects.Text[] = [];
-  private _logBuffer: string[] = [];
+  // Log
+  private _logSystem!: LogSystem;
+  private _logPanel!: LogPanel;
 
-  // Inventory action bar
-  private _slots: SlotGraphics[] = [];
+  // Inventory overlay
+  private _inventoryPanel!: InventoryPanel;
+  private _actionBar!: ActionBarPanel;
+  private _inventoryData: { items: unknown[]; equipped: Record<string, string | null>; identifiedItems: Record<string, boolean> } | null = null;
+  private _selectedInventoryIndex = 0;
+
+  // _slots removido — gerenciado por ActionBarPanel
 
   constructor() {
     super({ key: 'UIScene' });
   }
 
   create(): void {
-    this._createTopPanel();
-    this._createActionBar();
-    this._createMessageLog();
+    this._logSystem = new LogSystem();
+    this._logSystem.bindEventBus();
+
+    this._actionBar      = new ActionBarPanel(this);
+    this._logPanel       = new LogPanel(this);
+    this._inventoryPanel = new InventoryPanel(this);
+
+    // LogPanel deve parar antes da action bar
+    this._logPanel.layout(this.scale.width, this.scale.height, this._actionBar.getHeight());
+
+    this._createStatsPanel();
     this._registerEvents();
   }
 
-  shutdown(): void {
-    EventBus.off(EVENTS.PLAYER_HP_CHANGED,   this._onHPChanged,   this);
-    EventBus.off(EVENTS.PLAYER_MANA_CHANGED, this._onManaChanged, this);
-    EventBus.off(EVENTS.PLAYER_XP_CHANGED,   this._onXPChanged,   this);
-    EventBus.off(EVENTS.PLAYER_LEVELED_UP,   this._onLevelUp,     this);
-    EventBus.off(EVENTS.UI_LOG,              this._onLog,         this);
-    EventBus.off(EVENTS.ITEM_PICKED_UP,      this._onItemPickedUp, this);
-    EventBus.off(EVENTS.ITEM_USED,           this._onItemUsed,    this);
+  update(): void {
+    if (this._logPanel.isDirty()) {
+      const vm = this._logSystem.buildViewModel(UI.LOG_VISIBLE_LINES);
+      this._logPanel.render(vm);
+    }
+    if (this._inventoryPanel.isDirty() && this._inventoryData) {
+      const vm = this._buildInventoryViewModel();
+      this._inventoryPanel.render(vm);
+    }
   }
 
-  // ─── Criação ─────────────────────────────────────────────────────────────
+  shutdown(): void {
+    EventBus.off(EVENTS.PLAYER_HP_CHANGED,        this._onHPChanged,    this);
+    EventBus.off(EVENTS.PLAYER_MANA_CHANGED,      this._onManaChanged,  this);
+    EventBus.off(EVENTS.PLAYER_XP_CHANGED,        this._onXPChanged,    this);
+    EventBus.off(EVENTS.PLAYER_LEVELED_UP,        this._onLevelUp,      this);
+    EventBus.off(EVENTS.ITEM_PICKED_UP,           this._onItemPickedUp, this);
+    EventBus.off(EVENTS.ITEM_USED,                this._onItemUsed,     this);
+    EventBus.off(EVENTS.INVENTORY_OPENED,         undefined,            this);
+    EventBus.off(EVENTS.INVENTORY_STATE_RESPONSE, undefined,            this);
+    EventBus.off(EVENTS.INVENTORY_CLOSED,         undefined,            this);
+    EventBus.off(EVENTS.ITEM_EQUIPPED,            undefined,            this);
+    EventBus.off(EVENTS.ITEM_UNEQUIPPED,          undefined,            this);
+  }
 
-  private _createTopPanel(): void {
-    const d = SLOT_DEPTH;
+  // ─── InventoryViewModel builder ──────────────────────────────────────────
 
+  private _buildInventoryViewModel(): InventoryViewModel {
+    const data     = this._inventoryData!;
+    const selIdx   = this._selectedInventoryIndex;
+    const equipped = data.equipped;
+    const equippedIds = new Set(Object.values(equipped).filter(Boolean));
+
+    const items: InventoryItemViewModel[] = (data.items as Array<{ id: string; type: string; getDisplayName: (m: Record<string, boolean>) => string } | null>).map((item, index) => {
+      if (!item) return { index, id: null, displayName: '—', type: '', isEquipped: false, isSelected: false };
+      const isEquipped = equippedIds.has(item.id);
+      return {
+        index,
+        id:          item.id,
+        displayName: item.getDisplayName(data.identifiedItems),
+        type:        item.type,
+        isEquipped,
+        isSelected:  index === selIdx,
+      };
+    });
+
+    const slots: EquipmentSlotViewModel[] = EQUIPMENT_SLOT_ORDER.map(slotId => {
+      const equippedId = equipped[slotId] ?? null;
+      const equippedItem = equippedId
+        ? (data.items as Array<{ id: string; getDisplayName: (m: Record<string, boolean>) => string } | null>).find(i => i?.id === equippedId)
+        : null;
+      return {
+        id:              slotId as EquipmentSlotId,
+        label:           EQUIPMENT_SLOT_LABELS[slotId as EquipmentSlotId],
+        equippedItemId:  equippedId,
+        equippedItemName: equippedItem ? equippedItem.getDisplayName(data.identifiedItems) : '',
+        isSelected:      false,
+      };
+    });
+
+    const selectedItem = items[selIdx];
+    const selectedItemDetail = selectedItem?.id
+      ? {
+          name:        selectedItem.displayName,
+          description: `Tipo: ${selectedItem.type}`,
+          actions:     (['use', 'drop'] as Array<'equip' | 'use' | 'drop'>),
+        }
+      : null;
+
+    return { items, slots, selectedItemDetail };
+  }
+
+  // ─── Stats Panel (dentro do painel esquerdo 33%) ─────────────────────────
+
+  private _createStatsPanel(): void {
+    const panelW = Math.floor(this.scale.width * UI.LOG_PANEL_WIDTH_FRACTION);
+    const d = DEPTH;
+
+    // Fundo do painel de stats (topo do painel esquerdo)
     this.add
-      .rectangle(PANEL_X - 4, PANEL_Y - 4, BAR_W + 70, 56, 0x000000, 0.65)
+      .rectangle(0, 0, panelW, 56, 0x000000, 0.55)
       .setOrigin(0, 0).setScrollFactor(0).setDepth(d);
 
     const hpY = PANEL_Y + 4;
@@ -113,59 +186,6 @@ export class UIScene extends Phaser.Scene {
       .setScrollFactor(0).setDepth(d + 1);
   }
 
-  private _createActionBar(): void {
-    const { width, height } = this.scale;
-    const totalW = SLOT_COUNT * (SLOT_SIZE + SLOT_GAP) - SLOT_GAP;
-    const startX = Math.floor((width - totalW) / 2);
-    const barY   = height - SLOT_SIZE - 10;
-
-    // Fundo da barra
-    this.add
-      .rectangle(startX - 6, barY - 4, totalW + 12, SLOT_SIZE + 8, 0x000000, 0.7)
-      .setOrigin(0, 0).setScrollFactor(0).setDepth(SLOT_DEPTH);
-
-    for (let i = 0; i < SLOT_COUNT; i++) {
-      const x = startX + i * (SLOT_SIZE + SLOT_GAP);
-
-      const bg = this.add
-        .rectangle(x, barY, SLOT_SIZE, SLOT_SIZE, 0x222244)
-        .setOrigin(0, 0).setScrollFactor(0).setDepth(SLOT_DEPTH + 1)
-        .setStrokeStyle(1, 0x4455aa);
-
-      // Ícone: sprite real do item (invisível até ter item no slot)
-      const icon = this.add
-        .sprite(x + SLOT_SIZE / 2, barY + SLOT_SIZE / 2, SPRITES.POTION, 0)
-        .setScrollFactor(0).setDepth(SLOT_DEPTH + 2)
-        .setVisible(false);
-
-      // Tecla de atalho (1–9)
-      const key = this.add
-        .text(x + 2, barY + 2, String(i + 1), { fontSize: '7px', color: '#667799', fontFamily: 'monospace' })
-        .setScrollFactor(0).setDepth(SLOT_DEPTH + 3);
-
-      this._slots.push({ bg, icon, key });
-    }
-  }
-
-  private _createMessageLog(): void {
-    const { width, height } = this.scale;
-    const logH = LOG_LINES * 13 + 10;
-    // Posiciona acima da action bar
-    const logY = height - logH - SLOT_SIZE - 20;
-
-    this.add
-      .rectangle(4, logY, width - 8, logH, 0x000000, 0.55)
-      .setOrigin(0, 0).setScrollFactor(0).setDepth(SLOT_DEPTH);
-
-    for (let i = 0; i < LOG_LINES; i++) {
-      this._logLines.push(
-        this.add
-          .text(10, logY + 5 + i * 13, '', { ...TEXT_STYLE, color: '#94a3b8' })
-          .setScrollFactor(0).setDepth(SLOT_DEPTH + 1),
-      );
-    }
-  }
-
   // ─── Registro de Eventos ──────────────────────────────────────────────────
 
   private _registerEvents(): void {
@@ -173,9 +193,33 @@ export class UIScene extends Phaser.Scene {
     EventBus.on(EVENTS.PLAYER_MANA_CHANGED, this._onManaChanged,  this);
     EventBus.on(EVENTS.PLAYER_XP_CHANGED,   this._onXPChanged,    this);
     EventBus.on(EVENTS.PLAYER_LEVELED_UP,   this._onLevelUp,      this);
-    EventBus.on(EVENTS.UI_LOG,              this._onLog,          this);
     EventBus.on(EVENTS.ITEM_PICKED_UP,      this._onItemPickedUp, this);
     EventBus.on(EVENTS.ITEM_USED,           this._onItemUsed,     this);
+
+    EventBus.on(EVENTS.INVENTORY_OPENED, () => {
+      if (!this.sys.isActive()) return;
+      EventBus.emit(EVENTS.INVENTORY_STATE_REQUESTED, { timestamp: Date.now() });
+    }, this);
+
+    EventBus.on(EVENTS.INVENTORY_STATE_RESPONSE, (data: {
+      items: unknown[];
+      equipped: Record<string, string | null>;
+      identifiedItems: Record<string, boolean>;
+    }) => {
+      if (!this.sys.isActive()) return;
+      this._inventoryData = data;
+      this._selectedInventoryIndex = 0;
+      this._inventoryPanel.show();
+      this._inventoryPanel.markDirty();
+    }, this);
+
+    EventBus.on(EVENTS.INVENTORY_CLOSED, () => {
+      if (!this.sys.isActive()) return;
+      this._inventoryPanel.hide();
+    }, this);
+
+    EventBus.on(EVENTS.ITEM_EQUIPPED,   () => { this._inventoryPanel.markDirty(); }, this);
+    EventBus.on(EVENTS.ITEM_UNEQUIPPED, () => { this._inventoryPanel.markDirty(); }, this);
   }
 
   // ─── Handlers ────────────────────────────────────────────────────────────
@@ -205,35 +249,13 @@ export class UIScene extends Phaser.Scene {
     this._levelLabel.setText(`Nv ${data.level}  ATK ${data.attack}`);
   }
 
-  private _onLog(message: string): void {
-    if (!this.sys.isActive()) return;
-    this._logBuffer.push(`> ${message}`);
-    if (this._logBuffer.length > LOG_LINES) this._logBuffer.shift();
-    this._logLines.forEach((line, i) => line.setText(this._logBuffer[i] ?? ''));
-  }
-
-  private _getItemVisual(type: ItemType): { texture: string; frame: number } {
-    switch (type) {
-      case 'potion_heal':   return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_HEAL };
-      case 'potion_poison': return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_POISON };
-      case 'gold':          return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
-    }
-  }
-
   private _onItemPickedUp(data: { item: Item; slotIndex: number }): void {
     if (!this.sys.isActive()) return;
-    const slot = this._slots[data.slotIndex];
-    if (!slot) return;
-    const { texture, frame } = this._getItemVisual(data.item.type);
-    slot.icon.setTexture(texture, frame).setVisible(true);
-    slot.bg.setStrokeStyle(1, 0xffd700);
+    this._actionBar.setItem(data.slotIndex, data.item.type);
   }
 
   private _onItemUsed(data: { itemIndex: number }): void {
     if (!this.sys.isActive()) return;
-    const slot = this._slots[data.itemIndex];
-    if (!slot) return;
-    slot.icon.setVisible(false);
-    slot.bg.setStrokeStyle(1, 0x4455aa);
+    this._actionBar.clearItem(data.itemIndex);
   }
 }

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -5,7 +5,10 @@ import { Item } from '../entities/Item';
 import { LogSystem } from '../systems/LogSystem';
 import { LogPanel } from '../ui/LogPanel';
 import { InventoryPanel } from '../ui/InventoryPanel';
+import { ShopPanel } from '../ui/ShopPanel';
+import { DialogPanel } from '../ui/DialogPanel';
 import { ActionBarPanel } from '../ui/ActionBarPanel';
+import type { ShopViewModel } from '../types/viewmodels';
 import { EQUIPMENT_SLOT_ORDER, EQUIPMENT_SLOT_LABELS, type EquipmentSlotId } from '../types/equipment';
 import type { InventoryViewModel, InventoryItemViewModel, EquipmentSlotViewModel } from '../types/viewmodels';
 
@@ -36,6 +39,7 @@ export class UIScene extends Phaser.Scene {
   // Status labels
   private _levelLabel!: Phaser.GameObjects.Text;
   private _xpLabel!: Phaser.GameObjects.Text;
+  private _goldLabel!: Phaser.GameObjects.Text;
 
   // Log
   private _logSystem!: LogSystem;
@@ -43,9 +47,12 @@ export class UIScene extends Phaser.Scene {
 
   // Inventory overlay
   private _inventoryPanel!: InventoryPanel;
+  private _shopPanel!: ShopPanel;
+  private _dialogPanel!: DialogPanel;
   private _actionBar!: ActionBarPanel;
-  private _inventoryData: { items: unknown[]; equipped: Record<string, string | null>; identifiedItems: Record<string, boolean> } | null = null;
+  private _inventoryData: { items: unknown[]; equipped: Record<string, string | null>; identifiedItems: Record<string, boolean>; selectedIndex?: number } | null = null;
   private _selectedInventoryIndex = 0;
+  private _shopData: ShopViewModel | null = null;
 
   // _slots removido — gerenciado por ActionBarPanel
 
@@ -60,6 +67,8 @@ export class UIScene extends Phaser.Scene {
     this._actionBar      = new ActionBarPanel(this);
     this._logPanel       = new LogPanel(this);
     this._inventoryPanel = new InventoryPanel(this);
+    this._shopPanel      = new ShopPanel(this);
+    this._dialogPanel    = new DialogPanel(this);
 
     // LogPanel deve parar antes da action bar
     this._logPanel.layout(this.scale.width, this.scale.height, this._actionBar.getHeight());
@@ -69,13 +78,19 @@ export class UIScene extends Phaser.Scene {
   }
 
   update(): void {
-    if (this._logPanel.isDirty()) {
+    if (this._logSystem.isDirty()) {
       const vm = this._logSystem.buildViewModel(UI.LOG_VISIBLE_LINES);
       this._logPanel.render(vm);
     }
     if (this._inventoryPanel.isDirty() && this._inventoryData) {
       const vm = this._buildInventoryViewModel();
       this._inventoryPanel.render(vm);
+    }
+    if (this._shopPanel.isDirty() && this._shopData) {
+      this._shopPanel.render(this._shopData);
+    }
+    if (this._dialogPanel.isDirty()) {
+      this._dialogPanel.render();
     }
   }
 
@@ -89,8 +104,15 @@ export class UIScene extends Phaser.Scene {
     EventBus.off(EVENTS.INVENTORY_OPENED,         undefined,            this);
     EventBus.off(EVENTS.INVENTORY_STATE_RESPONSE, undefined,            this);
     EventBus.off(EVENTS.INVENTORY_CLOSED,         undefined,            this);
-    EventBus.off(EVENTS.ITEM_EQUIPPED,            undefined,            this);
-    EventBus.off(EVENTS.ITEM_UNEQUIPPED,          undefined,            this);
+    EventBus.off(EVENTS.ITEM_EQUIPPED,              undefined,            this);
+    EventBus.off(EVENTS.ITEM_UNEQUIPPED,            undefined,            this);
+    EventBus.off(EVENTS.PLAYER_GOLD_CHANGED,        undefined,            this);
+    EventBus.off(EVENTS.INVENTORY_SELECTION_CHANGED,undefined,            this);
+    EventBus.off(EVENTS.SHOP_OPENED,                undefined,            this);
+    EventBus.off(EVENTS.SHOP_UPDATED,               undefined,            this);
+    EventBus.off(EVENTS.SHOP_CLOSED,                undefined,            this);
+    EventBus.off(EVENTS.DIALOG_OPENED,              undefined,            this);
+    EventBus.off(EVENTS.DIALOG_CLOSED,              undefined,            this);
   }
 
   // ─── InventoryViewModel builder ──────────────────────────────────────────
@@ -101,7 +123,8 @@ export class UIScene extends Phaser.Scene {
     const equipped = data.equipped;
     const equippedIds = new Set(Object.values(equipped).filter(Boolean));
 
-    const items: InventoryItemViewModel[] = (data.items as Array<{ id: string; type: string; getDisplayName: (m: Record<string, boolean>) => string } | null>).map((item, index) => {
+    const rawItems = data.items as Array<{ id: string; type: string; slotId?: string; getDisplayName: (m: Record<string, boolean>) => string } | null>;
+    const items: InventoryItemViewModel[] = rawItems.map((item, index) => {
       if (!item) return { index, id: null, displayName: '—', type: '', isEquipped: false, isSelected: false };
       const isEquipped = equippedIds.has(item.id);
       return {
@@ -111,6 +134,7 @@ export class UIScene extends Phaser.Scene {
         type:        item.type,
         isEquipped,
         isSelected:  index === selIdx,
+        slotId:      item.slotId as EquipmentSlotId | undefined,
       };
     });
 
@@ -130,11 +154,18 @@ export class UIScene extends Phaser.Scene {
 
     const selectedItem = items[selIdx];
     const selectedItemDetail = selectedItem?.id
-      ? {
-          name:        selectedItem.displayName,
-          description: `Tipo: ${selectedItem.type}`,
-          actions:     (['use', 'drop'] as Array<'equip' | 'use' | 'drop'>),
-        }
+      ? (() => {
+          const isEquipped = equippedIds.has(selectedItem.id!);
+          const hasSlot = !!selectedItem.slotId;
+          const actions: Array<'equip' | 'unequip' | 'use' | 'drop'> = hasSlot
+            ? (isEquipped ? ['unequip', 'drop'] : ['equip', 'drop'])
+            : ['use', 'drop'];
+          return {
+            name:        selectedItem.displayName,
+            description: `Tipo: ${selectedItem.type}`,
+            actions:     actions as Array<'equip' | 'use' | 'drop'>,
+          };
+        })()
       : null;
 
     return { items, slots, selectedItemDetail };
@@ -184,6 +215,14 @@ export class UIScene extends Phaser.Scene {
     this._xpLabel = this.add
       .text(PANEL_X, xpY + 12, 'XP: 0 / 100', TEXT_STYLE)
       .setScrollFactor(0).setDepth(d + 1);
+    this._goldLabel = this.add
+      .text(PANEL_X, xpY + 24, 'Ouro: 500', { ...TEXT_STYLE, color: '#ffd700' })
+      .setScrollFactor(0).setDepth(d + 1);
+
+    // Ajustar altura do fundo do painel de stats para acomodar nova linha
+    this.add
+      .rectangle(0, 0, panelW, 70, 0x000000, 0.55)
+      .setOrigin(0, 0).setScrollFactor(0).setDepth(d - 1);
   }
 
   // ─── Registro de Eventos ──────────────────────────────────────────────────
@@ -198,6 +237,7 @@ export class UIScene extends Phaser.Scene {
 
     EventBus.on(EVENTS.INVENTORY_OPENED, () => {
       if (!this.sys.isActive()) return;
+      this._inventoryPanel.show();
       EventBus.emit(EVENTS.INVENTORY_STATE_REQUESTED, { timestamp: Date.now() });
     }, this);
 
@@ -205,12 +245,16 @@ export class UIScene extends Phaser.Scene {
       items: unknown[];
       equipped: Record<string, string | null>;
       identifiedItems: Record<string, boolean>;
+      selectedIndex?: number;
     }) => {
       if (!this.sys.isActive()) return;
       this._inventoryData = data;
-      this._selectedInventoryIndex = 0;
-      this._inventoryPanel.show();
-      this._inventoryPanel.markDirty();
+      if (data.selectedIndex !== undefined) {
+        this._selectedInventoryIndex = data.selectedIndex;
+      }
+      if (this._inventoryPanel.isVisible()) {
+        this._inventoryPanel.markDirty();
+      }
     }, this);
 
     EventBus.on(EVENTS.INVENTORY_CLOSED, () => {
@@ -220,6 +264,43 @@ export class UIScene extends Phaser.Scene {
 
     EventBus.on(EVENTS.ITEM_EQUIPPED,   () => { this._inventoryPanel.markDirty(); }, this);
     EventBus.on(EVENTS.ITEM_UNEQUIPPED, () => { this._inventoryPanel.markDirty(); }, this);
+
+    EventBus.on(EVENTS.PLAYER_GOLD_CHANGED, (data: { gold: number }) => {
+      if (!this.sys.isActive() || !this._goldLabel?.active) return;
+      this._goldLabel.setText(`Ouro: ${data.gold}`);
+    }, this);
+
+    EventBus.on(EVENTS.INVENTORY_SELECTION_CHANGED, (data: { selectedIndex: number }) => {
+      if (!this.sys.isActive()) return;
+      this._selectedInventoryIndex = data.selectedIndex;
+      this._inventoryPanel.markDirty();
+    }, this);
+
+    EventBus.on(EVENTS.SHOP_OPENED, () => {
+      if (!this.sys.isActive()) return;
+      this._shopPanel.show();
+    }, this);
+
+    EventBus.on(EVENTS.SHOP_UPDATED, (data: ShopViewModel) => {
+      if (!this.sys.isActive()) return;
+      this._shopData = data;
+      this._shopPanel.markDirty();
+    }, this);
+
+    EventBus.on(EVENTS.SHOP_CLOSED, () => {
+      if (!this.sys.isActive()) return;
+      this._shopPanel.hide();
+    }, this);
+
+    EventBus.on(EVENTS.DIALOG_OPENED, (data: { title: string; options: Array<{ id: string; label: string; content: string; action?: string; goldCost?: number }> }) => {
+      if (!this.sys.isActive()) return;
+      this._dialogPanel.show(data.title, data.options);
+    }, this);
+
+    EventBus.on(EVENTS.DIALOG_CLOSED, () => {
+      if (!this.sys.isActive()) return;
+      this._dialogPanel.hide();
+    }, this);
   }
 
   // ─── Handlers ────────────────────────────────────────────────────────────

--- a/src/systems/CityDecorationSystem.ts
+++ b/src/systems/CityDecorationSystem.ts
@@ -1,0 +1,51 @@
+import * as Phaser from 'phaser';
+import { TILE_SIZE } from '../utils/constants';
+import { LAYER_WORLD_BASE } from '../config/sprites-config';
+import type { WorldObjectDef } from '../types/town';
+import type { TownLabelDef } from '../config/town.config';
+
+export class CityDecorationSystem {
+  /**
+   * Renderiza objetos do mundo e labels de texto para a cidade.
+   * Retorna todos os GameObjects criados para serem adicionados ao _decorObjects
+   * da GameScene (destruídos automaticamente no cleanup de área).
+   * @param scene        - Cena Phaser onde os objetos serão adicionados
+   * @param worldObjects - Objetos do mundo vindos do ProcessedTownLayout
+   * @param labels       - Labels de texto vindos do TOWN_CONFIG
+   * @returns Array de GameObjects criados
+   */
+  render(
+    scene: Phaser.Scene,
+    worldObjects: WorldObjectDef[],
+    labels: TownLabelDef[],
+  ): Phaser.GameObjects.GameObject[] {
+    const objects: Phaser.GameObjects.GameObject[] = [];
+
+    for (const obj of worldObjects) {
+      const px = obj.gridX * TILE_SIZE + TILE_SIZE / 2;
+      const py = obj.gridY * TILE_SIZE + TILE_SIZE / 2;
+      objects.push(
+        scene.add.sprite(px, py, obj.sprite, obj.frame)
+          .setDepth(LAYER_WORLD_BASE + obj.gridY * 10)
+          .setScrollFactor(1),
+      );
+    }
+
+    for (const label of labels) {
+      const px = label.x * TILE_SIZE + TILE_SIZE / 2;
+      const py = label.y * TILE_SIZE - 2;
+      objects.push(
+        scene.add.text(px, py, label.text, {
+          fontSize: '6px',
+          color: label.color,
+          fontFamily: 'monospace',
+        })
+          .setOrigin(0.5, 1)
+          .setDepth(label.depth)
+          .setScrollFactor(1),
+      );
+    }
+
+    return objects;
+  }
+}

--- a/src/systems/DifficultyScalingSystem.ts
+++ b/src/systems/DifficultyScalingSystem.ts
@@ -1,0 +1,20 @@
+import { getFloorDifficulty, type FloorDifficulty } from '../config/difficulty.config';
+
+export type { FloorDifficulty };
+
+export class DifficultyScalingSystem {
+  getFloorDifficulty(floor: number): FloorDifficulty {
+    return getFloorDifficulty(floor);
+  }
+
+  scaleEnemyStats(
+    base: { hp: number; attack: number },
+    floor: number,
+  ): { hp: number; attack: number } {
+    const diff = getFloorDifficulty(floor);
+    return {
+      hp:     Math.round(base.hp     * diff.enemyHpMultiplier),
+      attack: Math.round(base.attack * diff.enemyAtkMultiplier),
+    };
+  }
+}

--- a/src/systems/DungeonFloorManager.ts
+++ b/src/systems/DungeonFloorManager.ts
@@ -1,0 +1,65 @@
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+import type { DungeonFloorState, DungeonMetadata, FloorConnectionData } from '../types/dungeon';
+
+export class DungeonFloorManager {
+  private _floors      = new Map<number, DungeonFloorState>();
+  private _connections = new Map<number, FloorConnectionData>();
+  private _meta: DungeonMetadata = { currentFloor: 1, maxFloorReached: 1 };
+
+  get currentFloor(): number {
+    return this._meta.currentFloor;
+  }
+
+  get maxFloorReached(): number {
+    return this._meta.maxFloorReached;
+  }
+
+  saveFloor(state: DungeonFloorState): void {
+    this._floors.set(state.floor, state);
+  }
+
+  loadFloor(floor: number): DungeonFloorState | null {
+    return this._floors.get(floor) ?? null;
+  }
+
+  hasFloor(floor: number): boolean {
+    return this._floors.has(floor);
+  }
+
+  descend(): void {
+    const previousFloor = this._meta.currentFloor;
+    this._meta.currentFloor++;
+    if (this._meta.currentFloor > this._meta.maxFloorReached) {
+      this._meta.maxFloorReached = this._meta.currentFloor;
+    }
+    const floor = this._meta.currentFloor;
+    EventBus.emit(EVENTS.FLOOR_DESCEND,  { floor, timestamp: Date.now() });
+    EventBus.emit(EVENTS.FLOOR_CHANGED,  { floor, previousFloor, timestamp: Date.now() });
+    EventBus.emit(EVENTS.UI_LOG, `Você desce para o andar ${floor}…`);
+  }
+
+  ascend(): void {
+    if (this._meta.currentFloor <= 1) return;
+    const previousFloor = this._meta.currentFloor;
+    this._meta.currentFloor--;
+    const floor = this._meta.currentFloor;
+    EventBus.emit(EVENTS.FLOOR_ASCEND,  { floor, timestamp: Date.now() });
+    EventBus.emit(EVENTS.FLOOR_CHANGED, { floor, previousFloor, timestamp: Date.now() });
+    EventBus.emit(EVENTS.UI_LOG, `Você sobe para o andar ${floor}.`);
+  }
+
+  saveFloorConnections(floor: number, data: FloorConnectionData): void {
+    this._connections.set(floor, data);
+  }
+
+  getFloorConnections(floor: number): FloorConnectionData | null {
+    return this._connections.get(floor) ?? null;
+  }
+
+  reset(): void {
+    this._floors.clear();
+    this._connections.clear();
+    this._meta = { currentFloor: 1, maxFloorReached: 1 };
+  }
+}

--- a/src/systems/EnemySystem.ts
+++ b/src/systems/EnemySystem.ts
@@ -1,6 +1,7 @@
 import * as Phaser from 'phaser';
 import { ENEMY, EVENTS, TILE_SIZE } from '../utils/constants';
 import type { DungeonGenerator, GridPos } from '../generators/DungeonGenerator';
+import type { FloorDifficulty } from '../config/difficulty.config';
 
 export type EnemyState = 'IDLE' | 'CHASING' | 'ATTACKING';
 
@@ -134,9 +135,13 @@ export class EnemySystem {
 
 export function createEnemies(
   dungeon: DungeonGenerator,
-  count: number,
   playerPos: GridPos,
+  difficulty?: FloorDifficulty,
 ): EnemySystem[] {
+  const count    = difficulty?.enemyCount ?? ENEMY.COUNT;
+  const hpScale  = difficulty?.enemyHpMultiplier  ?? 1;
+  const atkScale = difficulty?.enemyAtkMultiplier ?? 1;
+
   const enemies: EnemySystem[] = [];
   const occupied = new Set<string>();
   occupied.add(`${playerPos.x},${playerPos.y}`);
@@ -151,7 +156,12 @@ export function createEnemies(
 
     if (!occupied.has(`${pos.x},${pos.y}`)) {
       occupied.add(`${pos.x},${pos.y}`);
-      enemies.push(new EnemySystem(pos.x, pos.y, i));
+      const enemy = new EnemySystem(pos.x, pos.y, i);
+      // Aplicar scaling no spawn — base stats das constants nunca mutadas
+      enemy.hp    = Math.round(ENEMY.HP     * hpScale);
+      enemy.maxHp = Math.round(ENEMY.HP     * hpScale);
+      enemy.attack = Math.round(ENEMY.ATTACK * atkScale);
+      enemies.push(enemy);
     }
   }
 

--- a/src/systems/EquipmentSystem.ts
+++ b/src/systems/EquipmentSystem.ts
@@ -1,0 +1,68 @@
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+import {
+  EQUIPMENT_SLOT_ORDER,
+  type EquipmentSlotId,
+  type EquipResult,
+} from '../types/equipment';
+
+export type { EquipmentSlotId, EquipResult };
+
+export class EquipmentSystem {
+  private _equipped: Record<EquipmentSlotId, string | null> = {
+    helmet: null,
+    shield: null,
+    sword:  null,
+    pants:  null,
+    boots:  null,
+    amulet: null,
+  };
+
+  equip(itemId: string, slotId: EquipmentSlotId): EquipResult {
+    const previousItemId = this._equipped[slotId];
+    this._equipped[slotId] = itemId;
+
+    EventBus.emit(EVENTS.ITEM_EQUIPPED, {
+      itemId,
+      slotId,
+      previousItemId,
+      timestamp: Date.now(),
+    });
+
+    const hadPrevious = previousItemId !== null;
+    return {
+      success: true,
+      message: hadPrevious
+        ? `Equipou e desequipou o item anterior do slot ${slotId}.`
+        : `Item equipado no slot ${slotId}.`,
+      previousItemId,
+    };
+  }
+
+  unequip(slotId: EquipmentSlotId): string | null {
+    const itemId = this._equipped[slotId];
+    if (!itemId) return null;
+
+    this._equipped[slotId] = null;
+    EventBus.emit(EVENTS.ITEM_UNEQUIPPED, { itemId, slotId, timestamp: Date.now() });
+    return itemId;
+  }
+
+  getEquippedId(slotId: EquipmentSlotId): string | null {
+    return this._equipped[slotId];
+  }
+
+  isEquipped(itemId: string): boolean {
+    return EQUIPMENT_SLOT_ORDER.some(slotId => this._equipped[slotId] === itemId);
+  }
+
+  getAllEquipped(): Record<EquipmentSlotId, string | null> {
+    return { ...this._equipped };
+  }
+
+  reset(): void {
+    for (const slotId of EQUIPMENT_SLOT_ORDER) {
+      this._equipped[slotId] = null;
+    }
+  }
+}

--- a/src/systems/InputModeManager.ts
+++ b/src/systems/InputModeManager.ts
@@ -1,0 +1,36 @@
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+import type { InputMode } from '../types/input';
+
+export type { InputMode };
+
+export class InputModeManager {
+  private _mode: InputMode = 'GAMEPLAY';
+  private _stack: InputMode[] = [];
+
+  get current(): InputMode {
+    return this._mode;
+  }
+
+  set(mode: InputMode): void {
+    const previousMode = this._mode;
+    this._mode = mode;
+    EventBus.emit(EVENTS.INPUT_MODE_CHANGED, { mode, previousMode, timestamp: Date.now() });
+  }
+
+  is(mode: InputMode): boolean {
+    return this._mode === mode;
+  }
+
+  push(mode: InputMode): void {
+    this._stack.push(this._mode);
+    this.set(mode);
+  }
+
+  pop(): void {
+    const previous = this._stack.pop();
+    if (previous !== undefined) {
+      this.set(previous);
+    }
+  }
+}

--- a/src/systems/InteractiveObjectSystem.ts
+++ b/src/systems/InteractiveObjectSystem.ts
@@ -1,0 +1,116 @@
+import * as Phaser from 'phaser';
+import { TILE_SIZE } from '../utils/constants';
+import { LAYER_UI_LABELS } from '../config/sprites-config';
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+import type { NPCInstanceDef, InteractiveObjectDef } from '../types/town';
+import type { NPCController } from './NPCController';
+
+export class InteractiveObjectSystem {
+  private _npcController: NPCController | null = null;
+  private _promptText:    Phaser.GameObjects.Text | null = null;
+  private _tKey:          Phaser.Input.Keyboard.Key | null = null;
+  private _currentTarget: NPCInstanceDef | null = null;
+
+  /**
+   * Inicializa o sistema registrando o NPCController e criando o texto de prompt.
+   */
+  load(
+    scene: Phaser.Scene,
+    _objects: InteractiveObjectDef[],
+    npcController: NPCController,
+  ): void {
+    this._npcController = npcController;
+
+    this._promptText = scene.add
+      .text(0, 0, '[T] Interagir', {
+        fontSize:        '7px',
+        color:           '#ffffff',
+        fontFamily:      'monospace',
+        backgroundColor: '#000000',
+        padding:         { x: 3, y: 2 },
+      })
+      .setOrigin(0.5, 1)
+      .setDepth(LAYER_UI_LABELS)
+      .setScrollFactor(1)
+      .setVisible(false);
+
+    this._tKey = scene.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.T);
+  }
+
+  /**
+   * Deve ser chamado uma vez por frame a partir de GameScene.update().
+   */
+  update(playerGridX: number, playerGridY: number): void {
+    this._checkProximity(playerGridX, playerGridY);
+
+    if (this._currentTarget && Phaser.Input.Keyboard.JustDown(this._tKey!)) {
+      this._interact();
+    }
+  }
+
+  /**
+   * Para NPCs com houseBounds: player deve estar DENTRO do edifício.
+   * Para NPCs sem houseBounds: usa adjacência ortogonal clássica.
+   */
+  private _checkProximity(px: number, py: number): void {
+    if (!this._npcController || !this._promptText) return;
+
+    let found: NPCInstanceDef | null = null;
+
+    // Iterar sobre todos os NPCs e checar condição de proximidade
+    const allNPCs = this._npcController.getAllNPCs();
+    for (const npc of allNPCs) {
+      if (this._canInteract(npc, px, py)) {
+        found = npc;
+        break;
+      }
+    }
+
+    this._currentTarget = found;
+
+    if (found) {
+      const wx = found.gridX * TILE_SIZE + TILE_SIZE / 2;
+      const wy = found.gridY * TILE_SIZE;
+      this._promptText.setPosition(wx, wy).setVisible(true);
+    } else {
+      this._promptText.setVisible(false);
+    }
+  }
+
+  private _canInteract(npc: NPCInstanceDef, px: number, py: number): boolean {
+    if (npc.houseBounds) {
+      const b = npc.houseBounds;
+      return px >= b.x && px < b.x + b.w && py >= b.y && py < b.y + b.h;
+    }
+    // Adjacência ortogonal
+    const dx = Math.abs(npc.gridX - px);
+    const dy = Math.abs(npc.gridY - py);
+    return (dx === 1 && dy === 0) || (dx === 0 && dy === 1);
+  }
+
+  private _interact(): void {
+    const npc = this._currentTarget;
+    if (!npc?.interaction) return;
+
+    if (npc.interaction.type === 'shop') {
+      EventBus.emit(EVENTS.SHOP_OPENED, { npcId: npc.id, shopId: 'merchant' });
+    } else if (npc.interaction.type === 'menu') {
+      EventBus.emit(EVENTS.DIALOG_OPENED, {
+        npcId: npc.id ?? npc.name,
+        title: npc.name,
+        options: npc.interaction.menuOptions ?? [],
+      });
+    } else {
+      EventBus.emit(EVENTS.UI_LOG, `[${npc.name}]: ${npc.interaction.message}`);
+    }
+  }
+
+  destroy(): void {
+    this._promptText?.destroy();
+    this._promptText    = null;
+    this._currentTarget = null;
+    this._npcController = null;
+    this._tKey = null;
+  }
+}

--- a/src/systems/LogSystem.ts
+++ b/src/systems/LogSystem.ts
@@ -13,16 +13,20 @@ export interface LogEntry {
 export class LogSystem {
   private _buffer: LogEntry[] = [];
   private readonly _maxEntries: number;
+  private _dirty = false;
 
   constructor(maxEntries = UI.LOG_MAX_HISTORY) {
     this._maxEntries = maxEntries;
   }
+
+  isDirty(): boolean { return this._dirty; }
 
   add(message: string, category?: LogCategory): void {
     this._buffer.push({ message, timestamp: Date.now(), category });
     if (this._buffer.length > this._maxEntries) {
       this._buffer.shift();
     }
+    this._dirty = true;
   }
 
   getVisible(count: number): LogEntry[] {
@@ -30,6 +34,7 @@ export class LogSystem {
   }
 
   buildViewModel(visibleCount: number): LogViewModel {
+    this._dirty = false;
     const entries = this.getVisible(visibleCount);
     const total = entries.length;
     const result: LogEntryViewModel[] = entries.map((entry, i) => {

--- a/src/systems/LogSystem.ts
+++ b/src/systems/LogSystem.ts
@@ -1,0 +1,52 @@
+import { EventBus } from '../utils/EventBus';
+import { EVENTS, UI } from '../utils/constants';
+import type { LogViewModel, LogEntryViewModel } from '../types/viewmodels';
+
+export type LogCategory = 'combat' | 'item' | 'system' | 'floor';
+
+export interface LogEntry {
+  message: string;
+  timestamp: number;
+  category?: LogCategory;
+}
+
+export class LogSystem {
+  private _buffer: LogEntry[] = [];
+  private readonly _maxEntries: number;
+
+  constructor(maxEntries = UI.LOG_MAX_HISTORY) {
+    this._maxEntries = maxEntries;
+  }
+
+  add(message: string, category?: LogCategory): void {
+    this._buffer.push({ message, timestamp: Date.now(), category });
+    if (this._buffer.length > this._maxEntries) {
+      this._buffer.shift();
+    }
+  }
+
+  getVisible(count: number): LogEntry[] {
+    return this._buffer.slice(-count);
+  }
+
+  buildViewModel(visibleCount: number): LogViewModel {
+    const entries = this.getVisible(visibleCount);
+    const total = entries.length;
+    const result: LogEntryViewModel[] = entries.map((entry, i) => {
+      const age = total - 1 - i;
+      const alpha = Math.max(0.4, 1 - age * 0.06);
+      return { text: `> ${entry.message}`, alpha };
+    });
+    return { entries: result };
+  }
+
+  clear(): void {
+    this._buffer = [];
+  }
+
+  bindEventBus(): void {
+    EventBus.on(EVENTS.UI_LOG, (message: string) => {
+      this.add(message);
+    });
+  }
+}

--- a/src/systems/MapTransitionSystem.ts
+++ b/src/systems/MapTransitionSystem.ts
@@ -1,0 +1,74 @@
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+import type { SpawnPoint, TransitionPoint, TransitionResolution } from '../types/transitions';
+
+export class MapTransitionSystem {
+  private _spawnPoints  = new Map<string, SpawnPoint>();
+  private _transitions  = new Map<string, TransitionPoint>();
+  private _lastTransitionId:  string | null = null;
+  private _lastFromMapId:     string | null = null;
+  private _currentFloor = 1;
+
+  registerSpawn(point: SpawnPoint): void {
+    this._spawnPoints.set(point.id, point);
+  }
+
+  registerTransition(point: TransitionPoint): void {
+    this._transitions.set(point.id, point);
+  }
+
+  setCurrentFloor(floor: number): void {
+    this._currentFloor = floor;
+  }
+
+  requestTransition(transitionId: string): TransitionResolution | null {
+    const transition = this._transitions.get(transitionId);
+    if (!transition) {
+      EventBus.emit(EVENTS.UI_LOG, `[ERRO] Transição não encontrada: ${transitionId}`);
+      return null;
+    }
+
+    const targetSpawn = this._spawnPoints.get(transition.targetSpawnId);
+    if (!targetSpawn) {
+      EventBus.emit(EVENTS.UI_LOG, `[ERRO] SpawnPoint não encontrado: ${transition.targetSpawnId}`);
+      return null;
+    }
+
+    this._lastTransitionId = transitionId;
+    this._lastFromMapId    = transition.fromMapId;
+
+    const resolution: TransitionResolution = {
+      transitionId,
+      targetMapId:    transition.toMapId,
+      targetSpawn,
+      transitionType: 'instant',
+      floor:          this._currentFloor,
+      metadata:       { fromMapId: transition.fromMapId },
+    };
+
+    EventBus.emit(EVENTS.MAP_TRANSITION_STARTED, { transitionId, timestamp: Date.now() });
+    return resolution;
+  }
+
+  completeTransition(resolution: TransitionResolution): void {
+    EventBus.emit(EVENTS.MAP_TRANSITION_COMPLETED, {
+      targetMapId:  resolution.targetMapId,
+      targetSpawn:  resolution.targetSpawn,
+      floor:        resolution.floor,
+      timestamp:    Date.now(),
+    });
+  }
+
+  getReturnSpawnFor(toMapId: string): SpawnPoint | null {
+    if (!this._lastTransitionId || !this._lastFromMapId) return null;
+
+    // Procura transição reversa: de toMapId para lastFromMapId
+    for (const [, t] of this._transitions) {
+      if (t.fromMapId === toMapId && t.toMapId === this._lastFromMapId) {
+        const spawn = this._spawnPoints.get(t.targetSpawnId);
+        return spawn ?? null;
+      }
+    }
+    return null;
+  }
+}

--- a/src/systems/NPCController.ts
+++ b/src/systems/NPCController.ts
@@ -1,0 +1,144 @@
+import * as Phaser from 'phaser';
+import { TILE_SIZE, TILE } from '../utils/constants';
+import { LAYER_WORLD_BASE } from '../config/sprites-config';
+import type { NPCInstanceDef, NPCStateId } from '../types/town';
+
+interface NPCInstance {
+  def:       NPCInstanceDef;
+  sprite:    Phaser.GameObjects.Sprite;
+  state:     NPCStateId;
+  gridX:     number;
+  gridY:     number;
+  stepCount: number;
+  timer:     number;
+}
+
+const IDLE_DURATION    = 2000; // ms before wandering (reserved — wander disabled)
+const MOVE_DELAY       = 400;  // ms between wander steps (reserved)
+const MAX_WANDER_STEPS = 4;    // steps before returning to idle (reserved)
+
+export class NPCController {
+  private _npcs:     NPCInstance[] = [];
+  private _occupied: Set<string>   = new Set();
+
+  /**
+   * Cria sprites para todos os NPCs definidos e registra suas posições no grid de ocupação.
+   * @param scene - Cena Phaser onde os sprites serão adicionados
+   * @param defs  - Definições de instâncias de NPC vindas do ProcessedTownLayout
+   * @returns Array de sprites criados
+   */
+  spawn(scene: Phaser.Scene, defs: NPCInstanceDef[]): Phaser.GameObjects.Sprite[] {
+    this._npcs     = [];
+    this._occupied = new Set();
+    const sprites: Phaser.GameObjects.Sprite[] = [];
+
+    for (const raw of defs) {
+      // Garante que todo NPC tenha uma interação padrão
+      const def: NPCInstanceDef = {
+        ...raw,
+        interaction: raw.interaction ?? { type: 'dialogue', message: 'hi' },
+      };
+
+      const px = def.gridX * TILE_SIZE + TILE_SIZE / 2;
+      const py = def.gridY * TILE_SIZE + TILE_SIZE / 2;
+      const sprite = scene.add
+        .sprite(px, py, def.sprite, def.frame)
+        .setDepth(LAYER_WORLD_BASE + def.gridY * 10)
+        .setScrollFactor(1);
+
+      this._npcs.push({
+        def,
+        sprite,
+        state:     'idle',
+        gridX:     def.gridX,
+        gridY:     def.gridY,
+        stepCount: 0,
+        timer:     IDLE_DURATION * Math.random(), // stagger start times (reserved for wander)
+      });
+      this._occupied.add(`${def.gridX},${def.gridY}`);
+      sprites.push(sprite);
+    }
+
+    return sprites;
+  }
+
+  /**
+   * Retorna a definição do NPC posicionado na célula (gx, gy), ou null se vazia.
+   */
+  getNPCAt(gx: number, gy: number): NPCInstanceDef | null {
+    return this._npcs.find(n => n.gridX === gx && n.gridY === gy)?.def ?? null;
+  }
+
+  /** Retorna as definições de todos os NPCs carregados. */
+  getAllNPCs(): NPCInstanceDef[] {
+    return this._npcs.map(n => n.def);
+  }
+
+  /**
+   * Retorna true se a célula (gx, gy) está ocupada por algum NPC.
+   * @param gx - Coluna do grid
+   * @param gy - Linha do grid
+   */
+  isTileOccupied(gx: number, gy: number): boolean {
+    return this._occupied.has(`${gx},${gy}`);
+  }
+
+  /**
+   * Reservado para re-habilitação futura do wander FSM.
+   * Atualmente é um no-op — todos os NPCs permanecem idle indefinidamente.
+   * @param _delta - Tempo em ms desde o último frame
+   * @param _grid  - Grid de colisão da área atual
+   */
+  update(delta: number, grid: number[][]): void {
+    for (const npc of this._npcs) {
+      if (!npc.def.wanderBounds) continue;
+      npc.timer -= delta;
+      if (npc.timer > 0) continue;
+      if (npc.state === 'idle') {
+        npc.state = 'wander'; npc.stepCount = 0; npc.timer = MOVE_DELAY;
+      } else {
+        this._wanderStep(npc, grid);
+        npc.stepCount++;
+        if (npc.stepCount >= MAX_WANDER_STEPS) { npc.state = 'idle'; npc.timer = IDLE_DURATION; }
+        else { npc.timer = MOVE_DELAY; }
+      }
+    }
+  }
+
+  private _wanderStep(npc: NPCInstance, grid: number[][]): void {
+    const bounds = npc.def.wanderBounds!;
+    const dirs = [
+      { dx: 0, dy: -1 }, { dx: 0, dy: 1 },
+      { dx: -1, dy: 0 }, { dx: 1, dy: 0 },
+    ].filter(d => {
+      const nx = npc.gridX + d.dx;
+      const ny = npc.gridY + d.dy;
+      return (
+        nx >= bounds.minX && nx <= bounds.maxX &&
+        ny >= bounds.minY && ny <= bounds.maxY &&
+        grid[ny]?.[nx] === TILE.FLOOR
+      );
+    });
+
+    if (dirs.length === 0) return;
+
+    const dir = dirs[Math.floor(Math.random() * dirs.length)];
+    this._occupied.delete(`${npc.gridX},${npc.gridY}`);
+    npc.gridX += dir.dx;
+    npc.gridY += dir.dy;
+    this._occupied.add(`${npc.gridX},${npc.gridY}`);
+
+    const px = npc.gridX * TILE_SIZE + TILE_SIZE / 2;
+    const py = npc.gridY * TILE_SIZE + TILE_SIZE / 2;
+    npc.sprite.setPosition(px, py);
+    npc.sprite.setDepth(LAYER_WORLD_BASE + npc.gridY * 10);
+  }
+
+  /** Destrói todos os sprites de NPC gerenciados por este controller. */
+  destroy(): void {
+    this._npcs.forEach(n => n.sprite.destroy());
+    this._npcs     = [];
+    this._occupied = new Set();
+  }
+}
+

--- a/src/systems/NPCSystem.ts
+++ b/src/systems/NPCSystem.ts
@@ -1,0 +1,34 @@
+import * as Phaser from 'phaser';
+import { TILE_SIZE } from '../utils/constants';
+import type { TownConfig } from '../config/town.config';
+
+export class NPCSystem {
+  private _sprites: Phaser.GameObjects.Sprite[] = [];
+
+  /**
+   * Cria sprites estáticos para os NPCs definidos no config.
+   * Retorna os sprites para que possam ser adicionados ao _decorObjects
+   * da GameScene (destruídos automaticamente no cleanup de área).
+   */
+  spawn(scene: Phaser.Scene, config: TownConfig): Phaser.GameObjects.Sprite[] {
+    this._sprites = [];
+
+    for (const npc of config.npcs) {
+      const px = npc.x * TILE_SIZE + TILE_SIZE / 2;
+      const py = npc.y * TILE_SIZE + TILE_SIZE / 2;
+      const sprite = scene.add
+        .sprite(px, py, npc.sprite, npc.frame)
+        .setDepth(5)
+        .setScrollFactor(1);
+      this._sprites.push(sprite);
+    }
+
+    return this._sprites;
+  }
+
+  /** Destrói todos os sprites de NPC (chamado no cleanup de área). */
+  destroy(): void {
+    this._sprites.forEach(s => s.destroy());
+    this._sprites = [];
+  }
+}

--- a/src/systems/ShopSystem.ts
+++ b/src/systems/ShopSystem.ts
@@ -1,0 +1,122 @@
+import { EventBus } from '../utils/EventBus';
+import { EVENTS, SHOP } from '../utils/constants';
+import { SHOP_CATALOG, createItemFromCatalogEntry, buildBonusText } from '../config/shop.catalog';
+import type { ShopItemDef } from '../config/shop.catalog';
+import type { Player } from '../entities/Player';
+import type { InventorySystem } from './InventorySystem';
+import type { ShopViewModel, SellItemViewModel } from '../types/viewmodels';
+
+export interface BuyResult { success: boolean; message: string; }
+export interface SellResult { success: boolean; message: string; goldGained: number; }
+
+export class ShopSystem {
+  private _catalog: ShopItemDef[];
+
+  constructor(catalog: ShopItemDef[] = SHOP_CATALOG) {
+    this._catalog = catalog;
+  }
+
+  get catalog(): ShopItemDef[] {
+    return this._catalog;
+  }
+
+  buyItem(player: Player, index: number, inventory: InventorySystem): BuyResult {
+    const entry = this._catalog[index];
+    if (!entry) return { success: false, message: 'Item inválido.' };
+
+    if (player.gold < entry.price) {
+      return { success: false, message: `Ouro insuficiente. Precisa de ${entry.price} moedas.` };
+    }
+    if (inventory.isFull()) {
+      return { success: false, message: 'Inventário cheio. Faça espaço antes de comprar.' };
+    }
+
+    const item = createItemFromCatalogEntry(entry);
+    inventory.addItem(item);
+    player.gold -= entry.price;
+
+    EventBus.emit(EVENTS.PLAYER_GOLD_CHANGED, { gold: player.gold });
+
+    return { success: true, message: `Comprou ${entry.name} por ${entry.price} moedas.` };
+  }
+
+  sellItem(player: Player, itemIndex: number, inventory: InventorySystem): SellResult {
+    const item = inventory.getItem(itemIndex);
+    if (!item) return { success: false, message: 'Nenhum item selecionado.', goldGained: 0 };
+
+    const basePrice = item.price ?? 0;
+    if (basePrice === 0) {
+      return { success: false, message: 'Este item não pode ser vendido.', goldGained: 0 };
+    }
+
+    const goldGained = Math.floor(basePrice * SHOP.SELL_RATIO);
+    inventory.removeItem(itemIndex);
+    player.gold += goldGained;
+
+    EventBus.emit(EVENTS.PLAYER_GOLD_CHANGED, { gold: player.gold });
+
+    return {
+      success: true,
+      message: `Vendeu ${item.name ?? item.type} por ${goldGained} moedas.`,
+      goldGained,
+    };
+  }
+
+  buildSellItems(
+    player: { inventory: InventorySystem },
+    equippedIds: Set<string>,
+    selectedIndex: number,
+  ): SellItemViewModel[] {
+    const result: SellItemViewModel[] = [];
+    const items = player.inventory.items;
+    let poolIndex = 0;
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (!item) continue;
+      const canSell = (item.price != null && item.price > 0) && !equippedIds.has(item.id);
+      const sellPrice = Math.floor((item.price ?? 0) * SHOP.SELL_RATIO);
+      result.push({
+        inventoryIndex: i,
+        id: item.id,
+        name: item.name ?? item.type,
+        sellPrice,
+        isSelected: poolIndex === selectedIndex,
+        canSell,
+      });
+      poolIndex++;
+    }
+    return result;
+  }
+
+  buildViewModel(
+    player: Player,
+    selectedIndex: number,
+    tab: 'buy' | 'sell' = 'buy',
+    inventory?: InventorySystem,
+    equippedIds?: Set<string>,
+  ): ShopViewModel {
+    const buyItems = this._catalog.map((entry, i) => ({
+      index:      i,
+      id:         entry.id,
+      name:       entry.name,
+      price:      entry.price,
+      rarity:     entry.rarity,
+      bonusText:  buildBonusText(entry.bonuses),
+      canAfford:  player.gold >= entry.price,
+      isSelected: tab === 'buy' && i === selectedIndex,
+    }));
+
+    const sellItems: SellItemViewModel[] = (inventory && equippedIds)
+      ? this.buildSellItems({ inventory }, equippedIds, tab === 'sell' ? selectedIndex : -1)
+      : [];
+
+    return {
+      items: buyItems,
+      buyItems,
+      sellItems,
+      tab,
+      playerGold: player.gold,
+      selectedIndex,
+    };
+  }
+}

--- a/src/systems/WorldSystem.ts
+++ b/src/systems/WorldSystem.ts
@@ -1,23 +1,19 @@
-import { Item } from '../entities/Item';
+import type { Item } from '../entities/Item';
 import { DungeonGenerator } from '../generators/DungeonGenerator';
-import { TILE, TOWN } from '../utils/constants';
+import { TOWN_CONFIG } from '../config/town.config';
 
 /**
  * TownMap — mapa fixo da cidade. Estende DungeonGenerator para compatibilidade
  * com TurnManager e EnemySystem sem alterar suas assinaturas.
+ * Grid e spawn lidos do TOWN_CONFIG (data-driven).
  */
 export class TownMap extends DungeonGenerator {
   constructor() {
-    const { WIDTH: W, HEIGHT: H } = TOWN;
-    super(W, H);
-    this.grid = Array.from({ length: H }, (_, y) =>
-      Array.from({ length: W }, (_, x) => {
-        if (x === 0 || x === W - 1 || y === 0 || y === H - 1) return TILE.WALL;
-        return TILE.FLOOR;
-      })
-    );
+    super(TOWN_CONFIG.width, TOWN_CONFIG.height);
+    // Cópia profunda para evitar mutação do config
+    this.grid = TOWN_CONFIG.grid.map(row => [...row]);
     this.rooms = [];
-    this.startPos = { x: TOWN.START_X, y: TOWN.START_Y };
+    this.startPos = { x: TOWN_CONFIG.startX, y: TOWN_CONFIG.startY };
   }
 }
 

--- a/src/types/dungeon.ts
+++ b/src/types/dungeon.ts
@@ -1,0 +1,47 @@
+export interface GridPos {
+  x: number;
+  y: number;
+}
+
+export interface EnemySerializedState {
+  id: number;
+  gridX: number;
+  gridY: number;
+  hp: number;
+  maxHp: number;
+  attack: number;
+  alive: boolean;
+}
+
+export interface ItemSerializedState {
+  id: string;
+  type: string;
+  gridX: number;
+  gridY: number;
+  identified: boolean;
+}
+
+export interface StairConnection {
+  targetFloor: number | 'town';
+  sourcePosition: GridPos;
+  targetPosition: GridPos;
+}
+
+export interface FloorConnectionData {
+  stairsUp?: StairConnection;
+  stairsDown?: StairConnection;
+}
+
+export interface DungeonFloorState {
+  floor: number;
+  seed: number;
+  discovered: boolean;
+  connections: FloorConnectionData;
+  enemyStates: EnemySerializedState[];
+  itemStates: ItemSerializedState[];
+}
+
+export interface DungeonMetadata {
+  currentFloor: number;
+  maxFloorReached: number;
+}

--- a/src/types/equipment.ts
+++ b/src/types/equipment.ts
@@ -1,0 +1,36 @@
+export type EquipmentSlotId = 'helmet' | 'shield' | 'sword' | 'pants' | 'boots' | 'amulet';
+
+export const EQUIPMENT_SLOT_LABELS: Record<EquipmentSlotId, string> = {
+  helmet: 'Capacete',
+  shield: 'Escudo',
+  sword:  'Espada',
+  pants:  'Calça',
+  boots:  'Bota',
+  amulet: 'Amuleto',
+};
+
+export const EQUIPMENT_SLOT_ORDER: EquipmentSlotId[] = [
+  'helmet', 'shield', 'sword', 'pants', 'boots', 'amulet',
+];
+
+export type EquippableItemType =
+  | 'sword_iron' | 'sword_steel'
+  | 'helmet_leather' | 'helmet_iron'
+  | 'shield_wood' | 'boots_leather' | 'amulet_stone';
+
+export type ItemRarity = 'common' | 'uncommon' | 'rare';
+
+export interface EquippableItem {
+  id: string;
+  type: EquippableItemType;
+  slotId: EquipmentSlotId;
+  name: string;
+  description: string;
+  rarity: ItemRarity;
+}
+
+export interface EquipResult {
+  success: boolean;
+  message: string;
+  previousItemId: string | null;
+}

--- a/src/types/equipment.ts
+++ b/src/types/equipment.ts
@@ -1,5 +1,13 @@
 export type EquipmentSlotId = 'helmet' | 'shield' | 'sword' | 'pants' | 'boots' | 'amulet';
 
+export interface StatBonuses {
+  str?: number;
+  dex?: number;
+  con?: number;
+  attack?: number;
+  maxHp?: number;
+}
+
 export const EQUIPMENT_SLOT_LABELS: Record<EquipmentSlotId, string> = {
   helmet: 'Capacete',
   shield: 'Escudo',
@@ -14,9 +22,12 @@ export const EQUIPMENT_SLOT_ORDER: EquipmentSlotId[] = [
 ];
 
 export type EquippableItemType =
-  | 'sword_iron' | 'sword_steel'
-  | 'helmet_leather' | 'helmet_iron'
-  | 'shield_wood' | 'boots_leather' | 'amulet_stone';
+  | 'sword_iron' | 'sword_steel' | 'sword_silver'
+  | 'helmet_leather' | 'helmet_iron' | 'helmet_bronze'
+  | 'shield_wood' | 'shield_iron' | 'shield_steel'
+  | 'pants_leather' | 'pants_iron'
+  | 'boots_leather' | 'boots_iron'
+  | 'amulet_stone' | 'amulet_silver' | 'amulet_gold';
 
 export type ItemRarity = 'common' | 'uncommon' | 'rare';
 
@@ -27,6 +38,8 @@ export interface EquippableItem {
   name: string;
   description: string;
   rarity: ItemRarity;
+  bonuses: StatBonuses;
+  price: number;
 }
 
 export interface EquipResult {

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -1,1 +1,1 @@
-export type InputMode = 'GAMEPLAY' | 'INVENTORY' | 'MODAL' | 'DEBUG';
+export type InputMode = 'GAMEPLAY' | 'INVENTORY' | 'SHOP' | 'DIALOG' | 'MODAL' | 'DEBUG';

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -1,0 +1,1 @@
+export type InputMode = 'GAMEPLAY' | 'INVENTORY' | 'MODAL' | 'DEBUG';

--- a/src/types/town.ts
+++ b/src/types/town.ts
@@ -1,0 +1,54 @@
+export type BiomeType = 'urban' | 'natural' | 'interior' | 'transition';
+export type TileLayerName = 'ground' | 'world' | 'overhead';
+export type NPCStateId = 'idle' | 'wander';
+export type InteractiveType = 'door' | 'sign' | 'chest';
+
+export interface DialogMenuOption {
+  id: string;
+  label: string;
+  content: string;
+  action?: 'rest';
+  goldCost?: number;
+}
+
+export interface ResolvedTile { sprite: string; frame: number; biome: BiomeType; }
+
+export interface ProcessedTownLayout {
+  width: number; height: number;
+  collisionGrid: number[][];
+  groundTiles:  ResolvedTile[][];
+  worldObjects: WorldObjectDef[];
+  npcs:         NPCInstanceDef[];
+  interactive:  InteractiveObjectDef[];
+  spawnPos:     { x: number; y: number };
+  exitPos:      { x: number; y: number };
+}
+
+export interface WorldObjectDef {
+  gridX: number; gridY: number;
+  sprite: string; frame: number;
+  solid: boolean;
+  layer: TileLayerName;
+}
+
+export interface NPCInstanceDef {
+  id: string;
+  gridX: number; gridY: number;
+  sprite: string; frame: number;
+  name: string;
+  state: NPCStateId;
+  wanderBounds?: { minX: number; maxX: number; minY: number; maxY: number };
+  houseBounds?: { x: number; y: number; w: number; h: number };
+  interaction?: {
+    type: 'dialogue' | 'shop' | 'menu';
+    message: string;
+    menuOptions?: DialogMenuOption[];
+  };
+}
+
+export interface InteractiveObjectDef {
+  gridX: number; gridY: number;
+  type: InteractiveType;
+  label?: string;
+  properties?: Record<string, unknown>;
+}

--- a/src/types/transitions.ts
+++ b/src/types/transitions.ts
@@ -1,0 +1,25 @@
+export interface SpawnPoint {
+  id: string;
+  mapId: string;
+  gridX: number;
+  gridY: number;
+}
+
+export interface TransitionPoint {
+  id: string;
+  fromMapId: string;
+  toMapId: string;
+  fromGridX: number;
+  fromGridY: number;
+  targetSpawnId: string;
+}
+
+export interface TransitionResolution {
+  transitionId: string;
+  targetMapId: string;
+  targetSpawn: SpawnPoint;
+  transitionType: 'instant' | 'fade' | 'async';
+  floor: number;
+  preloadAssets?: string[];
+  metadata: Record<string, unknown>;
+}

--- a/src/types/viewmodels.ts
+++ b/src/types/viewmodels.ts
@@ -1,4 +1,4 @@
-import type { EquipmentSlotId } from './equipment';
+import type { EquipmentSlotId, ItemRarity } from './equipment';
 
 export interface LogEntryViewModel {
   text: string;
@@ -30,11 +30,41 @@ export interface EquipmentSlotViewModel {
 export interface InventoryDetailViewModel {
   name: string;
   description: string;
-  actions: Array<'equip' | 'use' | 'drop'>;
+  actions: Array<'equip' | 'unequip' | 'use' | 'drop'>;
 }
 
 export interface InventoryViewModel {
   items: InventoryItemViewModel[];
   slots: EquipmentSlotViewModel[];
   selectedItemDetail: InventoryDetailViewModel | null;
+}
+
+export interface ShopItemViewModel {
+  index: number;
+  id: string;
+  name: string;
+  price: number;
+  rarity: ItemRarity;
+  bonusText: string;
+  canAfford: boolean;
+  isSelected: boolean;
+}
+
+export interface SellItemViewModel {
+  inventoryIndex: number;
+  id: string;
+  name: string;
+  sellPrice: number;
+  isSelected: boolean;
+  canSell: boolean;
+}
+
+export interface ShopViewModel {
+  /** @deprecated use buyItems */
+  items: ShopItemViewModel[];
+  buyItems: ShopItemViewModel[];
+  sellItems: SellItemViewModel[];
+  tab: 'buy' | 'sell';
+  playerGold: number;
+  selectedIndex: number;
 }

--- a/src/types/viewmodels.ts
+++ b/src/types/viewmodels.ts
@@ -1,0 +1,40 @@
+import type { EquipmentSlotId } from './equipment';
+
+export interface LogEntryViewModel {
+  text: string;
+  alpha: number;
+}
+
+export interface LogViewModel {
+  entries: LogEntryViewModel[];
+}
+
+export interface InventoryItemViewModel {
+  index: number;
+  id: string | null;
+  displayName: string;
+  type: string;
+  isEquipped: boolean;
+  isSelected: boolean;
+  slotId?: EquipmentSlotId;
+}
+
+export interface EquipmentSlotViewModel {
+  id: EquipmentSlotId;
+  label: string;
+  equippedItemId: string | null;
+  equippedItemName: string;
+  isSelected: boolean;
+}
+
+export interface InventoryDetailViewModel {
+  name: string;
+  description: string;
+  actions: Array<'equip' | 'use' | 'drop'>;
+}
+
+export interface InventoryViewModel {
+  items: InventoryItemViewModel[];
+  slots: EquipmentSlotViewModel[];
+  selectedItemDetail: InventoryDetailViewModel | null;
+}

--- a/src/ui/ActionBarPanel.ts
+++ b/src/ui/ActionBarPanel.ts
@@ -18,20 +18,20 @@ export class ActionBarPanel {
   private _slots: SlotGraphics[] = [];
 
   constructor(scene: Phaser.Scene) {
-    const panelW  = Math.floor(scene.scale.width * UI.LOG_PANEL_WIDTH_FRACTION);
+    const screenW = scene.scale.width;
     const screenH = scene.scale.height;
     const totalW  = SLOT_COUNT * (SLOT_SIZE + SLOT_GAP) - SLOT_GAP;
-    const startX  = Math.floor((panelW - totalW) / 2);
+    const startX  = Math.floor((screenW - totalW) / 2);
     const barY    = screenH - PANEL_H;
 
     this._root = scene.add.container(0, 0).setScrollFactor(0).setDepth(DEPTH);
 
-    // Fundo compacto apenas para a barra
+    // Fundo compacto apenas para a barra (largura total da tela)
     const bg = scene.add
-      .rectangle(0, barY, panelW, PANEL_H, 0x111122, 0.90)
+      .rectangle(0, barY, screenW, PANEL_H, 0x111122, 0.90)
       .setOrigin(0, 0);
     const border = scene.add
-      .rectangle(0, barY, panelW, 1, 0x334466, 1.0)
+      .rectangle(0, barY, screenW, 1, 0x334466, 1.0)
       .setOrigin(0, 0);
 
     this._root.add([bg, border]);

--- a/src/ui/ActionBarPanel.ts
+++ b/src/ui/ActionBarPanel.ts
@@ -1,0 +1,88 @@
+import * as Phaser from 'phaser';
+import { SPRITES, DAWNLIKE_FRAMES, UI } from '../utils/constants';
+import type { ItemType } from '../entities/Item';
+
+const SLOT_COUNT = 9;
+const SLOT_SIZE  = 20;
+const SLOT_GAP   = 3;
+const DEPTH      = 200;
+const PANEL_H    = SLOT_SIZE + 16;
+
+type SlotGraphics = {
+  bg:   Phaser.GameObjects.Rectangle;
+  icon: Phaser.GameObjects.Sprite;
+};
+
+export class ActionBarPanel {
+  private _root:  Phaser.GameObjects.Container;
+  private _slots: SlotGraphics[] = [];
+
+  constructor(scene: Phaser.Scene) {
+    const panelW  = Math.floor(scene.scale.width * UI.LOG_PANEL_WIDTH_FRACTION);
+    const screenH = scene.scale.height;
+    const totalW  = SLOT_COUNT * (SLOT_SIZE + SLOT_GAP) - SLOT_GAP;
+    const startX  = Math.floor((panelW - totalW) / 2);
+    const barY    = screenH - PANEL_H;
+
+    this._root = scene.add.container(0, 0).setScrollFactor(0).setDepth(DEPTH);
+
+    // Fundo compacto apenas para a barra
+    const bg = scene.add
+      .rectangle(0, barY, panelW, PANEL_H, 0x111122, 0.90)
+      .setOrigin(0, 0);
+    const border = scene.add
+      .rectangle(0, barY, panelW, 1, 0x334466, 1.0)
+      .setOrigin(0, 0);
+
+    this._root.add([bg, border]);
+
+    for (let i = 0; i < SLOT_COUNT; i++) {
+      const x = startX + i * (SLOT_SIZE + SLOT_GAP);
+      const y = barY + Math.floor((PANEL_H - SLOT_SIZE) / 2);
+
+      const slotBg = scene.add
+        .rectangle(x, y, SLOT_SIZE, SLOT_SIZE, 0x222244)
+        .setOrigin(0, 0)
+        .setStrokeStyle(1, 0x4455aa);
+
+      const icon = scene.add
+        .sprite(x + SLOT_SIZE / 2, y + SLOT_SIZE / 2, SPRITES.POTION, 0)
+        .setVisible(false)
+        .setScale(0.8);
+
+      const key = scene.add.text(x + 2, y + 2, String(i + 1), {
+        fontSize: '6px', color: '#667799', fontFamily: 'monospace',
+      });
+
+      this._root.add([slotBg, icon, key]);
+      this._slots.push({ bg: slotBg, icon });
+    }
+  }
+
+  getHeight(): number {
+    return PANEL_H;
+  }
+
+  setItem(slotIndex: number, type: ItemType): void {
+    const slot = this._slots[slotIndex];
+    if (!slot) return;
+    const { texture, frame } = this._getItemVisual(type);
+    slot.icon.setTexture(texture, frame).setVisible(true);
+    slot.bg.setStrokeStyle(1, 0xffd700);
+  }
+
+  clearItem(slotIndex: number): void {
+    const slot = this._slots[slotIndex];
+    if (!slot) return;
+    slot.icon.setVisible(false);
+    slot.bg.setStrokeStyle(1, 0x4455aa);
+  }
+
+  private _getItemVisual(type: ItemType): { texture: string; frame: number } {
+    switch (type) {
+      case 'potion_heal':   return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_HEAL };
+      case 'potion_poison': return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_POISON };
+      case 'gold':          return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
+    }
+  }
+}

--- a/src/ui/DialogPanel.ts
+++ b/src/ui/DialogPanel.ts
@@ -1,0 +1,122 @@
+import * as Phaser from 'phaser';
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+
+interface DialogOption {
+  id: string;
+  label: string;
+  content: string;
+  action?: string;
+  goldCost?: number;
+}
+
+const DEPTH = 500;
+
+export class DialogPanel {
+  private _root: Phaser.GameObjects.Container;
+  private _dirty = false;
+  private _visible = false;
+  private _titleText!: Phaser.GameObjects.Text;
+  private _optionBgs: Phaser.GameObjects.Rectangle[] = [];
+  private _optionTexts: Phaser.GameObjects.Text[] = [];
+  private _contentText!: Phaser.GameObjects.Text;
+  private _selectedIndex = 0;
+  private _options: DialogOption[] = [];
+  private readonly OPTION_POOL = 8;
+
+  constructor(scene: Phaser.Scene) {
+    this._root = scene.add.container(0, 0).setScrollFactor(0).setDepth(DEPTH).setVisible(false);
+    this._build(scene);
+
+    EventBus.on(EVENTS.DIALOG_OPTION_SELECTED, (data: { index: number; option: DialogOption }) => {
+      if (!this._visible) return;
+      this._selectedIndex = data.index;
+      this._dirty = true;
+    }, this);
+  }
+
+  private _build(scene: Phaser.Scene): void {
+    const sw = scene.scale.width;
+    const sh = scene.scale.height;
+    const panelW = Math.floor(sw * 0.7);
+    const panelH = Math.floor(sh * 0.65);
+    const ox = Math.floor((sw - panelW) / 2);
+    const oy = Math.floor((sh - panelH) / 2);
+    const padding = 10;
+    const listW = Math.floor(panelW * 0.45);
+    const rowH = 18;
+
+    const bg     = scene.add.rectangle(ox, oy, panelW, panelH, 0x0a0a1a, 0.95).setOrigin(0, 0);
+    const border = scene.add.rectangle(ox, oy, panelW, panelH).setOrigin(0, 0)
+      .setStrokeStyle(2, 0x4444aa).setFillStyle(0, 0);
+    this._titleText = scene.add.text(ox + panelW / 2, oy + 12, '', {
+      fontSize: '12px', color: '#aabbff', fontFamily: 'monospace',
+    }).setOrigin(0.5, 0);
+    const hint = scene.add.text(
+      ox + panelW / 2, oy + panelH - 16,
+      '[↑↓] Navegar  [Enter/E] Selecionar  [ESC] Fechar',
+      { fontSize: '9px', color: '#556688', fontFamily: 'monospace' },
+    ).setOrigin(0.5, 0);
+    const divLine = scene.add.rectangle(ox + listW, oy + 35, 1, panelH - 50, 0x4444aa, 0.5).setOrigin(0, 0);
+
+    for (let i = 0; i < this.OPTION_POOL; i++) {
+      const y = oy + 40 + i * (rowH + 3);
+      const bg2 = scene.add.rectangle(ox + padding, y, listW - padding * 2, rowH, 0x111133).setOrigin(0, 0);
+      const txt = scene.add.text(ox + padding + 6, y + 3, '', { fontSize: '10px', color: '#e2e8f0', fontFamily: 'monospace' });
+      const idx = i;
+      bg2.setInteractive().on('pointerdown', () => {
+        if (!this._visible) return;
+        EventBus.emit(EVENTS.DIALOG_OPTION_SELECTED, { index: idx, option: this._options[idx] });
+      });
+      this._optionBgs.push(bg2);
+      this._optionTexts.push(txt);
+    }
+
+    this._contentText = scene.add.text(
+      ox + listW + padding, oy + 50, '',
+      { fontSize: '10px', color: '#ccddee', fontFamily: 'monospace', wordWrap: { width: panelW - listW - padding * 2 } },
+    );
+
+    this._root.add([
+      bg, border, this._titleText, hint, divLine,
+      ...this._optionBgs, ...this._optionTexts,
+      this._contentText,
+    ]);
+  }
+
+  show(title: string, options: DialogOption[]): void {
+    this._options = options;
+    this._selectedIndex = 0;
+    this._titleText.setText(title);
+    this._visible = true;
+    this._root.setVisible(true);
+    this._dirty = true;
+  }
+
+  hide(): void { this._visible = false; this._root.setVisible(false); }
+  markDirty(): void { this._dirty = true; }
+  isDirty(): boolean { return this._dirty && this._visible; }
+  isVisible(): boolean { return this._visible; }
+
+  render(): void {
+    if (!this._dirty) return;
+    this._dirty = false;
+
+    for (let i = 0; i < this.OPTION_POOL; i++) {
+      const opt = this._options[i];
+      if (!opt) {
+        this._optionBgs[i].setFillStyle(0x0a0a1a);
+        this._optionTexts[i].setText('');
+        continue;
+      }
+      const selected = i === this._selectedIndex;
+      this._optionBgs[i].setFillStyle(selected ? 0x334477 : 0x111133);
+      this._optionTexts[i]
+        .setText(opt.label)
+        .setStyle({ fontSize: '10px', color: selected ? '#ffffff' : '#e2e8f0', fontFamily: 'monospace' });
+    }
+
+    const sel = this._options[this._selectedIndex];
+    this._contentText.setText(sel?.content ?? '');
+  }
+}

--- a/src/ui/InventoryPanel.ts
+++ b/src/ui/InventoryPanel.ts
@@ -1,0 +1,222 @@
+import * as Phaser from 'phaser';
+import { EQUIPMENT_SLOT_ORDER, EQUIPMENT_SLOT_LABELS } from '../types/equipment';
+import type { InventoryViewModel, InventoryItemViewModel, EquipmentSlotViewModel } from '../types/viewmodels';
+
+const DEPTH        = 500;
+const PANEL_BG     = 0x0a0a1a;
+const PANEL_BORDER = 0x4444aa;
+const SEL_COLOR    = 0x334477;
+const EMPTY_COLOR  = 0x111133;
+const TEXT_BASE: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '10px',
+  color: '#e2e8f0',
+  fontFamily: 'monospace',
+};
+const TEXT_DIM: Phaser.Types.GameObjects.Text.TextStyle = {
+  ...TEXT_BASE,
+  color: '#556688',
+};
+const TEXT_TITLE: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '11px',
+  color: '#aabbff',
+  fontFamily: 'monospace',
+};
+const TEXT_HINT: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '9px',
+  color: '#556688',
+  fontFamily: 'monospace',
+};
+
+export class InventoryPanel {
+  private _root: Phaser.GameObjects.Container;
+  private _dirty = false;
+  private _visible = false;
+
+  // Itens — pool fixo de texto reutilizável
+  private _itemTexts: Phaser.GameObjects.Text[] = [];
+  private _itemBgs: Phaser.GameObjects.Rectangle[] = [];
+
+  // Equipamentos
+  private _slotBgs: Phaser.GameObjects.Rectangle[]  = [];
+  private _slotTexts: Phaser.GameObjects.Text[]  = [];
+  private _slotValueTexts: Phaser.GameObjects.Text[] = [];
+
+  // Detalhes
+  private _detailName!: Phaser.GameObjects.Text;
+  private _detailDesc!: Phaser.GameObjects.Text;
+  private _detailActions!: Phaser.GameObjects.Text;
+
+  private readonly ITEM_POOL_SIZE = 20;
+  private readonly SLOT_COUNT     = 6;
+
+  constructor(scene: Phaser.Scene) {
+    this._root = scene.add.container(0, 0).setScrollFactor(0).setDepth(DEPTH).setVisible(false);
+    this._build(scene);
+  }
+
+  private _build(scene: Phaser.Scene): void {
+    const sw = scene.scale.width;
+    const sh = scene.scale.height;
+
+    const panelW = Math.floor(sw * 0.85);
+    const panelH = Math.floor(sh * 0.80);
+    const ox     = Math.floor((sw - panelW) / 2);
+    const oy     = Math.floor((sh - panelH) / 2);
+
+    const eqW      = Math.floor(panelW * 0.30);
+    const itemW    = Math.floor(panelW * 0.38);
+    const detailW  = panelW - eqW - itemW;
+    const innerH   = panelH - 40;
+    const rowH     = 16;
+    const padding  = 8;
+
+    // Fundo e borda principal
+    const bg = scene.add.rectangle(ox, oy, panelW, panelH, PANEL_BG, 0.95).setOrigin(0, 0);
+    const border = scene.add.rectangle(ox, oy, panelW, panelH).setOrigin(0, 0)
+      .setStrokeStyle(2, PANEL_BORDER).setFillStyle(0, 0);
+    const title = scene.add.text(ox + panelW / 2, oy + 10, 'INVENTÁRIO', TEXT_TITLE).setOrigin(0.5, 0);
+    const hint  = scene.add.text(ox + panelW / 2, oy + panelH - 16,
+      '[E] Equipar  [U] Usar  [D] Dropar  [ESC/I] Fechar', TEXT_HINT).setOrigin(0.5, 0);
+
+    // Divisórias
+    const divX1 = ox + eqW;
+    const divX2 = ox + eqW + itemW;
+    const divLine1 = scene.add.rectangle(divX1, oy + 30, 1, innerH, PANEL_BORDER, 0.5).setOrigin(0, 0);
+    const divLine2 = scene.add.rectangle(divX2, oy + 30, 1, innerH, PANEL_BORDER, 0.5).setOrigin(0, 0);
+
+    // Subtítulos das colunas
+    const eqLabel     = scene.add.text(ox + padding, oy + 30, 'EQUIPAMENTOS', { ...TEXT_BASE, color: '#8888cc' });
+    const itemLabel   = scene.add.text(divX1 + padding, oy + 30, 'ITENS', { ...TEXT_BASE, color: '#8888cc' });
+    const detailLabel = scene.add.text(divX2 + padding, oy + 30, 'DETALHES', { ...TEXT_BASE, color: '#8888cc' });
+
+    // Pool de slots de equipamento
+    for (let i = 0; i < this.SLOT_COUNT; i++) {
+      const y = oy + 48 + i * (rowH + 4);
+      const bg2 = scene.add.rectangle(ox + padding, y, eqW - padding * 2, rowH, EMPTY_COLOR).setOrigin(0, 0);
+      const label = scene.add.text(ox + padding + 4, y + 2, '', TEXT_DIM);
+      const value = scene.add.text(ox + eqW - padding - 4, y + 2, '', TEXT_DIM).setOrigin(1, 0);
+      this._slotBgs.push(bg2);
+      this._slotTexts.push(label);
+      this._slotValueTexts.push(value);
+    }
+
+    // Pool de itens do inventário
+    for (let i = 0; i < this.ITEM_POOL_SIZE; i++) {
+      const y = oy + 48 + i * (rowH + 2);
+      const itemBg = scene.add.rectangle(divX1 + padding, y, itemW - padding * 2, rowH, EMPTY_COLOR).setOrigin(0, 0);
+      const itemTxt = scene.add.text(divX1 + padding + 4, y + 2, '', TEXT_DIM);
+      this._itemBgs.push(itemBg);
+      this._itemTexts.push(itemTxt);
+    }
+
+    // Área de detalhes
+    this._detailName    = scene.add.text(divX2 + padding, oy + 48, '', { ...TEXT_BASE, color: '#ffffff' });
+    this._detailDesc    = scene.add.text(divX2 + padding, oy + 66, '', {
+      ...TEXT_BASE, color: '#aabbcc',
+      wordWrap: { width: detailW - padding * 2 },
+    });
+    this._detailActions = scene.add.text(divX2 + padding, oy + panelH - 60, '', {
+      ...TEXT_BASE, color: '#ffdd88',
+    });
+
+    this._root.add([
+      bg, border, title, hint, divLine1, divLine2,
+      eqLabel, itemLabel, detailLabel,
+      ...this._slotBgs, ...this._slotTexts, ...this._slotValueTexts,
+      ...this._itemBgs, ...this._itemTexts,
+      this._detailName, this._detailDesc, this._detailActions,
+    ]);
+  }
+
+  show(): void {
+    this._visible = true;
+    this._root.setVisible(true);
+    this._dirty = true;
+  }
+
+  hide(): void {
+    this._visible = false;
+    this._root.setVisible(false);
+  }
+
+  toggle(): void {
+    this._visible ? this.hide() : this.show();
+  }
+
+  isVisible(): boolean {
+    return this._visible;
+  }
+
+  markDirty(): void {
+    this._dirty = true;
+  }
+
+  isDirty(): boolean {
+    return this._dirty && this._visible;
+  }
+
+  render(vm: InventoryViewModel): void {
+    if (!this._dirty) return;
+    this._dirty = false;
+
+    this._renderEquipmentSlots(vm.slots);
+    this._renderItems(vm.items);
+    this._renderDetail(vm);
+  }
+
+  private _renderEquipmentSlots(slots: EquipmentSlotViewModel[]): void {
+    for (let i = 0; i < this.SLOT_COUNT; i++) {
+      const slot = slots[i];
+      if (!slot) {
+        this._slotTexts[i].setText('');
+        this._slotValueTexts[i].setText('');
+        continue;
+      }
+      const hasItem = slot.equippedItemId !== null;
+      const col = slot.isSelected ? SEL_COLOR : (hasItem ? 0x1a2a3a : EMPTY_COLOR);
+      this._slotBgs[i].setFillStyle(col, 1);
+      this._slotTexts[i]
+        .setText(slot.label)
+        .setStyle({ ...TEXT_BASE, color: hasItem ? '#aaddff' : '#445566' });
+      this._slotValueTexts[i]
+        .setText(hasItem ? slot.equippedItemName : '—')
+        .setStyle({ ...TEXT_BASE, color: hasItem ? '#ffffff' : '#334455' });
+    }
+  }
+
+  private _renderItems(items: InventoryItemViewModel[]): void {
+    for (let i = 0; i < this.ITEM_POOL_SIZE; i++) {
+      const item = items[i];
+      if (!item || item.id === null) {
+        this._itemBgs[i].setFillStyle(EMPTY_COLOR, 1);
+        this._itemTexts[i].setText('').setStyle(TEXT_DIM);
+        continue;
+      }
+      const col = item.isSelected ? SEL_COLOR : (item.isEquipped ? 0x1a3a1a : EMPTY_COLOR);
+      this._itemBgs[i].setFillStyle(col, 1);
+      const prefix = item.isEquipped ? '[E] ' : '     ';
+      this._itemTexts[i]
+        .setText(`${prefix}${item.displayName}`)
+        .setStyle({ ...TEXT_BASE, color: item.isSelected ? '#ffffff' : '#99bbcc' });
+    }
+  }
+
+  private _renderDetail(vm: InventoryViewModel): void {
+    if (!vm.selectedItemDetail) {
+      this._detailName.setText('');
+      this._detailDesc.setText('Selecione um item para ver detalhes.');
+      this._detailActions.setText('');
+      return;
+    }
+    const d = vm.selectedItemDetail;
+    this._detailName.setText(d.name);
+    this._detailDesc.setText(d.description || '(Sem descrição)');
+
+    const actionMap: Record<string, string> = {
+      equip: '[E] Equipar',
+      use:   '[U] Usar',
+      drop:  '[D] Dropar',
+    };
+    this._detailActions.setText(d.actions.map(a => actionMap[a]).join('\n'));
+  }
+}

--- a/src/ui/InventoryPanel.ts
+++ b/src/ui/InventoryPanel.ts
@@ -213,9 +213,10 @@ export class InventoryPanel {
     this._detailDesc.setText(d.description || '(Sem descrição)');
 
     const actionMap: Record<string, string> = {
-      equip: '[E] Equipar',
-      use:   '[U] Usar',
-      drop:  '[D] Dropar',
+      equip:   '[E] Equipar',
+      unequip: '[E] Desequipar',
+      use:     '[U] Usar',
+      drop:    '[D] Dropar',
     };
     this._detailActions.setText(d.actions.map(a => actionMap[a]).join('\n'));
   }

--- a/src/ui/LogPanel.ts
+++ b/src/ui/LogPanel.ts
@@ -1,0 +1,81 @@
+import * as Phaser from 'phaser';
+import { UI } from '../utils/constants';
+import type { LogViewModel } from '../types/viewmodels';
+
+const PADDING    = 8;
+const LINE_H     = 13;
+const FONT_STYLE: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '10px',
+  color: '#aaffaa',
+  fontFamily: 'monospace',
+  wordWrap: { width: 0 },  // updated on layout
+};
+
+export class LogPanel {
+  private _root: Phaser.GameObjects.Container;
+  private _bg: Phaser.GameObjects.Rectangle;
+  private _border: Phaser.GameObjects.Rectangle;
+  private _textPool: Phaser.GameObjects.Text[];
+  private _dirty = false;
+  private _panelW = 0;
+  private _panelH = 0;
+
+  constructor(scene: Phaser.Scene) {
+    this._root      = scene.add.container(0, 0).setScrollFactor(0).setDepth(190);
+    this._bg        = scene.add.rectangle(0, 0, 10, 10, UI.LOG_BG_COLOR, UI.LOG_ALPHA).setOrigin(0, 0);
+    this._border    = scene.add.rectangle(0, 0, 10, 10).setOrigin(0, 0).setStrokeStyle(1, UI.LOG_BORDER_COLOR).setFillStyle(0, 0);
+    this._textPool  = [];
+
+    for (let i = 0; i < UI.LOG_VISIBLE_LINES; i++) {
+      this._textPool.push(scene.add.text(PADDING, 0, '', FONT_STYLE).setScrollFactor(0));
+    }
+
+    this._root.add([this._bg, this._border, ...this._textPool]);
+    this.layout(scene.scale.width, scene.scale.height);
+  }
+
+  layout(screenW: number, screenH: number, reservedBottomHeight = 0): void {
+    this._panelW = Math.floor(screenW * UI.LOG_PANEL_WIDTH_FRACTION);
+    this._panelH = screenH - reservedBottomHeight;
+    this._bg.setSize(this._panelW, this._panelH);
+    this._border.setSize(this._panelW, this._panelH);
+
+    const wrapW = this._panelW - PADDING * 2;
+    const startY = this._panelH - PADDING - UI.LOG_VISIBLE_LINES * LINE_H;
+
+    this._textPool.forEach((t, i) => {
+      t.setPosition(PADDING, startY + i * LINE_H);
+      t.setStyle({ ...FONT_STYLE, wordWrap: { width: wrapW } });
+    });
+    this._dirty = true;
+  }
+
+  markDirty(): void {
+    this._dirty = true;
+  }
+
+  isDirty(): boolean {
+    return this._dirty;
+  }
+
+  render(vm: LogViewModel): void {
+    if (!this._dirty) return;
+    this._dirty = false;
+
+    const entries = vm.entries;
+    const offset  = UI.LOG_VISIBLE_LINES - entries.length;
+
+    this._textPool.forEach((t, i) => {
+      const entry = entries[i - offset];
+      if (entry) {
+        t.setText(entry.text).setAlpha(entry.alpha);
+      } else {
+        t.setText('').setAlpha(1);
+      }
+    });
+  }
+
+  setVisible(visible: boolean): void {
+    this._root.setVisible(visible);
+  }
+}

--- a/src/ui/LogPanel.ts
+++ b/src/ui/LogPanel.ts
@@ -2,32 +2,33 @@ import * as Phaser from 'phaser';
 import { UI } from '../utils/constants';
 import type { LogViewModel } from '../types/viewmodels';
 
-const PADDING    = 8;
-const LINE_H     = 13;
+const PADDING = 6;
+const LINE_H  = 13;
 const FONT_STYLE: Phaser.Types.GameObjects.Text.TextStyle = {
   fontSize: '10px',
   color: '#aaffaa',
   fontFamily: 'monospace',
-  wordWrap: { width: 0 },  // updated on layout
+  wordWrap: { width: 0 },
 };
 
 export class LogPanel {
-  private _root: Phaser.GameObjects.Container;
-  private _bg: Phaser.GameObjects.Rectangle;
-  private _border: Phaser.GameObjects.Rectangle;
+  private _root:     Phaser.GameObjects.Container;
+  private _bg:       Phaser.GameObjects.Rectangle;
+  private _border:   Phaser.GameObjects.Rectangle;
   private _textPool: Phaser.GameObjects.Text[];
-  private _dirty = false;
-  private _panelW = 0;
-  private _panelH = 0;
+  private _panelW  = 0;
+  private _textX   = PADDING;
+  private _boxY    = 0;
+  private _boxH    = 0;
 
   constructor(scene: Phaser.Scene) {
-    this._root      = scene.add.container(0, 0).setScrollFactor(0).setDepth(190);
-    this._bg        = scene.add.rectangle(0, 0, 10, 10, UI.LOG_BG_COLOR, UI.LOG_ALPHA).setOrigin(0, 0);
-    this._border    = scene.add.rectangle(0, 0, 10, 10).setOrigin(0, 0).setStrokeStyle(1, UI.LOG_BORDER_COLOR).setFillStyle(0, 0);
-    this._textPool  = [];
+    this._root     = scene.add.container(0, 0).setScrollFactor(0).setDepth(190);
+    this._bg       = scene.add.rectangle(0, 0, 10, 10, UI.LOG_BG_COLOR, UI.LOG_ALPHA).setOrigin(0, 0);
+    this._border   = scene.add.rectangle(0, 0, 10, 10).setOrigin(0, 0).setStrokeStyle(1, UI.LOG_BORDER_COLOR).setFillStyle(0, 0);
+    this._textPool = [];
 
     for (let i = 0; i < UI.LOG_VISIBLE_LINES; i++) {
-      this._textPool.push(scene.add.text(PADDING, 0, '', FONT_STYLE).setScrollFactor(0));
+      this._textPool.push(scene.add.text(0, 0, '', FONT_STYLE).setScrollFactor(0).setVisible(false));
     }
 
     this._root.add([this._bg, this._border, ...this._textPool]);
@@ -36,43 +37,36 @@ export class LogPanel {
 
   layout(screenW: number, screenH: number, reservedBottomHeight = 0): void {
     this._panelW = Math.floor(screenW * UI.LOG_PANEL_WIDTH_FRACTION);
-    this._panelH = screenH - reservedBottomHeight;
-    this._bg.setSize(this._panelW, this._panelH);
-    this._border.setSize(this._panelW, this._panelH);
+    const wrapW  = this._panelW - PADDING * 2;
+    this._boxH   = UI.LOG_VISIBLE_LINES * LINE_H + PADDING * 2;
+    this._boxY   = screenH - reservedBottomHeight - this._boxH;
+    this._textX  = PADDING;
 
-    const wrapW = this._panelW - PADDING * 2;
-    const startY = this._panelH - PADDING - UI.LOG_VISIBLE_LINES * LINE_H;
+    this._bg.setPosition(0, this._boxY).setSize(this._panelW, this._boxH);
+    this._border.setPosition(0, this._boxY).setSize(this._panelW, this._boxH);
 
-    this._textPool.forEach((t, i) => {
-      t.setPosition(PADDING, startY + i * LINE_H);
+    this._textPool.forEach(t => {
+      t.setPosition(this._textX, this._boxY);
       t.setStyle({ ...FONT_STYLE, wordWrap: { width: wrapW } });
+      t.setVisible(false);
     });
-    this._dirty = true;
-  }
-
-  markDirty(): void {
-    this._dirty = true;
-  }
-
-  isDirty(): boolean {
-    return this._dirty;
   }
 
   render(vm: LogViewModel): void {
-    if (!this._dirty) return;
-    this._dirty = false;
-
-    const entries = vm.entries;
-    const offset  = UI.LOG_VISIBLE_LINES - entries.length;
-
-    this._textPool.forEach((t, i) => {
-      const entry = entries[i - offset];
-      if (entry) {
-        t.setText(entry.text).setAlpha(entry.alpha);
-      } else {
-        t.setText('').setAlpha(1);
-      }
-    });
+    this._textPool.forEach(t => t.setVisible(false));
+    let y = this._boxY + this._boxH - PADDING;
+    let poolIdx = 0;
+    for (let i = vm.entries.length - 1; i >= 0 && poolIdx < this._textPool.length; i--) {
+      const entry = vm.entries[i];
+      const text  = this._textPool[poolIdx];
+      text.setText(entry.text).setAlpha(entry.alpha);
+      // After setText, text.height reflects actual wrapped height
+      y -= text.height + 2;
+      if (y < this._boxY + PADDING) break;
+      text.setPosition(this._textX, y);
+      text.setVisible(true);
+      poolIdx++;
+    }
   }
 
   setVisible(visible: boolean): void {

--- a/src/ui/ShopPanel.ts
+++ b/src/ui/ShopPanel.ts
@@ -1,0 +1,216 @@
+import * as Phaser from 'phaser';
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+import type { ShopViewModel } from '../types/viewmodels';
+
+const DEPTH        = 500;
+const PANEL_BG     = 0x0a0a1a;
+const PANEL_BORDER = 0x4444aa;
+const SEL_COLOR    = 0x334477;
+const EMPTY_COLOR  = 0x111133;
+const AFFORD_COLOR = 0x113311;
+const DIM_COLOR    = 0x221111;
+
+const TEXT_BASE: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '10px', color: '#e2e8f0', fontFamily: 'monospace',
+};
+const TEXT_DIM: Phaser.Types.GameObjects.Text.TextStyle = {
+  ...TEXT_BASE, color: '#556688',
+};
+const TEXT_TITLE: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '11px', color: '#aabbff', fontFamily: 'monospace',
+};
+const TEXT_HINT: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '9px', color: '#556688', fontFamily: 'monospace',
+};
+const TEXT_GOLD: Phaser.Types.GameObjects.Text.TextStyle = {
+  fontSize: '10px', color: '#ffd700', fontFamily: 'monospace',
+};
+
+const RARITY_COLORS: Record<string, string> = {
+  common:   '#aaaaaa',
+  uncommon: '#55ff55',
+  rare:     '#aaaaff',
+};
+
+export class ShopPanel {
+  private _root: Phaser.GameObjects.Container;
+  private _dirty  = false;
+  private _visible = false;
+
+  private _itemBgs:    Phaser.GameObjects.Rectangle[] = [];
+  private _itemTexts:  Phaser.GameObjects.Text[] = [];
+  private _itemPrices: Phaser.GameObjects.Text[] = [];
+
+  private _goldLabel!:    Phaser.GameObjects.Text;
+  private _detailName!:   Phaser.GameObjects.Text;
+  private _detailBonus!:  Phaser.GameObjects.Text;
+  private _detailRarity!: Phaser.GameObjects.Text;
+  private _detailPrice!:  Phaser.GameObjects.Text;
+
+  private _tabBuyBg!:  Phaser.GameObjects.Rectangle;
+  private _tabSellBg!: Phaser.GameObjects.Rectangle;
+  private _tabBuyTxt!: Phaser.GameObjects.Text;
+  private _tabSellTxt!: Phaser.GameObjects.Text;
+
+  private readonly ITEM_POOL_SIZE = 20;
+  private readonly ROW_H = 16;
+
+  constructor(scene: Phaser.Scene) {
+    this._root = scene.add.container(0, 0).setScrollFactor(0).setDepth(DEPTH).setVisible(false);
+    this._build(scene);
+  }
+
+  private _build(scene: Phaser.Scene): void {
+    const sw = scene.scale.width;
+    const sh = scene.scale.height;
+
+    const panelW = Math.floor(sw * 0.85);
+    const panelH = Math.floor(sh * 0.80);
+    const ox     = Math.floor((sw - panelW) / 2);
+    const oy     = Math.floor((sh - panelH) / 2);
+    const padding = 8;
+    const listW  = Math.floor(panelW * 0.55);
+    const detailW = panelW - listW;
+    const rowH    = this.ROW_H;
+
+    const bg     = scene.add.rectangle(ox, oy, panelW, panelH, PANEL_BG, 0.95).setOrigin(0, 0);
+    const border = scene.add.rectangle(ox, oy, panelW, panelH).setOrigin(0, 0)
+      .setStrokeStyle(2, PANEL_BORDER).setFillStyle(0, 0);
+    const title  = scene.add.text(ox + panelW / 2, oy + 10, 'LOJA', TEXT_TITLE).setOrigin(0.5, 0);
+    const hint   = scene.add.text(
+      ox + panelW / 2, oy + panelH - 16,
+      '[←→] Aba  [E/Enter] Comprar  [V] Vender  [ESC] Fechar',
+      TEXT_HINT,
+    ).setOrigin(0.5, 0);
+
+    // Tab headers
+    const tabW = Math.floor(listW / 2) - padding;
+    this._tabBuyBg  = scene.add.rectangle(ox + padding, oy + 26, tabW, 14, 0x334477).setOrigin(0, 0);
+    this._tabSellBg = scene.add.rectangle(ox + padding + tabW + 4, oy + 26, tabW, 14, EMPTY_COLOR).setOrigin(0, 0);
+    this._tabBuyTxt  = scene.add.text(ox + padding + tabW / 2, oy + 28, 'Comprar', { ...TEXT_BASE, fontSize: '9px' }).setOrigin(0.5, 0);
+    this._tabSellTxt = scene.add.text(ox + padding + tabW + 4 + tabW / 2, oy + 28, 'Vender', { ...TEXT_DIM, fontSize: '9px' }).setOrigin(0.5, 0);
+
+    const divLine = scene.add.rectangle(ox + listW, oy + 30, 1, panelH - 40, PANEL_BORDER, 0.5).setOrigin(0, 0);
+    const detailLabel = scene.add.text(ox + listW + padding, oy + 30, 'DETALHES', { ...TEXT_BASE, color: '#8888cc' });
+
+    for (let i = 0; i < this.ITEM_POOL_SIZE; i++) {
+      const y = oy + 48 + i * (rowH + 2);
+      const idx = i;
+      const itemBg    = scene.add.rectangle(ox + padding, y, listW - padding * 2, rowH, EMPTY_COLOR).setOrigin(0, 0);
+      const itemTxt   = scene.add.text(ox + padding + 4, y + 2, '', TEXT_DIM);
+      const priceTxt  = scene.add.text(ox + listW - padding - 4, y + 2, '', TEXT_DIM).setOrigin(1, 0);
+      itemBg
+        .setInteractive()
+        .on('pointerover', () => EventBus.emit(EVENTS.SHOP_ITEM_HOVERED, { index: idx }))
+        .on('pointerdown', () => EventBus.emit(EVENTS.SHOP_ITEM_SELECTED, { index: idx }));
+      this._itemBgs.push(itemBg);
+      this._itemTexts.push(itemTxt);
+      this._itemPrices.push(priceTxt);
+    }
+
+    const dx = ox + listW + padding;
+    this._goldLabel   = scene.add.text(dx, oy + 48, '', TEXT_GOLD);
+    this._detailName  = scene.add.text(dx, oy + 68, '', { ...TEXT_BASE, color: '#ffffff' });
+    this._detailRarity = scene.add.text(dx, oy + 84, '', TEXT_DIM);
+    this._detailBonus = scene.add.text(dx, oy + 100, '', { ...TEXT_BASE, color: '#88ffaa', wordWrap: { width: detailW - padding * 2 } });
+    this._detailPrice = scene.add.text(dx, oy + 132, '', TEXT_GOLD);
+
+    this._root.add([
+      bg, border, title, hint, divLine,
+      this._tabBuyBg, this._tabSellBg, this._tabBuyTxt, this._tabSellTxt,
+      detailLabel,
+      ...this._itemBgs, ...this._itemTexts, ...this._itemPrices,
+      this._goldLabel, this._detailName, this._detailRarity, this._detailBonus, this._detailPrice,
+    ]);
+  }
+
+  show(): void  { this._visible = true;  this._root.setVisible(true);  this._dirty = true; }
+  hide(): void  { this._visible = false; this._root.setVisible(false); }
+  markDirty():  void { this._dirty = true; }
+  isDirty():    boolean { return this._dirty && this._visible; }
+  isVisible():  boolean { return this._visible; }
+
+  render(vm: ShopViewModel): void {
+    if (!this._dirty) return;
+    this._dirty = false;
+
+    this._goldLabel.setText(`Suas moedas: ${vm.playerGold}`);
+
+    // Update tab headers
+    const isBuy = vm.tab === 'buy';
+    this._tabBuyBg.setFillStyle(isBuy ? 0x334477 : EMPTY_COLOR);
+    this._tabSellBg.setFillStyle(!isBuy ? 0x334477 : EMPTY_COLOR);
+    this._tabBuyTxt.setStyle({ ...TEXT_BASE, fontSize: '9px', color: isBuy ? '#ffffff' : '#556688' });
+    this._tabSellTxt.setStyle({ ...TEXT_BASE, fontSize: '9px', color: !isBuy ? '#ffffff' : '#556688' });
+
+    if (vm.tab === 'sell') {
+      const sellItems = vm.sellItems;
+      for (let i = 0; i < this.ITEM_POOL_SIZE; i++) {
+        const entry = sellItems[i];
+        if (!entry) {
+          this._itemBgs[i].setFillStyle(EMPTY_COLOR);
+          this._itemTexts[i].setText('');
+          this._itemPrices[i].setText('');
+          continue;
+        }
+        const col = entry.isSelected ? SEL_COLOR : (entry.canSell ? EMPTY_COLOR : DIM_COLOR);
+        this._itemBgs[i].setFillStyle(col);
+        this._itemTexts[i]
+          .setText(entry.name)
+          .setStyle({ ...TEXT_BASE, color: entry.canSell ? (entry.isSelected ? '#ffffff' : '#e2e8f0') : '#443333' });
+        this._itemPrices[i]
+          .setText(entry.canSell ? `${entry.sellPrice}g` : 'Eqp')
+          .setStyle({ ...TEXT_BASE, color: entry.canSell ? '#ffd700' : '#443333' });
+      }
+      const sel = sellItems[vm.selectedIndex];
+      if (sel) {
+        this._detailName.setText(sel.name);
+        this._detailRarity.setText(sel.canSell ? 'Pode vender' : 'Equipado — não pode vender').setStyle({ ...TEXT_BASE, color: sel.canSell ? '#88ffaa' : '#ff8888' });
+        this._detailBonus.setText('');
+        this._detailPrice.setText(sel.canSell ? `Venda: ${sel.sellPrice}g` : '');
+      } else {
+        this._detailName.setText('');
+        this._detailRarity.setText('');
+        this._detailBonus.setText('Selecione um item.');
+        this._detailPrice.setText('');
+      }
+    } else {
+      const buyItems = vm.buyItems ?? vm.items;
+      for (let i = 0; i < this.ITEM_POOL_SIZE; i++) {
+        const entry = buyItems[i];
+        if (!entry) {
+          this._itemBgs[i].setFillStyle(EMPTY_COLOR);
+          this._itemTexts[i].setText('');
+          this._itemPrices[i].setText('');
+          continue;
+        }
+
+        const col = entry.isSelected
+          ? SEL_COLOR
+          : (entry.canAfford ? AFFORD_COLOR : EMPTY_COLOR);
+        this._itemBgs[i].setFillStyle(col);
+        const rarityColor = RARITY_COLORS[entry.rarity] ?? '#aaaaaa';
+        this._itemTexts[i]
+          .setText(entry.name)
+          .setStyle({ ...TEXT_BASE, color: entry.isSelected ? '#ffffff' : rarityColor });
+        this._itemPrices[i]
+          .setText(`${entry.price}g`)
+          .setStyle({ ...TEXT_BASE, color: entry.canAfford ? '#ffd700' : '#885533' });
+      }
+
+      const sel = (buyItems)[vm.selectedIndex];
+      if (sel) {
+        this._detailName.setText(sel.name);
+        this._detailRarity.setText(`Raridade: ${sel.rarity}`).setStyle({ ...TEXT_BASE, color: RARITY_COLORS[sel.rarity] ?? '#aaaaaa' });
+        this._detailBonus.setText(sel.bonusText !== '—' ? `Bônus: ${sel.bonusText}` : 'Sem bônus');
+        this._detailPrice.setText(`Preço: ${sel.price}g`);
+      } else {
+        this._detailName.setText('');
+        this._detailRarity.setText('');
+        this._detailBonus.setText('Selecione um item.');
+        this._detailPrice.setText('');
+      }
+    }
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -81,6 +81,11 @@ export const SPRITES = {
   PLATINO: 'reptiles',
   POTION: 'potion',
   MONEY: 'money',
+  // Cidade
+  TREE0:      'tree0',
+  DECOR0:     'decor0',
+  HUMANOID0:  'humanoid0',
+  CAT0:       'cat0',
 } as const;
 
 // --- Cores de fallback (usadas se assets não carregarem) ---
@@ -156,17 +161,40 @@ export const EVENTS = {
   ITEM_UNEQUIPPED:  'item-unequipped',
   // Input
   INPUT_MODE_CHANGED: 'input-mode-changed',
+  // Seleção de inventário
+  INVENTORY_SELECTION_CHANGED: 'inventory-selection-changed',
+  // Moedas
+  PLAYER_GOLD_CHANGED: 'player-gold-changed',
+  // Loja
+  SHOP_OPENED:  'shop-opened',
+  SHOP_CLOSED:  'shop-closed',
+  SHOP_UPDATED: 'shop-updated',
+  SHOP_ITEM_HOVERED:      'shop-item-hovered',
+  SHOP_ITEM_SELECTED:     'shop-item-selected',
+  // Diálogo
+  DIALOG_OPENED:          'dialog-opened',
+  DIALOG_CLOSED:          'dialog-closed',
+  DIALOG_OPTION_SELECTED: 'dialog-option-selected',
 } as const;
+
+// --- Loja ---
+export const SHOP = {
+  SELL_RATIO: 0.4,
+} as const;
+
+// --- Taverna ---
+export const TAVERN = { REST_COST: 20 } as const;
 
 // --- Cidade (hub) ---
 export const TOWN = {
-  WIDTH:       24,
-  HEIGHT:      20,
-  START_X:     12,
-  START_Y:     8,
-  EXIT_X:      12,
-  EXIT_Y:      18,
-  FLOOR_FRAME: 16,  // grama verde do Ground0.png
+  WIDTH:            24,
+  HEIGHT:           20,
+  START_X:          12,
+  START_Y:          8,
+  EXIT_X:           12,
+  EXIT_Y:           18,
+  FLOOR_FRAME:      16,  // grama verde do Ground0.png
+  STONE_PATH_FRAME: 1,   // pedra cinza do Ground0.png (caminho central)
 } as const;
 
 // --- Loot ---

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -140,6 +140,22 @@ export const EVENTS = {
   ITEM_USED: 'item-used',
   ITEM_DROPPED: 'item-dropped',
   AREA_CHANGED: 'area-changed',
+  // Transições de mapa
+  MAP_TRANSITION_STARTED:    'map-transition-started',
+  MAP_TRANSITION_COMPLETED:  'map-transition-completed',
+  // Andares de dungeon
+  FLOOR_CHANGED:  'floor-changed',
+  FLOOR_DESCEND:  'floor-descend',
+  FLOOR_ASCEND:   'floor-ascend',
+  // Inventário e equipamentos
+  INVENTORY_OPENED:           'inventory-opened',
+  INVENTORY_CLOSED:           'inventory-closed',
+  INVENTORY_STATE_REQUESTED:  'inventory-state-requested',
+  INVENTORY_STATE_RESPONSE:   'inventory-state-response',
+  ITEM_EQUIPPED:    'item-equipped',
+  ITEM_UNEQUIPPED:  'item-unequipped',
+  // Input
+  INPUT_MODE_CHANGED: 'input-mode-changed',
 } as const;
 
 // --- Cidade (hub) ---
@@ -159,6 +175,16 @@ export const LOOT = {
   CHANCE_HEAL:     0.30,  // acumulado: 0–0.30
   CHANCE_POISON:   0.20,  // acumulado: 0.30–0.50
   CHANCE_GOLD:     0.10,  // acumulado: 0.50–0.60
+} as const;
+
+// --- UI ---
+export const UI = {
+  LOG_PANEL_WIDTH_FRACTION: 0.33,
+  LOG_VISIBLE_LINES: 12,
+  LOG_MAX_HISTORY: 50,
+  LOG_BG_COLOR: 0x0a0a1a,
+  LOG_BORDER_COLOR: 0x4444aa,
+  LOG_ALPHA: 0.75,
 } as const;
 
 // --- IA Generativa ---

--- a/tests/enemy.test.js
+++ b/tests/enemy.test.js
@@ -87,13 +87,13 @@ describe('createEnemies', () => {
 
   it('cria o número correto de inimigos', () => {
     const dungeon = makeDungeon();
-    const enemies = createEnemies(dungeon, 3, dungeon.startPos);
+    const enemies = createEnemies(dungeon, dungeon.startPos, { enemyCount: 3, enemyHpMultiplier: 1, enemyAtkMultiplier: 1, lootQualityBonus: 0 });
     expect(enemies.length).toBe(3);
   });
 
   it('todos os inimigos iniciam vivos', () => {
     const dungeon = makeDungeon();
-    const enemies = createEnemies(dungeon, 4, dungeon.startPos);
+    const enemies = createEnemies(dungeon, dungeon.startPos, { enemyCount: 4, enemyHpMultiplier: 1, enemyAtkMultiplier: 1, lootQualityBonus: 0 });
     enemies.forEach((e) => expect(e.alive).toBe(true));
   });
 });

--- a/tests/shop.test.js
+++ b/tests/shop.test.js
@@ -1,0 +1,233 @@
+/**
+ * shop.test.js — Testes do ShopSystem e bônus de equipamento do Player
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ShopSystem } from '../src/systems/ShopSystem';
+import { InventorySystem } from '../src/systems/InventorySystem';
+import { Item } from '../src/entities/Item';
+import { SHOP_CATALOG, createItemFromCatalogEntry, buildBonusText } from '../src/config/shop.catalog';
+import { EventBus } from '../src/utils/EventBus';
+
+// Mock do EventBus para não depender de cena Phaser
+vi.spyOn(EventBus, 'emit').mockImplementation(() => EventBus);
+
+// Player mínimo para os testes
+function makePlayer(gold = 500) {
+  const _bonuses = {};
+  return {
+    gold,
+    hp: 93,
+    maxHp: 93,
+    attack: 10,
+    con: 18,
+    wis: 10,
+    intel: 10,
+    level: 1,
+    _equipmentBonuses: _bonuses,
+    recalcStats() {
+      this.maxHp  = this.con * 5 + this.level * 3 + (this._equipmentBonuses.maxHp ?? 0);
+      this.attack = 10 + (this._equipmentBonuses.attack ?? 0);
+      this.hp     = Math.min(this.hp, this.maxHp);
+    },
+    applyEquipmentBonuses(bonuses) {
+      for (const key of Object.keys(bonuses)) {
+        this._equipmentBonuses[key] = (this._equipmentBonuses[key] ?? 0) + (bonuses[key] ?? 0);
+      }
+      this.recalcStats();
+    },
+    removeEquipmentBonuses(bonuses) {
+      for (const key of Object.keys(bonuses)) {
+        this._equipmentBonuses[key] = (this._equipmentBonuses[key] ?? 0) - (bonuses[key] ?? 0);
+      }
+      this.recalcStats();
+    },
+  };
+}
+
+// ─── createItemFromCatalogEntry ───────────────────────────────────────────────
+
+describe('createItemFromCatalogEntry', () => {
+  it('cria item com campos corretos', () => {
+    const entry = SHOP_CATALOG.find(e => e.id === 'sword_iron_1');
+    const item = createItemFromCatalogEntry(entry);
+    expect(item.name).toBe('Espada de Ferro');
+    expect(item.slotId).toBe('sword');
+    expect(item.price).toBe(120);
+    expect(item.rarity).toBe('common');
+    expect(item.bonuses.attack).toBe(3);
+  });
+
+  it('poção de cura chegam identificadas', () => {
+    const entry = SHOP_CATALOG.find(e => e.id === 'potion_heal_shop');
+    const item = createItemFromCatalogEntry(entry);
+    expect(item.identified).toBe(true);
+  });
+});
+
+// ─── buildBonusText ───────────────────────────────────────────────────────────
+
+describe('buildBonusText', () => {
+  it('formata bônus corretamente', () => {
+    expect(buildBonusText({ attack: 3 })).toBe('+3 ATK');
+    expect(buildBonusText({ maxHp: 10, con: 2 })).toBe('+10 HP, +2 CON');
+    expect(buildBonusText({})).toBe('—');
+  });
+});
+
+// ─── ShopSystem — compra ──────────────────────────────────────────────────────
+
+describe('ShopSystem — buyItem', () => {
+  let shop, inv, player;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shop   = new ShopSystem(SHOP_CATALOG);
+    inv    = new InventorySystem();
+    player = makePlayer(500);
+  });
+
+  it('compra com sucesso quando tem ouro suficiente', () => {
+    const idx = SHOP_CATALOG.findIndex(e => e.id === 'sword_iron_1'); // preço 120
+    const result = shop.buyItem(player, idx, inv);
+    expect(result.success).toBe(true);
+    expect(player.gold).toBe(380);
+    expect(inv.count()).toBe(1);
+  });
+
+  it('falha quando ouro insuficiente', () => {
+    player.gold = 50;
+    const idx = SHOP_CATALOG.findIndex(e => e.id === 'sword_iron_1'); // preço 120
+    const result = shop.buyItem(player, idx, inv);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('insuficiente');
+    expect(player.gold).toBe(50);
+    expect(inv.count()).toBe(0);
+  });
+
+  it('falha quando inventário cheio', () => {
+    // Encher o inventário com 20 poções
+    for (let i = 0; i < 20; i++) {
+      inv.addItem(new Item(`p${i}`, 'potion_heal', null, null));
+    }
+    const idx = SHOP_CATALOG.findIndex(e => e.id === 'potion_heal_shop');
+    const result = shop.buyItem(player, idx, inv);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('cheio');
+  });
+
+  it('emite PLAYER_GOLD_CHANGED após compra', () => {
+    const idx = SHOP_CATALOG.findIndex(e => e.id === 'potion_heal_shop'); // preço 30
+    shop.buyItem(player, idx, inv);
+    expect(EventBus.emit).toHaveBeenCalledWith('player-gold-changed', { gold: 470 });
+  });
+});
+
+// ─── ShopSystem — venda ───────────────────────────────────────────────────────
+
+describe('ShopSystem — sellItem', () => {
+  let shop, inv, player;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shop   = new ShopSystem(SHOP_CATALOG);
+    inv    = new InventorySystem();
+    player = makePlayer(100);
+  });
+
+  it('vende item com preço e adiciona 40% do valor ao ouro', () => {
+    const item = new Item('sword1', 'sword_iron', null, null);
+    item.name  = 'Espada de Ferro';
+    item.price = 120;
+    inv.addItem(item);
+
+    const result = shop.sellItem(player, 0, inv);
+    expect(result.success).toBe(true);
+    expect(result.goldGained).toBe(48); // floor(120 * 0.4)
+    expect(player.gold).toBe(148);
+    expect(inv.count()).toBe(0);
+  });
+
+  it('falha ao vender item sem preço', () => {
+    const item = new Item('p1', 'potion_heal', null, null);
+    // price = undefined
+    inv.addItem(item);
+    const result = shop.sellItem(player, 0, inv);
+    expect(result.success).toBe(false);
+    expect(result.goldGained).toBe(0);
+    expect(player.gold).toBe(100);
+  });
+
+  it('falha ao vender slot vazio', () => {
+    const result = shop.sellItem(player, 5, inv);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Player — applyEquipmentBonuses / removeEquipmentBonuses ─────────────────
+
+describe('Player — bônus de equipamento', () => {
+  it('aplica bônus de ataque', () => {
+    const p = makePlayer();
+    p.applyEquipmentBonuses({ attack: 6 });
+    expect(p.attack).toBe(16);
+  });
+
+  it('aplica bônus de maxHp e não ultrapassa hp', () => {
+    const p = makePlayer();
+    p.hp = 50;
+    p.applyEquipmentBonuses({ maxHp: 20 });
+    expect(p.maxHp).toBe(113); // 18*5 + 1*3 + 20
+    expect(p.hp).toBe(50); // hp não sobe sozinho
+  });
+
+  it('hp é clamped para maxHp se maxHp cair', () => {
+    const p = makePlayer();
+    p.applyEquipmentBonuses({ maxHp: 20 });
+    p.hp = p.maxHp; // full hp com bônus
+    p.removeEquipmentBonuses({ maxHp: 20 });
+    expect(p.maxHp).toBe(93);
+    expect(p.hp).toBe(93); // clamped para novo maxHp
+  });
+
+  it('remove bônus corretamente revertendo stats', () => {
+    const p = makePlayer();
+    p.applyEquipmentBonuses({ attack: 5, con: 2 });
+    expect(p.attack).toBe(15);
+    p.removeEquipmentBonuses({ attack: 5, con: 2 });
+    expect(p.attack).toBe(10);
+  });
+
+  it('múltiplos equipamentos acumulam corretamente', () => {
+    const p = makePlayer();
+    p.applyEquipmentBonuses({ attack: 3 });
+    p.applyEquipmentBonuses({ attack: 6 });
+    expect(p.attack).toBe(19);
+    p.removeEquipmentBonuses({ attack: 3 });
+    expect(p.attack).toBe(16);
+  });
+});
+
+// ─── ShopSystem — buildViewModel ─────────────────────────────────────────────
+
+describe('ShopSystem — buildViewModel', () => {
+  it('marca item selecionado corretamente', () => {
+    const shop = new ShopSystem(SHOP_CATALOG);
+    const player = makePlayer(200);
+    const vm = shop.buildViewModel(player, 2);
+    expect(vm.items[2].isSelected).toBe(true);
+    expect(vm.items[0].isSelected).toBe(false);
+    expect(vm.selectedIndex).toBe(2);
+    expect(vm.playerGold).toBe(200);
+  });
+
+  it('canAfford reflete ouro do player', () => {
+    const shop = new ShopSystem(SHOP_CATALOG);
+    const player = makePlayer(25); // menos que qualquer item exceto poções
+    const vm = shop.buildViewModel(player, 0);
+    // Todos os itens com price > 25 devem ter canAfford=false
+    vm.items.forEach(item => {
+      if (item.price > 25) expect(item.canAfford).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Descrição

Implementa o sistema completo de comércio e equipamentos, evolui a interatividade da cidade (diálogos, gato vagante, Taberneiro com descanso) e corrige falhas críticas de gerenciamento de estado entre os modos de input SHOP, INVENTORY e GAMEPLAY que travavam o jogo após compras.

---

## Tipo de mudança

- [x] `feat` — nova funcionalidade
- [x] `fix` — correção de bug

---

## O que foi feito

- `ShopSystem`: lógica de compra e venda catalog-driven com 18 itens (espadas, capacetes, escudos, calças, botas, amuletos, poções); `buildViewModel()` e `buildSellItems()` sem acoplamento à UI
- `EquipmentSystem` + bônus reversíveis: `Player.applyEquipmentBonuses()` / `removeEquipmentBonuses()` acumulam em `_equipmentBonuses`; `recalcStats()` é a fonte de verdade dos stats derivados
- `ShopPanel` com 2 abas (Comprar / Vender), mouse hover + click, pool de linhas reutilizáveis e painel de detalhes com raridade/bônus/preço
- `DialogPanel` genérico: Guard abre menu de ajuda (objetivos, controles, dicas); Taberneiro (renomeado) oferece descanso por 20 ouros restaurando HP+Mana
- Gato vagante: posição corrigida para tile FLOOR (3,9), `customWanderBounds` dedicado, FSM wander reativado no `NPCController`
- Gold no HUD: começa com 500, atualizado em tempo real via `PLAYER_GOLD_CHANGED`
- **Fix crítico**: `INVENTORY_STATE_RESPONSE` não abre mais o painel — `INVENTORY_OPENED` é o único evento autorizado; removidas chamadas `_emitInventoryState()` das operações de loja
- **Fix crítico**: ESC e tecla I usam `inputMode.pop()` em vez de `set('GAMEPLAY')`, limpando corretamente a stack do `InputModeManager`
- Desequipar: `E` em item já equipado o desequipa (toggle); novo `_unequipSelectedItem()` com reversão de bônus
- Ações corretas no painel de detalhes do inventário: `[E] Equipar` / `[E] Desequipar` / `[U] Usar` / `[D] Dropar` conforme tipo do item
- Fix log multiline: `LogPanel.render()` reescrito com renderização bottom-up usando `text.height` real após `setText()` — elimina sobreposição de mensagens longas
- Fix foco de teclado: `BLUR`/`FOCUS` do jogo chamam `keyboard.resetKeys()` — previne teclas "presas" após alt+tab
- Atualizado `CHANGELOG.md`, `.kiro/specs/` e `docs/prompts/Vitor.md`

---

## Como testar

1. `npm install`
2. `npm run dev`
3. Interagir com o **Mercador** (tecla `T` adjacente ao edifício) — loja deve abrir com aba Comprar
4. Comprar um item (`E` ou `Enter`) — inventário **não deve abrir automaticamente**; ouro deve diminuir no HUD
5. Pressionar `ESC` — loja fecha, personagem pode se mover normalmente
6. Pressionar `I` — inventário abre; direcionais navegam itens (não movem o personagem)
7. Selecionar item equipável e pressionar `E` — item equipado, stats atualizados; pressionar `E` novamente no mesmo item — desequipa
8. Pressionar `ESC` — inventário fecha, personagem volta a se mover
9. Pressionar `←` / `→` na loja para trocar entre abas Comprar e Vender
10. Interagir com o **Guarda** — `DialogPanel` abre com 4 opções de ajuda; `ESC` fecha
11. Interagir com o **Taberneiro** — menu de descanso; "Repousar (20 ouros)" restaura HP e Mana (confirmar no HUD)
12. Observar o **Gato** vagando pela praça sem atravessar paredes
13. `npx vitest run` — 17 testes devem passar

---

## Evidências

npx vitest run tests/shop.test.js

✓ tests/shop.test.js (17 tests) 11ms

Test Files  1 passed (1)
Tests  17 passed (17)



---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/Vitor.md` (se usei IA neste PR)
- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser

---

## Observações

**Causa raiz do bug de inventário**: `UIScene` chamava `_inventoryPanel.show()` em todo `INVENTORY_STATE_RESPONSE`. Esse evento também era emitido por operações de compra na loja, abrindo o inventário enquanto o modo ainda era SHOP. Após o ESC fechar a loja, o painel ficava visível com o GameScene em GAMEPLAY — fazendo os direcionais mover o personagem em vez de navegar o inventário.

**Regra arquitetural estabelecida**: `INVENTORY_OPENED` é o único evento que autoriza `show()` no painel de inventário. `INVENTORY_STATE_RESPONSE` apenas atualiza dados internos.

**Bônus de equipamento são 100% reversíveis**: `Player._equipmentBonuses` acumula todos os bônus ativos; `recalcStats()` recalcula `maxHp` e `attack` do zero a cada equip/desequip — nunca muta os stats base.