### PR TITLE
feat: melhorias nas dungoes e mecanicas no jogo

### DIFF
--- a/.kiro/specs/product.md
+++ b/.kiro/specs/product.md
@@ -34,7 +34,10 @@ Input do jogador → Resolve ação → Atualiza visão (FOG) → Turno dos inim
 | Sistema | Responsabilidade |
 |---------|-----------------|
 | PlayerSystem | Atributos, HP/Mana, gold, bônus de equipamento acumulados em `_equipmentBonuses`; `recalcStats()` como fonte de verdade |
-| DungeonSystem | Geração procedural BSP, tiles, FOG of War |
+| DungeonSystem | Geração procedural BSP, múltiplos andares com cache |
+| AutoTileResolver | Interpreta vizinhos cardinais → `TileRenderData`; puro, sem Phaser |
+| DungeonRenderer | Itera grid + tema → `RenderCommand[]`; sem conhecer a Scene |
+| BonusAreaRenderer | Renderiza área bônus com debug e overrides isolados |
 | EnemySystem | Spawn, estados de IA (IDLE/CHASING/ATTACKING) |
 | CombatSystem | Resolução de ataque, dano, morte |
 | XPSystem | Ganho de XP, cálculo de nível, level up |
@@ -70,9 +73,17 @@ Input do jogador → Resolve ação → Atualiza visão (FOG) → Turno dos inim
 
 ### Dungeon
 - Geração por BSP (Binary Space Partitioning) com corredores L-shaped
-- FOG of War: tiles não visitados escuros, visitados em cinza, visíveis em destaque
-- Escadas de entrada e saída em cada andar
-- Temas visuais por faixa de andares (caverna, ruínas, cripta)
+- Múltiplos andares com cache de estado por andar: inimigos reiniciam, itens persistem
+- Escadas bidirecionais: descida (andar N+1), subida (andar N-1), retorno à cidade pelo andar 1
+- **Autotiling semântico**: `AutoTileResolver` interpreta vizinhos cardinais e escolhe frame — face, cantos externos, cantos côncavos, corpo sólido
+- **Temas visuais por andar**: andares 1–2 Dungeon (pedra cinza), 3–4 Mine (terra), 5–6 Underworld (pedra escura), 7+ Underworld Boss (mix abismo)
+- `DungeonRenderer` emite `RenderCommand[]` — `GameScene` apenas cria sprites; arquitetura extensível para novas categorias (water, lava, chasm)
+- FOG of War: spec pronta em `.kiro/specs/fog-of-war.spec.md` (não implementado)
+
+### Área Bônus
+- Mapa 30×22 tiles em game(12,0), acessível pela entrada norte da cidade
+- `BonusAreaRenderer` com sistema de overrides próprio (`BONUS_AREA_OVERRIDES`) isolado da cidade
+- Debug de tiles idêntico à cidade: labels `x,y`, toggle ON/OFF, clique exibe coordenadas e override atual
 
 ### Cidade (Town)
 

--- a/.kiro/specs/world.spec.md
+++ b/.kiro/specs/world.spec.md
@@ -8,10 +8,22 @@ O WorldSystem gerencia o estado do mundo entre transições de área dentro de u
 
 ## Áreas
 
-| Área     | Mapa           | Inimigos | Itens           |
-|----------|----------------|----------|-----------------|
-| `town`   | Fixo (TownMap) | Nenhum   | Nenhum          |
-| `dungeon`| BSP procedural | Sim (respawn sempre) | Sim (persistem) |
+| Área     | Mapa                        | Inimigos              | Itens              |
+|----------|-----------------------------|-----------------------|--------------------|
+| `town`   | Fixo (TownMap, TMX)         | Nenhum                | Nenhum             |
+| `dungeon`| BSP procedural, N andares   | Sim (respawn sempre)  | Sim (persistem por andar) |
+| `bonus`  | Fixo (BonusAreaRenderer, 30×22) | Nenhum           | Nenhum             |
+
+### Transições
+
+| De → Para | Gatilho |
+|-----------|---------|
+| `town` → `dungeon` | tile com `entrarDungeon: true` em `MANUAL_MAP_OVERRIDES` |
+| `dungeon` → `town` | escada para cima no andar 1 |
+| `dungeon` → `dungeon` (N+1) | tile `stairDown` da feature generator |
+| `dungeon` → `dungeon` (N-1) | tile `stairUp` da feature generator |
+| `town` → `bonus` | game(12,0) — borda norte da cidade |
+| `bonus` → `town` | `player.gridY >= BONUS_H - 1` (borda sul da área) |
 
 ---
 

--- a/.kiro/steering/game-steering.md
+++ b/.kiro/steering/game-steering.md
@@ -57,6 +57,11 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 - **InputModeManager** controla qual painel recebe input — `push()` ao abrir, `pop()` ao fechar; em modo ≠ GAMEPLAY o personagem não se move
 - **`INVENTORY_OPENED` é o único evento que autoriza `_inventoryPanel.show()`** — `INVENTORY_STATE_RESPONSE` apenas atualiza dados; nunca abre o painel
 - **Bônus de equipamento são reversíveis** — `Player.applyEquipmentBonuses()` / `removeEquipmentBonuses()` acumulam em `_equipmentBonuses`; `recalcStats()` é a fonte de verdade dos stats derivados
+- **Renderização de dungeon é delegada ao `DungeonRenderer`** — `GameScene` apenas itera `RenderCommand[]` e cria sprites; zero lógica de autotiling na cena
+- **`AutoTileResolver` nunca instancia objetos Phaser** — opera sobre grid[][] e retorna `TileRenderData`; extensão futura: adicionar case em `resolveCategory()` e `AutoTileSet` no tema
+- **Temas visuais em `dungeon-themes.ts`** — `TileCategory` extensível; frames organizados por `AutoTileSet` (face, cornerOuter_TL/TR, bodyFrames, cornerInner_TL/TR); `themeForFloor()` mapeia andar → tema
+- **`BONUS_AREA_OVERRIDES` é estritamente isolado de `MANUAL_MAP_OVERRIDES`** — nunca cruzar importações entre `BonusAreaData.ts` e `TileProperties.ts`
+- **`DEV_CONFIG.godMode`** em `constants.ts` — flag de desenvolvimento; `CombatSystem` consulta antes de aplicar dano ao player; manter `false` em produção
 
 ## Estrutura de Pastas
 
@@ -69,6 +74,7 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
                    InputModeManager, LootSystem, WorldSystem, LogSystem
                    NPCController, InteractiveObjectSystem, CityDecorationSystem
                    MapTransitionSystem, DungeonFloorManager, DifficultyScalingSystem
+                   AutoTileResolver, DungeonRenderer, BonusAreaRenderer
   /entities     → Entidades puras (Player — gold, equipmentBonuses; Item — slotId, bonuses)
   /generators   → DungeonGenerator, CityLayoutProcessor, TileVariantResolver
   /config       → constants.ts, town.config.ts, sprites-config.ts, shop.catalog.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,34 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ## [Unreleased]
 
+## [5.2.0] — 2026-05-10
+
+### Added
+
+#### Renderização semântica de dungeon com autotiling
+
+- **`AutoTileResolver`** (`src/systems/AutoTileResolver.ts`): resolve frames de tile com base no contexto espacial (vizinhos cardinais) — substitui seleção por hash simples; sem instanciar objetos Phaser
+- **`DungeonRenderer`** (`src/systems/DungeonRenderer.ts`): itera o grid, delega ao resolver e emite `RenderCommand[]` — `GameScene` apenas consome os comandos para criar sprites
+- **`dungeon-themes.ts`** reestruturado: `TileCategory` extensível, `AutoTileSet` com `face`, `cornerOuter_TL/TR`, `bodyFrames`, `cornerInner_TL/TR`; 4 temas completos (dungeon, mine, underworld, underworld_boss) com frames corretos de Wall.png e Floor.png
+- Temas visuais por andar: andares 1–2 → Dungeon (pedra cinza), 3–4 → Mine (terra), 5–6 → Underworld (pedra escura), 7+ → Underworld Boss (mix abismo)
+- Inner corners compartilhados (`cornerInner_TL: 362`, `cornerInner_TR: 360`) em todos os temas
+- Variação determinística de frames por hash posicional — mesma seed, visual idêntico em reentrada
+
+#### Configuração de desenvolvimento
+
+- **`DEV_CONFIG`** em `constants.ts`: flag `godMode` — quando `true`, player não recebe dano de inimigos; permite testes de exploração sem preocupação com HP
+
+### Fixed
+
+- Sprite de poção não desaparecia do mapa ao ser coletada: `delayedCall(0, s.destroy)` substituído por `item.sprite?.destroy()` imediato, eliminando race condition entre agendamento e cleanup de andar
+- Loop de recriação de sprites (`_loadDungeonFloor`) agora destrói sprite anterior antes de criar novo, evitando leak se sprite ainda estiver ativo
+- `ReferenceError: W is not defined` ao entrar na dungeon: `width: W, height: H` removidos inadvertidamente do destructuring durante refatoração; restaurados
+
+### Changed
+
+- `GameScene._loadDungeonFloor()`: loop inline de tiles substituído por `DungeonRenderer.buildCommands()` — zero lógica visual na cena
+- `dungeon-themes.ts`: removidas funções `pickFloorFrame` e `pickWallFrame` (encapsuladas no `AutoTileResolver`)
+
 ### Changed
 
 - Removidos arquivos de resumo/documentação obsoletos da raiz do repositório: `KIRO_RESUMO.md`, `IMPLEMENTATION_SUMMARY.md`, `fase_3.md`, `fase_5.md` — conteúdo migrado para `.kiro/` e `docs/`

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,10 +1,10 @@
 # PRD — Product Requirements Document
 # Dungeon of Echoes
 
-**Versão:** 0.3.0  
-**Data:** 2026-05-05  
+**Versão:** 5.2.0  
+**Data:** 2026-05-10  
 **Equipe:** Equipe 7 — IA para DEVs SCTEC T2  
-**Status:** Fase 3 entregue — Sistema de Inventário e Itens
+**Status:** Fase 5 entregue — Renderização semântica de dungeon, múltiplos andares, área bônus
 
 ---
 
@@ -70,6 +70,9 @@ Cada partida começa em uma dungeon nova. O jogador avança derrotando inimigos,
 - Geração procedural: até **8 salas** (4×4 a 10×8 tiles), conectadas por corredores em L
 - Borda sempre WALL; posição inicial do player sempre em tile FLOOR
 - Suporte a `seed` para reprodutibilidade em debug
+- **Múltiplos andares** com cache de estado por andar (`_dungeonCache`): escadas para baixo (andar N+1) e para cima (andar N-1), retorno à cidade pelo andar 1
+- **Tema visual por andar**: andares 1–2 → Dungeon, 3–4 → Mine, 5–6 → Underworld, 7+ → Underworld Boss; frames resolvidos por `AutoTileResolver` com autotiling de 4 vizinhos
+- **`DungeonRenderer`** emite `RenderCommand[]`; `GameScene` apenas cria sprites — zero lógica visual na cena
 
 ### 6.2 Player
 
@@ -228,7 +231,7 @@ Os requisitos abaixo são derivados diretamente das specs em `.kiro/specs/`.
 
 ## 9. Escopo
 
-### Dentro do escopo (v0.3.0 — estado atual)
+### Dentro do escopo (v5.2.0 — estado atual)
 
 - [x] Geração procedural de dungeon (salas + corredores BSP, 40×40 tiles)
 - [x] Player controlável (4 direções, turn-based real via TurnManager)
@@ -239,8 +242,14 @@ Os requisitos abaixo são derivados diretamente das specs em `.kiro/specs/`.
 - [x] HUD persistente via UIScene overlay (barras HP/Mana, log, action bar de inventário)
 - [x] Sistema de inventário: 20 slots, coleta automática, uso por tecla
 - [x] Sistema de identificação roguelike de itens (nome desconhecido → real ao usar)
+- [x] Equipamentos: armas e armaduras com slots, bônus reversíveis, loja de compra/venda
+- [x] Múltiplos andares de dungeon com cache de estado e escadas bidirecionais
+- [x] Tema visual por andar: Dungeon/Mine/Underworld/Boss com autotiling de 4 vizinhos
+- [x] Mapa da cidade (TMX) com NPCs, loja, estalajadeiro e debug de tiles
+- [x] Área bônus (30×22 tiles) com renderer próprio, debug idêntico à cidade e overrides isolados
+- [x] `DEV_CONFIG.godMode` para testes sem risco de morte
 - [x] Game Over com tela de resultado e restart
-- [x] 108 testes unitários
+- [x] 125 testes unitários
 - [x] Dashboard estático de acompanhamento do projeto
 
 ### Fora do escopo (planejado para versões futuras)

--- a/docs/guia-sprites.md
+++ b/docs/guia-sprites.md
@@ -23,17 +23,42 @@ O frame `0` é o canto superior esquerdo, incrementa da esquerda pra direita, de
 
 ## Onde Ajustar Cada Sprite
 
-### Dungeon — chão e parede
-**`src/utils/constants.ts`** — seção `DAWNLIKE_FRAMES`
+### Dungeon — chão e parede (autotiling por tema)
+**`src/config/dungeon-themes.ts`** — `AutoTileSet` por tema e categoria
+
+A dungeon usa renderização semântica: cada tile é resolvido pelo `AutoTileResolver` com base nos vizinhos cardinais. Os frames são definidos por tema em `dungeon-themes.ts`.
 
 ```typescript
-FLOOR_VARIANTS: [0, 1, 2, 3, 8, 9, 10, 16, 17, 24, 25, 32, 40, 48],
-FLOOR: 3,    // fallback fixo — frame 3 do Ground0.png
-WALL: 3,     // frame 3 do Wall.png
+// Estrutura de um AutoTileSet (exemplo: tema dungeon, categoria wall)
+wall: {
+  face:           181,        // borda superior visível (vizinho sul = floor)
+  cornerOuter_TL: 180,        // canto externo superior-esquerdo
+  cornerOuter_TR: 182,        // canto externo superior-direito
+  bodyFrames:     [200, 201], // corpo sólido — pool de variação por posição
+  cornerInner_TL: 362,        // canto côncavo (compartilhado entre temas)
+  cornerInner_TR: 360,
+},
+floor: {
+  bodyFrames: [210, 211, 212, 213, 214, 215], // Floor.png linha 10
+},
 ```
 
-- **Chão:** edite `FLOOR_VARIANTS` (lista sorteada por andar) ou `FLOOR` (fallback)
-- **Parede:** edite `WALL`
+**Temas por andar:**
+
+| Andares | Tema | Wall frames (body) | Floor frames |
+|---------|------|-------------------|--------------|
+| 1–2 | `dungeon` | 200, 201 | 210–215 |
+| 3–4 | `mine` | 155, 175 | 378–381, 399–402 |
+| 5–6 | `underworld` | 260, 261 | 441–444, 462–465 |
+| 7+ | `underworld_boss` | 260, 280 | 441–444, 210–212 |
+
+- **Chão:** edite `bodyFrames` na categoria `floor` do tema desejado
+- **Parede:** edite `face`, `cornerOuter_TL/TR`, `bodyFrames` na categoria `wall`
+- **Inner corners** (`362`, `360`) são compartilhados — mudar `SHARED_INNER` altera todos os temas
+
+**Spritesheets de referência:**
+- `Wall.png` — 20 colunas × 51 linhas; frame = linha × 20 + coluna
+- `Floor.png` — 21 colunas × 39 linhas; frame = linha × 21 + coluna
 
 ### Cidade — chão por bioma
 **`src/config/sprites-config.ts`** — objeto `FLOOR_ATLAS`
@@ -109,8 +134,9 @@ cat:       { imageFile: 'Cat0.png',      textureKey: 'cat0',      frame: 0,  des
 
 | O que mudar | Arquivo | Campo |
 |---|---|---|
-| Chão da dungeon | `src/utils/constants.ts` | `DAWNLIKE_FRAMES.FLOOR_VARIANTS` |
-| Parede da dungeon | `src/utils/constants.ts` | `DAWNLIKE_FRAMES.WALL` |
+| Chão da dungeon (por tema) | `src/config/dungeon-themes.ts` | `THEMES[tema].autoTileSets.floor.bodyFrames` |
+| Parede da dungeon (por tema) | `src/config/dungeon-themes.ts` | `THEMES[tema].autoTileSets.wall.*` |
+| Inner corners (todos os temas) | `src/config/dungeon-themes.ts` | `SHARED_INNER` |
 | Chão cidade por bioma | `src/config/sprites-config.ts` | `FLOOR_ATLAS[bioma].frames` |
 | Arquivo fonte de um bioma | `src/config/sprites-config.ts` | `FLOOR_ATLAS[bioma].imageFile` + `.textureKey` |
 | Caminho de pedra central | `src/utils/constants.ts` | `TOWN.STONE_PATH_FRAME` |

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -870,3 +870,76 @@ Arquivos modificados:
 - `IMPLEMENTATION_SUMMARY.md` — removido
 - `fase_3.md` — removido
 - `fase_5.md` — removido
+
+---
+
+## Prompt 26 — feat(dungeon): autotiling semântico por tema de andar
+
+Contexto:
+A renderização de dungeon usava seleção de frames por hash simples (sem contexto espacial) com lógica embutida diretamente no loop da GameScene. Um único tema visual era aplicado a todos os andares.
+
+Objetivo:
+1. Introduzir arquitetura de semantic rendering com separação estrita de camadas
+2. Implementar autotiling de 4 vizinhos com cantos externos/côncavos e corpo sólido
+3. Temas visuais distintos por faixa de andares (dungeon/mine/underworld/boss)
+4. Preparar extensão futura (water, lava, chasm) sem alterar renderer
+
+Tarefas realizadas:
+1. `dungeon-themes.ts` reestruturado: `TileCategory`, `AutoTileSet` (face, cornerOuter_TL/TR, bodyFrames, cornerInner_TL/TR), `DungeonTheme` com `autoTileSets`; 4 temas com frames corretos de Wall.png e Floor.png
+2. `AutoTileResolver` criado: interpreta vizinhos cardinais, resolve `TileRenderData`; sem objetos Phaser
+3. `DungeonRenderer` criado: itera grid, delega ao resolver, emite `RenderCommand[]`
+4. `GameScene._loadDungeonFloor()`: loop inline substituído por `DungeonRenderer.buildCommands()`; imports de `pickFloorFrame`/`pickWallFrame` removidos
+
+Arquivos modificados:
+- `src/config/dungeon-themes.ts` — reescrito com AutoTileSet e 4 temas
+- `src/systems/AutoTileResolver.ts` — novo
+- `src/systems/DungeonRenderer.ts` — novo
+- `src/scenes/GameScene.ts` — delegação ao DungeonRenderer, `width: W, height: H` restaurados
+
+---
+
+## Prompt 27 — fix(dungeon): sprite de poção não desaparecia ao coletar; feat(dev): godMode
+
+Contexto:
+Ao coletar uma poção na dungeon, o sprite permanecia visível no mapa. Além disso, foi solicitado um modo de desenvolvimento onde o player não toma dano.
+
+Objetivo:
+1. Corrigir sprite de item não desaparecendo ao coletar
+2. Adicionar flag `godMode` em configuração de desenvolvimento
+
+Tarefas realizadas:
+1. `_checkItemPickup()`: substituído `delayedCall(0, s.destroy)` por `item.sprite?.destroy()` imediato
+2. Loop de recriação de sprites em `_loadDungeonFloor()`: adicionado `item.sprite?.destroy()` antes de criar novo sprite
+3. `constants.ts`: adicionado `DEV_CONFIG = { godMode: false }` ao final do arquivo
+4. `CombatSystem`: importado `DEV_CONFIG`; dano ao player condicionado a `!DEV_CONFIG.godMode`
+
+Arquivos modificados:
+- `src/scenes/GameScene.ts` — destroy imediato, destroy antes de recriar
+- `src/utils/constants.ts` — DEV_CONFIG
+- `src/systems/CombatSystem.ts` — godMode check
+
+---
+
+## Prompt 28 — docs: atualização pós-v5.2.0
+
+Contexto:
+Após implementação do autotiling semântico, godMode e correções de bugs, atualizar toda a documentação.
+
+Objetivo:
+Manter documentação sincronizada com o estado atual do código.
+
+Tarefas realizadas:
+1. `CHANGELOG.md`: nova seção `[5.2.0]` com Added, Fixed e Changed
+2. `docs/guia-sprites.md`: seção de dungeon reescrita para API de autotiling; tabela resumo atualizada
+3. `docs/PRD.md`: versão 5.2.0, status atualizado, seção dungeon com múltiplos andares/temas, escopo expandido
+4. `.kiro/steering/game-steering.md`: estrutura de pastas e 6 novas restrições arquiteturais
+5. `.kiro/specs/product.md`: tabela de sistemas e seção Dungeon atualizadas; área bônus documentada
+6. `.kiro/specs/world.spec.md`: tabela de áreas e transições expandida com área bônus e múltiplos andares
+
+Arquivos modificados:
+- `CHANGELOG.md`
+- `docs/guia-sprites.md`
+- `docs/PRD.md`
+- `.kiro/steering/game-steering.md`
+- `.kiro/specs/product.md`
+- `.kiro/specs/world.spec.md`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jogo-dungeon-of-echoes",
-  "version": "5.1.0",
+  "version": "0.5.2",
   "type": "module",
   "description": "Dungeon of Echoes – RPG 2D tile-based com geração procedural",
   "scripts": {

--- a/src/config/dungeon-themes.ts
+++ b/src/config/dungeon-themes.ts
@@ -1,0 +1,134 @@
+// Temas visuais de dungeon por andar — frames extraídos dos TMXs de referência:
+//   Dungeon.tmx    → andares 1–2 (pedra cinza)
+//   Mine.tmx       → andares 3–4 (terra/minério)
+//   Underworld.tmx → andares 5–6 (pedra escura + abismo)
+//   Underworld boss → andar 7+ (mix abismo + diferenciação de boss floor)
+//
+// Os TMXs NÃO são carregados em runtime — servem apenas como referência visual.
+// Spritesheets: 'wall' (Wall.png 20 cols × 51 linhas) e 'floor' (Floor.png 21 cols × 39 linhas).
+
+// ── Categorias de tile semântico ─────────────────────────────────────────────
+// Expansível sem alterar AutoTileResolver ou DungeonRenderer.
+export type TileCategory = 'wall' | 'floor' | 'door' | 'water' | 'lava' | 'chasm' | 'pillar';
+
+// ── AutoTileSet ───────────────────────────────────────────────────────────────
+// Frames organizados por tipo de borda. Cada categoria em cada tema define seu set.
+export interface AutoTileSet {
+  face:             number;    // borda superior visível (vizinho sul = aberto)
+  cornerOuter_TL:   number;    // canto externo TL (sul=aberto, oeste=aberto)
+  cornerOuter_TR:   number;    // canto externo TR (sul=aberto, leste=aberto)
+  bodyFrames:       number[];  // corpo sólido — pool para variação determinística por posição
+  cornerInner_TL?:  number;    // canto côncavo TL (sul=fechado, leste=aberto, diag SE=aberto)
+  cornerInner_TR?:  number;    // canto côncavo TR (sul=fechado, oeste=aberto, diag SO=aberto)
+  isolated?:        number;    // tile sem vizinhos do mesmo tipo (fallback para face)
+}
+
+// ── DungeonTheme ──────────────────────────────────────────────────────────────
+export interface DungeonTheme {
+  autoTileSets: Partial<Record<TileCategory, AutoTileSet>>;
+
+  // Campos reservados para expansão futura (não usados ainda)
+  ambientColor?: number;   // tint de câmera/iluminação
+  fogDensity?:   number;   // FOG of War quando implementado
+  musicKey?:     string;   // trilha sonora por tema
+  propsPool?:    string[]; // decorações em spawn procedural
+}
+
+// ── Dados dos temas ───────────────────────────────────────────────────────────
+// Frames de inner corners (360, 362) são compartilhados — aparecem em todos os TMXs
+// nas linhas 18-20 de Wall.png.
+const SHARED_INNER: Pick<AutoTileSet, 'cornerInner_TL' | 'cornerInner_TR'> = {
+  cornerInner_TL: 362,  // Wall.png linha 18 col 2
+  cornerInner_TR: 360,  // Wall.png linha 18 col 0
+};
+
+const THEMES: Record<string, DungeonTheme> = {
+
+  // Dungeon.tmx — pedra cinza clara
+  // Wall.png linhas 9–11 (frames 180–222) · Floor.png linha 10 (frames 210–215)
+  dungeon: {
+    autoTileSets: {
+      wall: {
+        face:           181,          // linha 9 col 1
+        cornerOuter_TL: 180,          // linha 9 col 0
+        cornerOuter_TR: 182,          // linha 9 col 2
+        bodyFrames:     [200, 201],   // linha 10 col 0–1
+        ...SHARED_INNER,
+      },
+      floor: {
+        face:           210,          // (fallback; floor usa bodyFrames)
+        cornerOuter_TL: 210,
+        cornerOuter_TR: 210,
+        bodyFrames:     [210, 211, 212, 213, 214, 215],  // Floor.png linha 10
+      },
+    },
+  },
+
+  // Mine.tmx — terra/minério
+  // Wall.png linhas 6–8 (frames 120–175) · Floor.png linhas 18–19 (frames 378–402)
+  mine: {
+    autoTileSets: {
+      wall: {
+        face:           136,          // linha 6 col 16
+        cornerOuter_TL: 135,          // linha 6 col 15
+        cornerOuter_TR: 137,          // linha 6 col 17
+        bodyFrames:     [155, 175],   // linha 7 col 15 + linha 8 col 15
+        ...SHARED_INNER,
+      },
+      floor: {
+        face:           378,
+        cornerOuter_TL: 378,
+        cornerOuter_TR: 378,
+        bodyFrames:     [378, 379, 380, 381, 399, 400, 401, 402],  // Floor.png linhas 18–19
+      },
+    },
+  },
+
+  // Underworld.tmx — pedra escura + abismo
+  // Wall.png linhas 12–14 (frames 240–285) · Floor.png linhas 21–22 (frames 441–465)
+  underworld: {
+    autoTileSets: {
+      wall: {
+        face:           261,          // linha 13 col 1
+        cornerOuter_TL: 240,          // linha 12 col 0
+        cornerOuter_TR: 242,          // linha 12 col 2
+        bodyFrames:     [260, 261],   // linha 13 col 0–1
+        ...SHARED_INNER,
+      },
+      floor: {
+        face:           441,
+        cornerOuter_TL: 441,
+        cornerOuter_TR: 441,
+        bodyFrames:     [441, 442, 443, 444, 462, 463, 464, 465],  // Floor.png linhas 21–22
+      },
+    },
+  },
+
+  // Underworld boss (andar 7+) — mix abismo + pedra cinza, parede linha 12 mais escura
+  underworld_boss: {
+    autoTileSets: {
+      wall: {
+        face:           261,
+        cornerOuter_TL: 240,
+        cornerOuter_TR: 242,
+        bodyFrames:     [260, 280],   // linha 13 col 0 + linha 14 col 0 (mais escuro)
+        ...SHARED_INNER,
+      },
+      floor: {
+        face:           441,
+        cornerOuter_TL: 441,
+        cornerOuter_TR: 441,
+        bodyFrames:     [441, 442, 443, 444, 210, 211, 212],  // mix abismo + pedra cinza
+      },
+    },
+  },
+};
+
+// ── API pública ───────────────────────────────────────────────────────────────
+
+export function themeForFloor(floor: number): DungeonTheme {
+  if (floor <= 2) return THEMES.dungeon;
+  if (floor <= 4) return THEMES.mine;
+  if (floor <= 6) return THEMES.underworld;
+  return THEMES.underworld_boss;
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -12,6 +12,8 @@ import { TownMap } from '../systems/WorldSystem';
 import { NPCController } from '../systems/NPCController';
 import { InteractiveObjectSystem } from '../systems/InteractiveObjectSystem';
 import { TownTMXRenderer } from '../systems/TownTMXRenderer';
+import { themeForFloor } from '../config/dungeon-themes';
+import { DungeonRenderer } from '../systems/DungeonRenderer';
 import { BonusAreaRenderer } from '../systems/BonusAreaRenderer';
 import { LAYER_GROUND } from '../config/sprites-config';
 import { InputModeManager } from '../systems/InputModeManager';
@@ -370,8 +372,7 @@ export class GameScene extends Phaser.Scene {
     } else {
       this._dungeon = new DungeonGenerator();
       this._dungeon.generate();
-      const variants   = DAWNLIKE_FRAMES.FLOOR_VARIANTS;
-      this._floorFrame = variants[Math.floor(Math.random() * variants.length)];
+      this._floorFrame = 0; // mantido para compatibilidade com DungeonState (cache)
       this._items      = [];
       this._generateInitialItems();
       // Gerar features e salvar conexões apenas uma vez (Math.random implica não-determinismo)
@@ -383,23 +384,21 @@ export class GameScene extends Phaser.Scene {
     this._currentMap  = this._dungeon;
     this._currentArea = 'dungeon';
 
-    // Renderizar tiles
+    // Renderizar tiles via DungeonRenderer (semantic autotiling)
+    const theme = themeForFloor(floor);
     const { width: W, height: H, grid } = this._dungeon;
-    for (let y = 0; y < H; y++) {
-      for (let x = 0; x < W; x++) {
-        const isFloor = grid[y][x] === TILE.FLOOR;
-        const px = x * TILE_SIZE + TILE_SIZE / 2;
-        const py = y * TILE_SIZE + TILE_SIZE / 2;
-        this._tileObjects.push(
-          this.add.image(px, py, isFloor ? SPRITES.FLOOR : SPRITES.WALL,
-            isFloor ? this._floorFrame : DAWNLIKE_FRAMES.WALL).setDepth(0),
-        );
-      }
+    const renderer = new DungeonRenderer();
+    const commands = renderer.buildCommands(grid, theme, floor);
+    for (const cmd of commands) {
+      this._tileObjects.push(
+        this.add.image(cmd.x, cmd.y, cmd.texture, cmd.frame).setDepth(cmd.depth),
+      );
     }
 
     // Recriar sprites dos itens no chão
     for (const item of this._items) {
       if (item.gridX === null || item.gridY === null) continue;
+      item.sprite?.destroy();
       const px = item.gridX * TILE_SIZE + TILE_SIZE / 2;
       const py = item.gridY * TILE_SIZE + TILE_SIZE / 2;
       const { texture, frame } = this._getItemVisual(item.type);
@@ -609,10 +608,8 @@ export class GameScene extends Phaser.Scene {
       this.player.inventory.addItem(item);
       const slotIndex = this.player.inventory.items.findIndex(i => i === item);
 
-      const s = item.sprite;
+      item.sprite?.destroy();
       item.sprite = null;
-      s?.setVisible(false);
-      this.time.delayedCall(0, () => s?.destroy());
 
       EventBus.emit(EVENTS.UI_LOG, `Você pegou ${displayName}`);
       EventBus.emit(EVENTS.ITEM_PICKED_UP, { item, slotIndex });

--- a/src/systems/AutoTileResolver.ts
+++ b/src/systems/AutoTileResolver.ts
@@ -1,0 +1,113 @@
+import { TILE } from '../utils/constants';
+import type { DungeonTheme, TileCategory, AutoTileSet } from '../config/dungeon-themes';
+
+export interface TileRenderData {
+  texture: string;
+  frame:   number;
+  depth?:  number;  // reservado para expansão (chasm overlay, etc.)
+}
+
+/**
+ * Interpreta o contexto espacial de cada tile (vizinhos cardinais) e resolve
+ * qual frame renderizar. Não instancia objetos Phaser — pura lógica de dados.
+ *
+ * Extensão futura: adicionar novos TileCategory em dungeon-themes.ts e o case
+ * correspondente em resolveCategory(). Nenhuma alteração aqui é necessária.
+ */
+export class AutoTileResolver {
+
+  /** Determina a categoria semântica de um tile pelo seu valor no grid. */
+  resolveCategory(grid: number[][], x: number, y: number): TileCategory {
+    const v = grid[y]?.[x];
+    if (v === TILE.FLOOR) return 'floor';
+    if (v === TILE.WALL)  return 'wall';
+    // Expansão futura: TILE.WATER, TILE.DOOR, TILE.LAVA, etc.
+    return 'wall'; // fallback seguro — tile desconhecido age como parede
+  }
+
+  /**
+   * Resolve o frame visual de um tile em (x, y) com base nos vizinhos.
+   * @param grid     - Grid procedural (WALL/FLOOR/…)
+   * @param x, y     - Posição do tile
+   * @param theme    - Tema visual do andar
+   * @param floorNum - Número do andar (usado na variação determinística)
+   */
+  resolve(
+    grid:     number[][],
+    x:        number,
+    y:        number,
+    theme:    DungeonTheme,
+    floorNum: number,
+  ): TileRenderData {
+    const category = this.resolveCategory(grid, x, y);
+    const tileSet  = theme.autoTileSets[category];
+
+    if (!tileSet) {
+      return { texture: 'wall', frame: 0 }; // categoria sem dados → fallback neutro
+    }
+
+    if (category === 'floor') {
+      return {
+        texture: 'floor',
+        frame:   this._pickDeterministic(tileSet.bodyFrames, x, y, floorNum, 0),
+      };
+    }
+
+    // ── Tiles com borda (wall, pillar, chasm, …) ──────────────────────────────
+    const sOpen = !this._isSameOrOob(grid, category, x,     y + 1);
+    const eOpen = !this._isSameOrOob(grid, category, x + 1, y    );
+    const wOpen = !this._isSameOrOob(grid, category, x - 1, y    );
+
+    // Face superior visível (sul aberto) — escolhe canto ou face reta
+    if (sOpen) {
+      if (wOpen && !eOpen) return { texture: 'wall', frame: tileSet.cornerOuter_TL };
+      if (eOpen && !wOpen) return { texture: 'wall', frame: tileSet.cornerOuter_TR };
+      return { texture: 'wall', frame: tileSet.face };
+    }
+
+    // Cantos côncavos (inner corners) — detectados via diagonal quando disponíveis
+    if (tileSet.cornerInner_TL !== undefined && eOpen) {
+      const seOpen = !this._isSameOrOob(grid, category, x + 1, y + 1);
+      if (seOpen) return { texture: 'wall', frame: tileSet.cornerInner_TL };
+    }
+    if (tileSet.cornerInner_TR !== undefined && wOpen) {
+      const swOpen = !this._isSameOrOob(grid, category, x - 1, y + 1);
+      if (swOpen) return { texture: 'wall', frame: tileSet.cornerInner_TR };
+    }
+
+    // Corpo sólido — variação determinística por posição
+    return {
+      texture: 'wall',
+      frame:   this._pickDeterministic(tileSet.bodyFrames, x, y, floorNum, 1),
+    };
+  }
+
+  /**
+   * Retorna true se o vizinho em (gx, gy) é da mesma categoria que `category`
+   * OU está fora dos limites do grid (borda tratada como "mesmo tipo").
+   */
+  private _isSameOrOob(
+    grid:     number[][],
+    category: TileCategory,
+    gx:       number,
+    gy:       number,
+  ): boolean {
+    if (gy < 0 || gy >= grid.length || gx < 0 || gx >= (grid[0]?.length ?? 0)) return true;
+    return this.resolveCategory(grid, gx, gy) === category;
+  }
+
+  /**
+   * Hash determinístico: mesmo (x, y, floor) sempre retorna o mesmo índice.
+   * `salt` diferencia a seleção entre floor e body para evitar padrões idênticos.
+   */
+  private _pickDeterministic(
+    frames: number[],
+    x:      number,
+    y:      number,
+    floor:  number,
+    salt:   number,
+  ): number {
+    const hash = ((x * 2654435761) ^ (y * 2246822519) ^ (floor * 374761393) ^ (salt * 1234567891)) >>> 0;
+    return frames[hash % frames.length];
+  }
+}

--- a/src/systems/CombatSystem.ts
+++ b/src/systems/CombatSystem.ts
@@ -1,5 +1,5 @@
 import * as Phaser from 'phaser';
-import { EVENTS } from '../utils/constants';
+import { EVENTS, DEV_CONFIG } from '../utils/constants';
 import type { XPSystem } from './XPSystem';
 
 export interface CombatResult {
@@ -71,7 +71,7 @@ export class CombatSystem {
 
     // Inimigo contra-ataca
     result.enemyDamage = enemy.attack;
-    player.hp = Math.max(0, player.hp - enemy.attack);
+    if (!DEV_CONFIG.godMode) player.hp = Math.max(0, player.hp - enemy.attack);
     this.emitter.emit(EVENTS.COMBAT_HIT, { attacker: enemy, defender: player, damage: enemy.attack });
     if (player.getPixelPos) {
       this.emitter.emit(EVENTS.DAMAGE_PLAYER, { pos: player.getPixelPos(), damage: enemy.attack });

--- a/src/systems/DungeonRenderer.ts
+++ b/src/systems/DungeonRenderer.ts
@@ -1,0 +1,48 @@
+import { TILE_SIZE } from '../utils/constants';
+import { AutoTileResolver } from './AutoTileResolver';
+import type { DungeonTheme } from '../config/dungeon-themes';
+
+export interface RenderCommand {
+  x:       number;  // posição em pixels (centro do tile)
+  y:       number;
+  texture: string;
+  frame:   number;
+  depth:   number;
+}
+
+/**
+ * Itera o grid procedural, delega a resolução visual ao AutoTileResolver
+ * e retorna uma lista de RenderCommands.
+ *
+ * Não conhece Phaser.Scene — não instancia GameObjects.
+ * GameScene consome os comandos e cria os sprites.
+ */
+export class DungeonRenderer {
+  private _resolver = new AutoTileResolver();
+
+  buildCommands(
+    grid:      number[][],
+    theme:     DungeonTheme,
+    floor:     number,
+    baseDepth: number = 0,
+  ): RenderCommand[] {
+    const commands: RenderCommand[] = [];
+    const H = grid.length;
+    const W = grid[0]?.length ?? 0;
+
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const data = this._resolver.resolve(grid, x, y, theme, floor);
+        commands.push({
+          x:       x * TILE_SIZE + TILE_SIZE / 2,
+          y:       y * TILE_SIZE + TILE_SIZE / 2,
+          texture: data.texture,
+          frame:   data.frame,
+          depth:   data.depth ?? baseDepth,
+        });
+      }
+    }
+
+    return commands;
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -229,3 +229,8 @@ export const AI = {
   CACHE_MAX_SIZE: 100,          // Máximo de entradas no cache
   REQUEST_TIMEOUT: 5000,        // Timeout de 5s para chamadas LLM
 } as const;
+
+// ─── Configurações de desenvolvimento ────────────────────────────────────────
+export const DEV_CONFIG = {
+  godMode: false,  // true → player não toma dano
+};


### PR DESCRIPTION
## Descrição

Introduz renderização semântica de dungeon com autotiling por vizinhos cardinais e temas visuais por faixa de andares. Corrige sprite de item que não desaparecia ao ser coletado na dungeon e adiciona flag godMode para testes sem risco de morte.

---

## Tipo de mudança

<!-- Marque com [x] o tipo que se aplica. -->

- [x] `feat` — nova funcionalidade
- [x] `fix` — correção de bug
- [x] `refactor` — refatoração sem mudança de comportamento

---

## O que foi feito

- Criado AutoTileResolver: resolve frames por contexto espacial (4 vizinhos cardinais) — face, cantos externos/côncavos, corpo sólido; zero dependência de Phaser
- Criado DungeonRenderer: itera grid + tema e emite RenderCommand[]; GameScene apenas cria sprites, sem lógica visual
- Reestruturado dungeon-themes.ts com AutoTileSet e 4 temas: Dungeon (andares 1–2), Mine (3–4), Underworld (5–6), Underworld Boss (7+)
- Substituído loop inline de tiles em _loadDungeonFloor() pela delegação ao DungeonRenderer
Corrigido: sprite de poção permanecia no mapa após coleta — delayedCall(0, destroy) substituído por destroy() imediato
- Adicionado DEV_CONFIG.godMode em constants.ts; quando true, CombatSystem não aplica dano ao player

---

## Como testar

<!-- Passo a passo para reproduzir e validar as mudanças. -->

1. `npm install`
2. `npm run dev`
3. Entrar na dungeon e verificar que paredes renderizam com face visível no topo, cantos curvos e corpo sólido nas massas
4. Descer andares e confirmar mudança de tema visual (pedra cinza → terra → pedra escura)
5. Coletar uma poção no chão e confirmar que o sprite desaparece imediatamente
6. Para testar godMode: setar godMode: true em src/utils/constants.ts, entrar em combate e confirmar que HP não diminui

---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/<MeuNome>.md` (se usei IA neste PR)
- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser

---

## Observações

AutoTileResolver e DungeonRenderer são puros (sem Phaser) — extensão futura para novas categorias (water, lava, chasm) requer apenas adicionar case em resolveCategory() e AutoTileSet no tema correspondente, sem alterar a GameScene. DEV_CONFIG.godMode deve permanecer false em produção.
