### PR TITLE
feat: correcao de bugs na luta e inventario

### DIFF
--- a/.kiro/specs/spells.spec.md
+++ b/.kiro/specs/spells.spec.md
@@ -2,7 +2,7 @@
 
 ## Descrição
 
-O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços em projétil durante a exploração da dungeon. As magias são desbloqueadas automaticamente ao atingir certos níveis e equipadas em dois slots (`Q` e `E`).
+O sistema de magias permite ao jogador desbloquear, equipar e usar feitiços melee-range durante a exploração da dungeon. As magias atingem todos os inimigos adjacentes (4 tiles cardinais) ao custo de mana e respeitam cooldown por slot. São desbloqueadas automaticamente ao subir de nível e equipadas em dois slots (`J` e `K`).
 
 ---
 
@@ -11,11 +11,10 @@ O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços
 | Entidade / Sistema | Responsabilidade |
 |--------------------|-----------------|
 | `SpellSystem` | Gerencia desbloqueio, equipamento e cooldown dos slots |
-| `SpellCastingSystem` | Orquestra o disparo: valida mana, desconta custo, instancia `Projectile` |
-| `Projectile` | Sprite autônomo que se move em linha reta e detecta colisões |
+| `SpellCastingSystem` | Valida mana/cooldown, aplica dano em todos os inimigos adjacentes, retorna `SpellCastResult` |
 | `spells.db.ts` | Banco de dados data-driven das definições de magia |
 | `spell-progression.ts` | Tabela de desbloqueio por nível |
-| `SpellsPanel` | UI para equipar magias nos slots |
+| `SpellsPanel` | UI integrada ao painel `I`; navegação por teclado |
 | `StatusPanel` | UI de atributos detalhados do player |
 
 ---
@@ -35,8 +34,8 @@ O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços
 ## Slots de Magia
 
 - O player possui **dois slots** (`equippedSpells[0]` e `equippedSpells[1]`)
-- Slot 0 → tecla `Q` | Slot 1 → tecla `E`
-- Cada slot armazena o ID da magia equipada, timestamp do último cast e cooldown da magia
+- Slot 0 → tecla `J` | Slot 1 → tecla `K` (durante gameplay)
+- Slots exibidos no footer (action bar), canto direito, tamanho 20×20, com barra de cooldown azul na base
 - Uma magia só pode ser equipada se estiver em `player.unlockedSpells`
 
 ---
@@ -50,26 +49,29 @@ O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços
 
 ---
 
-## Fluxo de Disparo
+## Fluxo de Cast (Melee-Range)
 
-1. Player pressiona `Q` (slot 0) ou `E` (slot 1)
-2. `GameScene` chama `SpellCastingSystem.cast(slotIndex, player, spellSystem, scene, now)`
+1. Player pressiona `J` (slot 0) ou `K` (slot 1)
+2. `GameScene` chama `SpellCastingSystem.cast(slotIndex, player, spellSystem, enemies, now)`
 3. `SpellCastingSystem` verifica:
    - Slot tem magia equipada → senão retorna `null`
    - `spellSystem.canCast(slotIndex, now)` → cooldown zerado
    - `player.mana >= spell.manaCost` → mana suficiente
-4. Se válido: desconta mana, registra `recordCast`, emite `EVENTS.SPELL_CAST`, instancia `Projectile`
-5. `Projectile` é adicionado à cena e move-se na direção `player.facingDir`
+4. Se válido: desconta mana, registra `recordCast`, coleta todos os `EnemySystem` vivos nos 4 tiles cardinais adjacentes ao player
+5. Retorna `SpellCastResult { success, damage, spellName, hitEnemies }`
+6. `GameScene` itera `hitEnemies`: aplica dano, sincroniza barra de HP, concede XP se morreu
 
 ---
 
-## Projétil (`Projectile`)
+## Navegação no Painel de Magias (tecla `I`)
 
-- Velocidade definida por `spell.projectileSpeed` (em tiles/frame)
-- A cada frame, `updateMovement(dungeon)` verifica:
-  - Tile destino é WALL → destrói o projétil
-  - Distância até inimigo vivo < `HIT_RADIUS` (0.7 × TILE_SIZE) → aplica dano e destrói
-- Ao destruir: reproduz `spell.impactAnimKey` e emite `EVENTS.PROJECTILE_HIT`
+- **←/→** — troca de aba (Status / Inventário / Magias)
+- **↓** na aba Magias com foco nas abas → entra na lista, seleciona a primeira magia
+- **↑** na primeira magia (índice 0) → volta o foco para as abas (deseleciona)
+- **↑/↓** na lista → navega entre magias desbloqueadas
+- **Enter / E** → equipa magia selecionada no slot J (0)
+- **K** → equipa magia selecionada no slot K (1)
+- `SPELLS_SELECTION_CHANGED` é emitido por `GameScene` e ouvido por `UIScene` para atualizar seleção visual
 
 ---
 
@@ -77,7 +79,7 @@ O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços
 
 | Campo | Tipo | Descrição |
 |-------|------|-----------|
-| `facingDir` | `'up' \| 'down' \| 'left' \| 'right'` | Última direção de movimento |
+| `facingDir` | `'up' \| 'down' \| 'left' \| 'right'` | Última direção de movimento (reservado para uso futuro) |
 | `unlockedSpells` | `string[]` | IDs de magias desbloqueadas |
 | `equippedSpells` | `[string \| null, string \| null]` | IDs equipados nos dois slots |
 
@@ -87,9 +89,9 @@ O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços
 
 - R1: Magias só são equipadas se estiverem em `unlockedSpells`
 - R2: Cooldown é por slot, não global — os dois slots podem estar em cooldown simultaneamente
-- R3: `SpellCastingSystem` nunca acessa `spells.db.ts` diretamente para dados de dano — usa `Projectile.damage`
-- R4: `Projectile` não conhece `SpellSystem` — recebe `SpellDef` completo no construtor
-- R5: Se mana insuficiente, o cast é silenciosamente ignorado (sem erro no console)
+- R3: `SpellCastingSystem` usa `EnemySystem` (não `Enemy`) — `takeDamage` exige o emitter da cena
+- R4: Se nenhum inimigo adjacente, cast consome mana e cooldown e exibe mensagem no log
+- R5: Se mana insuficiente ou cooldown ativo, `cast()` retorna `null` sem consumir recursos
 - R6: `spells.db.ts` é a única fonte de verdade para atributos de magia
 
 ---
@@ -99,10 +101,10 @@ O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços
 | Situação | Comportamento Esperado |
 |----------|----------------------|
 | Slot sem magia equipada | `cast()` retorna `null` |
-| Cooldown ativo | `cast()` retorna `null` |
+| Cooldown ativo | `cast()` retorna `null`; mana inalterada |
 | Mana insuficiente | `cast()` retorna `null` |
-| ID de magia inválido em `equippedSpells` | `cast()` retorna `null` (magia não encontrada no DB) |
-| Projétil sai dos limites do grid | Destruído ao atingir tile WALL da borda |
+| ID de magia inválido em `equippedSpells` | `cast()` retorna `null` |
+| Nenhum inimigo adjacente | `hitEnemies = []`; log exibe "nenhum alvo adjacente" |
 
 ---
 
@@ -128,7 +130,7 @@ O sistema de magias permite ao jogador desbloquear, equipar e disparar feitiços
 - **Quando**: `cast(0, ...)` chamado
 - **Então**: Retorna `null`; mana do player inalterada
 
-### Cenário 5 — Projétil colide com parede
-- **Dado**: Tile à frente do projétil é WALL
-- **Quando**: `updateMovement(dungeon)` chamado
-- **Então**: Projétil destruído; `EVENTS.PROJECTILE_HIT` emitido
+### Cenário 5 — Dano em múltiplos inimigos adjacentes
+- **Dado**: Dois inimigos vivos nos tiles Norte e Leste do player; magia equipada com dano 15
+- **Quando**: `cast(0, ...)` chamado com mana e cooldown válidos
+- **Então**: `hitEnemies.length === 2`; ambos recebem 15 de dano

--- a/.kiro/steering/game-steering.md
+++ b/.kiro/steering/game-steering.md
@@ -67,10 +67,11 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 - **`BONUS_AREA_OVERRIDES` é estritamente isolado de `MANUAL_MAP_OVERRIDES`** — nunca cruzar importações entre `BonusAreaData.ts` e `TileProperties.ts`
 - **`DEV_CONFIG.godMode`** em `constants.ts` — flag de desenvolvimento; `CombatSystem` consulta antes de aplicar dano ao player; manter `false` em produção
 - **Magias são data-driven** — `spells.db.ts` é a única fonte de verdade para atributos de magia; `spell-progression.ts` define quando cada magia é desbloqueada; nunca hardcodar IDs ou dano em Systems
-- **`SpellCastingSystem` nunca importa `SpellSystem` diretamente** — recebe instância como parâmetro em `cast()`; desacoplamento total entre gestão de slots e disparo físico
-- **`Projectile` é uma entidade Phaser** — `scene.add.existing(this)` no construtor; `updateMovement()` chamado pelo `GameScene` a cada frame; destrói-se via `this.destroy()` após impacto
-- **Dois slots de magia (`equippedSpells[0]`, `equippedSpells[1]`)** — mapeados para teclas `Q` e `E`; `SpellSystem.equipSpell()` valida que o player desbloqueou a magia antes de equipar
-- **`facingDir`** em `Player` (`'up' | 'down' | 'left' | 'right'`) — atualizado pelo `GameScene` a cada movimento; `SpellCastingSystem` usa para definir direção do projétil
+- **`SpellCastingSystem` nunca importa `SpellSystem` diretamente** — recebe instância como parâmetro em `cast()`; retorna `SpellCastResult` com `hitEnemies: EnemySystem[]`
+- **Magias são melee-range** — `SpellCastingSystem.cast()` verifica os 4 tiles cardinais adjacentes ao player e aplica dano em todos os inimigos encontrados; sem projétil
+- **Dois slots de magia (`equippedSpells[0]`, `equippedSpells[1]`)** — mapeados para teclas `J` e `K` no gameplay; slots exibidos no footer (action bar), canto direito, tamanho 20×20
+- **`facingDir`** em `Player` mantido para uso futuro (direcionalidade); não é usado pelo `SpellCastingSystem` atual
+- **Navegação de magias no painel `I`** — ←/→ trocam aba; na aba Magias, ↓ entra na lista, ↑ na primeira magia volta às abas; Enter/E equipa em J, K equipa em K; `SPELLS_SELECTION_CHANGED` sincroniza seleção visual no `SpellsPanel`
 
 ## Estrutura de Pastas
 
@@ -85,7 +86,7 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
                    MapTransitionSystem, DungeonFloorManager, DifficultyScalingSystem
                    AutoTileResolver, DungeonRenderer, BonusAreaRenderer
                    SpellSystem, SpellCastingSystem
-  /entities     → Entidades puras (Player — gold, equipmentBonuses, facingDir, spells; Item — slotId, bonuses; Projectile — sprite autônomo)
+  /entities     → Entidades puras (Player — gold, equipmentBonuses, facingDir, spells; Item — slotId, bonuses)
   /generators   → DungeonGenerator, CityLayoutProcessor, TileVariantResolver
   /config       → constants.ts, town.config.ts, sprites-config.ts, shop.catalog.ts, spells.db.ts, spell-progression.ts
   /types        → town.ts, equipment.ts, viewmodels.ts, input.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,21 +56,28 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 #### Sistema de Magias (Spells)
 
-- **`SpellSystem`** (`src/systems/SpellSystem.ts`): gerencia desbloqueio e equipamento de magias; dois slots de magia (`equippedSpells[0]` e `[1]`); `unlockSpellsForLevel()` consulta `SPELL_PROGRESSION` data-driven; `canCast()` verifica cooldown; `recordCast()` registra timestamp
-- **`SpellCastingSystem`** (`src/systems/SpellCastingSystem.ts`): orquestra o disparo — verifica cooldown, desconta mana, emite `EVENTS.SPELL_CAST` e instancia `Projectile`; desacoplado de `SpellSystem` e `Player`
-- **`Projectile`** (`src/entities/Projectile.ts`): `Phaser.GameObjects.Sprite` com movimento autônomo por tile; detecta colisão com paredes (via `DungeonGenerator`) e inimigos (raio `TILE_SIZE × 0.7`); destrói-se ao impactar e emite `EVENTS.PROJECTILE_HIT`; reproduz animação de impacto antes de destruir o sprite
-- **`SpellsPanel`** (`src/ui/SpellsPanel.ts`): painel de UI para equipar magias nos dois slots — abre via `EVENTS.SPELLS_OPENED`; navegação por teclado; exibe nome, elemento, dano, custo de mana e cooldown
-- **`StatusPanel`** (`src/ui/StatusPanel.ts`): painel de atributos detalhados do player (STR/INT/DEX/CON/WIS/CHA, HP, Mana, nível) — abre via tecla `C`
-- **`spells.db.ts`** (`src/config/spells.db.ts`): banco de dados data-driven com 5 magias — `fire_bolt` (nv 1), `ice_shard` (nv 5), `wind_cyclone` (nv 10), `fire_explosion` (nv 15), `blizzard` (nv 20); campos: `damage`, `manaCost`, `cooldownMs`, `projectileSpeed`, `animKey`, `impactAnimKey`
-- **`spell-progression.ts`** (`src/config/spell-progression.ts`): tabela de desbloqueio por nível — extendível sem alterar `SpellSystem`
+- **`SpellSystem`** (`src/systems/SpellSystem.ts`): gerencia desbloqueio e equipamento de magias; dois slots (`equippedSpells[0]` e `[1]`); `unlockSpellsForLevel()` consulta `SPELL_PROGRESSION` data-driven; `canCast()` verifica cooldown; `recordCast()` registra timestamp
+- **`SpellCastingSystem`** (`src/systems/SpellCastingSystem.ts`): verifica cooldown e mana, desconta custo, aplica dano em **todos** os inimigos adjacentes (4 cardinais); retorna `SpellCastResult` com a lista de `hitEnemies`; sem projétil — mecânica melee-range igual ao ataque normal
+- **`SpellsPanel`** (`src/ui/SpellsPanel.ts`): painel de magias integrado ao painel `I`; mesmas dimensões do inventário (85%×80%); navegação por teclado — ↓ entra na lista, ↑ na primeira magia volta para as abas, **Enter/E** equipa no slot J, **K** equipa no slot K
+- **`StatusPanel`** (`src/ui/StatusPanel.ts`): painel de atributos detalhados do player (STR/INT/DEX/CON/WIS/CHA, HP, Mana, nível)
+- **`spells.db.ts`** (`src/config/spells.db.ts`): 5 magias data-driven — `fire_bolt` (nv 1), `ice_shard` (nv 5), `wind_cyclone` (nv 10), `fire_explosion` (nv 15), `blizzard` (nv 20)
+- **`spell-progression.ts`** (`src/config/spell-progression.ts`): tabela de desbloqueio por nível, extendível sem alterar `SpellSystem`
 - **`types/spells.ts`**: interfaces `SpellDef`, `SpellSlotState`, `SpellElement`, `Direction`
-- `EVENTS.SPELL_CAST`, `EVENTS.SPELL_EQUIPPED`, `EVENTS.PROJECTILE_HIT`, `EVENTS.SPELLS_OPENED`, `EVENTS.PLAYER_MANA_CHANGED` adicionados a `constants.ts`
+- Slots J/K movidos para dentro da action bar (footer), canto direito — mesmo tamanho dos slots de poção (20×20); barra de cooldown azul na base de cada slot
+- `EVENTS.SPELL_CAST`, `EVENTS.SPELL_EQUIPPED`, `EVENTS.SPELLS_SELECTION_CHANGED`, `EVENTS.PLAYER_MANA_CHANGED` adicionados a `constants.ts`
 
 ### Changed
 
 - `Player`: campos `facingDir: Direction`, `unlockedSpells: string[]`, `equippedSpells: [string | null, string | null]` adicionados à entidade
-- `UIScene`: exibe cooldown dos slots de magia e barra de mana atualizada em tempo real via `PLAYER_MANA_CHANGED`
+- `UIScene`: slots J/K no footer com cooldown visual; mana atualizada em tempo real via `PLAYER_MANA_CHANGED`
 - `XPSystem`: chama `SpellSystem.unlockSpellsForLevel()` ao subir de nível — desbloqueia magias automaticamente
+- `_handleInventoryInput` (GameScene): ←/→ trocam de aba; na aba Magias, ↓ entra na lista e ↑ na primeira magia retorna às abas
+- Barra de HP do inimigo sincronizada imediatamente após dano de magia (`_syncEnemySprite` chamado em `_castSpell`)
+
+### Fixed
+
+- `SpellCastingSystem` tipado com `EnemySystem` (não `Enemy`) — corrige `takeDamage` chamado sem o `emitter` obrigatório, eliminando o `TypeError: can't access property "emit", emitter is undefined`
+- Testes atualizados: `potion_poison` removido de `Item.ts` → substituído por `potion_mana`; HP no teste de cura ajustado para não ultrapassar o cap com `POTION_HEAL_AMOUNT = 25`; gold esperado no shop corrigido (preço 30→40)
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 **Versão:** 0.5.4  
 **Data:** 2026-05-12  
 **Equipe:** Equipe 7 — IA para DEVs SCTEC T2  
-**Status:** v0.5.4 entregue — Sistema de Magias com projéteis, dois slots equipáveis, progressão data-driven por nível
+**Status:** v0.5.4 entregue — Sistema de Magias melee-range, dois slots J/K no footer, navegação por teclado no painel de magias
 
 ---
 
@@ -357,15 +357,16 @@ Os requisitos abaixo são derivados diretamente das specs em `.kiro/specs/`.
 - [x] Todos os 4 temas de dungeon migrados para `bitmaskFrames`
 
 ### v0.5.4 — Sistema de Magias (entregue em 2026-05-12)
-- [x] `SpellSystem`: desbloqueio de magias por nível, dois slots equipáveis, cooldown por slot
-- [x] `SpellCastingSystem`: disparo com verificação de mana e cooldown; instancia `Projectile`
-- [x] `Projectile`: sprite com movimento autônomo, colisão com paredes e inimigos, animação de impacto
-- [x] `SpellsPanel`: painel de UI para equipar magias com navegação por teclado
+- [x] `SpellSystem`: desbloqueio de magias por nível, dois slots J/K com cooldown independente
+- [x] `SpellCastingSystem`: mecânica melee-range — verifica mana e cooldown, aplica dano em todos os inimigos adjacentes (4 cardinais)
+- [x] `SpellsPanel`: integrado ao painel `I`; mesmas dimensões do inventário; navegação por teclado (↓ entra na lista, ↑ na primeira magia volta às abas, Enter/E equipa em J, K equipa em K)
 - [x] `StatusPanel`: painel de atributos detalhados (STR/INT/DEX/CON/WIS/CHA, HP, Mana)
 - [x] `spells.db.ts`: 5 magias data-driven (fire_bolt, ice_shard, wind_cyclone, fire_explosion, blizzard)
 - [x] `spell-progression.ts`: tabela de desbloqueio por nível extendível
+- [x] Slots J/K no footer (action bar), canto direito, tamanho 20×20 com barra de cooldown
 - [x] Player com `facingDir`, `unlockedSpells` e `equippedSpells`
 - [x] XPSystem integrado: desbloqueia magias automaticamente ao subir de nível
+- [x] Barra de HP do inimigo atualizada imediatamente após dano de magia
 
 ### v0.6.0 — FOG of War (planejado)
 - [ ] FOG of War: HIDDEN / VISIBLE / REVEALED por tile

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -1008,3 +1008,58 @@ Arquivos modificados:
 - `.kiro/steering/game-steering.md`
 - `.kiro/specs/dungeon.spec.md`
 - `docs/prompts/Vitor.md`
+
+---
+
+## Prompt 30 — PR: feat(spells): sistema de magias melee-range v0.5.4
+Autor: Vitor
+Data: 2026-05-12
+
+Contexto:
+Branch `feature/game-structure-fixes`. Implementação do sistema de magias integrado ao jogo, com múltiplas iterações de correção durante a sessão.
+
+Objetivo:
+Adicionar sistema de magias jogável: desbloqueio por nível, dois slots equipáveis (J/K), mecânica melee-range (sem projétil), painel de magias integrado ao `I`, slots no footer e navegação por teclado.
+
+Decisões técnicas tomadas com IA:
+- Magias melee-range (4 cardinais adjacentes) em vez de projétil — eliminado `Projectile` para evitar bugs de ciclo de vida do sprite fora da cena
+- `SpellCastingSystem` tipado com `EnemySystem` (não `Enemy`) para compatibilidade com `takeDamage(amount, emitter)`
+- `hitEnemies: EnemySystem[]` em vez de `hitEnemy | null` — dano em todos os adjacentes simultâneo
+- Slots J/K movidos para dentro do footer (action bar), tamanho 20×20, mesmo padrão dos slots de poção
+- Navegação por teclado no painel de magias: estado `_spellsFocus: 'tabs' | 'list'` em GameScene; `SPELLS_SELECTION_CHANGED` sincroniza visual no SpellsPanel
+- `INVENTORY_TAB_CHANGED` com flag `_fromKeyboard` para distinguir origem teclado vs clique e evitar loop de eventos
+
+Tarefas realizadas:
+1. `SpellSystem.ts` (novo): desbloqueio, equipamento, cooldown por slot
+2. `SpellCastingSystem.ts` (novo/reescrito): cast melee — 4 tiles cardinais, retorna `SpellCastResult` com `hitEnemies[]`
+3. `SpellsPanel.ts` (novo): painel integrado ao `I`, 85%×80%, `clearSelection()` adicionado
+4. `StatusPanel.ts` (novo): atributos detalhados do player
+5. `spells.db.ts` + `spell-progression.ts` + `types/spells.ts` (novos): definições data-driven
+6. `GameScene.ts` (modificado): `_castSpell()` melee, `_inventoryTab`, `_spellsFocus`, `_spellsSelectedIndex`, navegação ←/→/↑/↓ no painel
+7. `UIScene.ts` (modificado): slots J/K no footer (20×20), `SPELLS_SELECTION_CHANGED` ouvido, `INVENTORY_TAB_CHANGED` com `_fromKeyboard`
+8. `constants.ts` (modificado): `SPELLS_SELECTION_CHANGED` adicionado
+9. Testes corrigidos: `potion_poison` → `potion_mana`; HP ajustado para cap de `POTION_HEAL_AMOUNT=25`; gold do shop 470→460
+
+Arquivos criados:
+- `src/systems/SpellSystem.ts`
+- `src/systems/SpellCastingSystem.ts`
+- `src/ui/SpellsPanel.ts`
+- `src/ui/StatusPanel.ts`
+- `src/config/spells.db.ts`
+- `src/config/spell-progression.ts`
+- `src/types/spells.ts`
+- `.kiro/specs/spells.spec.md`
+
+Arquivos modificados:
+- `src/scenes/GameScene.ts`
+- `src/scenes/UIScene.ts`
+- `src/entities/Player.ts`
+- `src/utils/constants.ts`
+- `tests/inventory.test.js`
+- `tests/shop.test.js`
+- `CHANGELOG.md`
+- `docs/PRD.md`
+- `README.md`
+- `.kiro/steering/game-steering.md`
+- `docs/prompts/Vitor.md`
+

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -28,7 +28,6 @@ import { ShopSystem } from '../systems/ShopSystem';
 import { SHOP_CATALOG } from '../config/shop.catalog';
 import { SpellSystem } from '../systems/SpellSystem';
 import { SpellCastingSystem } from '../systems/SpellCastingSystem';
-import { Projectile } from '../entities/Projectile';
 import { SPELLS_DB } from '../config/spells.db';
 import type { TransitionResolution } from '../types/transitions';
 import type { GridPos } from '../generators/DungeonGenerator';
@@ -70,7 +69,6 @@ export class GameScene extends Phaser.Scene {
   private _shopSystem!: ShopSystem;
   private _spellSystem!: SpellSystem;
   private _spellCastingSystem!: SpellCastingSystem;
-  private _projectiles: Projectile[] = [];
   private gameState!: string;
 
   // Cache de andares visitados (runtime — não serializado ainda)
@@ -120,6 +118,9 @@ export class GameScene extends Phaser.Scene {
 
   // ─── Estado de seleção de inventário / loja ───────────────────────────────
   private _inventorySelectedIndex = 0;
+  private _inventoryTab: 'inventory' | 'status' | 'spells' = 'status';
+  private _spellsSelectedIndex = 0;
+  private _spellsFocus: 'tabs' | 'list' = 'tabs';
   private _shopSelectedIndex = 0;
   private _shopTab: 'buy' | 'sell' = 'buy';
 
@@ -161,7 +162,6 @@ export class GameScene extends Phaser.Scene {
     this._shopSystem          = new ShopSystem(SHOP_CATALOG);
     this._spellSystem         = new SpellSystem();
     this._spellCastingSystem  = new SpellCastingSystem();
-    this._projectiles         = [];
     this._registerTransitions();
 
     // Player criado uma vez — moves between areas
@@ -179,7 +179,6 @@ export class GameScene extends Phaser.Scene {
   }
 
   shutdown(): void {
-    this._clearProjectiles();
     EventBus.off(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
     EventBus.off(EVENTS.INVENTORY_STATE_REQUESTED, undefined, this);
     EventBus.off(EVENTS.STATUS_STATE_REQUESTED,    undefined, this);
@@ -196,10 +195,7 @@ export class GameScene extends Phaser.Scene {
     if (this.gameState !== GAME_STATE.PLAYING) return;
     this._handleInput(_time);
 
-    // Atualizar projéteis de magia (real-time)
-    if (this._currentArea === 'dungeon' && this._dungeon) {
-      this._updateProjectiles();
-    }
+
 
     // Atualizar NPCs com wandering (cidade e área bônus)
     if ((this._currentArea === 'town' || this._currentArea === 'bonus') && this._npcController) {
@@ -265,8 +261,6 @@ export class GameScene extends Phaser.Scene {
   }
 
   private _cleanup(): void {
-    this._clearProjectiles();
-
     this._tileObjects.forEach(o => o.destroy());
     this._tileObjects = [];
 
@@ -725,6 +719,8 @@ export class GameScene extends Phaser.Scene {
         EventBus.emit(EVENTS.DIALOG_CLOSED, {});
       } else if (this.inputMode.is('INVENTORY')) {
         this.inputMode.pop();
+        this._inventoryTab = 'status';
+        this._spellsFocus = 'tabs';
         EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
       } else if (this.inputMode.is('SHOP')) {
         this.inputMode.pop();
@@ -743,6 +739,8 @@ export class GameScene extends Phaser.Scene {
     if (JD(this.iKey)) {
       if (this.inputMode.is('INVENTORY')) {
         this.inputMode.pop();
+        this._inventoryTab = 'status';
+        this._spellsFocus = 'tabs';
         EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
       } else if (this.inputMode.is('GAMEPLAY')) {
         this.inputMode.push('INVENTORY');
@@ -857,15 +855,82 @@ export class GameScene extends Phaser.Scene {
 
   private _handleInventoryInput(): void {
     const JD = Phaser.Input.Keyboard.JustDown;
+    const up   = JD(this.cursors.up)   || JD(this.wasd.up);
+    const down = JD(this.cursors.down) || JD(this.wasd.down);
+    const left = JD(this.cursors.left) || JD(this.wasd.left);
+    const right= JD(this.cursors.right)|| JD(this.wasd.right);
+
+    const TAB_ORDER: Array<'status' | 'inventory' | 'spells'> = ['status', 'inventory', 'spells'];
+
+    // ── Aba MAGIAS com foco na lista ──────────────────────────────────────
+    if (this._inventoryTab === 'spells' && this._spellsFocus === 'list') {
+      const spellCount = this.player.unlockedSpells.length;
+
+      if (up) {
+        if (this._spellsSelectedIndex === 0) {
+          // Volta o foco para as abas
+          this._spellsFocus = 'tabs';
+          EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: -1 });
+        } else {
+          this._spellsSelectedIndex--;
+          EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: this._spellsSelectedIndex });
+        }
+        return;
+      }
+      if (down) {
+        this._spellsSelectedIndex = Math.min(spellCount - 1, this._spellsSelectedIndex + 1);
+        EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: this._spellsSelectedIndex });
+        return;
+      }
+      // E/Enter — equipa no slot J (0) por padrão; K com tecla K
+      if (JD(this.enterKey) || JD(this.eKey)) {
+        const spellId = this.player.unlockedSpells[this._spellsSelectedIndex] ?? null;
+        if (spellId) EventBus.emit(EVENTS.SPELL_EQUIP_REQUEST, { slotIndex: 0, spellId });
+        return;
+      }
+      if (JD(this.kKey)) {
+        const spellId = this.player.unlockedSpells[this._spellsSelectedIndex] ?? null;
+        if (spellId) EventBus.emit(EVENTS.SPELL_EQUIP_REQUEST, { slotIndex: 1, spellId });
+        return;
+      }
+      return;
+    }
+
+    // ── Navegação de abas (←/→ ou ↓ entra na lista da aba magias) ─────────
+    if (left) {
+      const idx = TAB_ORDER.indexOf(this._inventoryTab);
+      this._inventoryTab = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length];
+      this._spellsFocus = 'tabs';
+      EventBus.emit(EVENTS.INVENTORY_TAB_CHANGED, { tab: this._inventoryTab, _fromKeyboard: true });
+      return;
+    }
+    if (right) {
+      const idx = TAB_ORDER.indexOf(this._inventoryTab);
+      this._inventoryTab = TAB_ORDER[(idx + 1) % TAB_ORDER.length];
+      this._spellsFocus = 'tabs';
+      EventBus.emit(EVENTS.INVENTORY_TAB_CHANGED, { tab: this._inventoryTab, _fromKeyboard: true });
+      return;
+    }
+    if (down && this._inventoryTab === 'spells') {
+      // Entra na lista de magias
+      this._spellsFocus = 'list';
+      this._spellsSelectedIndex = 0;
+      EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: 0 });
+      return;
+    }
+
+    // ── Aba INVENTÁRIO ────────────────────────────────────────────────────
+    if (this._inventoryTab !== 'inventory') return;
+
     const inv = this.player.inventory;
     const total = inv.items.filter(i => i !== null).length;
 
-    if (JD(this.cursors.up) || JD(this.wasd.up)) {
+    if (up) {
       this._inventorySelectedIndex = Math.max(0, this._inventorySelectedIndex - 1);
       this._emitInventorySelectionChanged();
       return;
     }
-    if (JD(this.cursors.down) || JD(this.wasd.down)) {
+    if (down) {
       this._inventorySelectedIndex = Math.min(total - 1, this._inventorySelectedIndex + 1);
       this._emitInventorySelectionChanged();
       return;
@@ -1116,61 +1181,34 @@ export class GameScene extends Phaser.Scene {
 
   private _castSpell(slotIndex: 0 | 1): void {
     if (this._currentArea !== 'dungeon') return;
-    const projectile = this._spellCastingSystem.cast(
-      slotIndex, this.player, this._spellSystem, this, Date.now(),
+    const result = this._spellCastingSystem.cast(
+      slotIndex, this.player, this._spellSystem, this._enemies, Date.now(),
     );
-    if (projectile) {
-      this._projectiles.push(projectile);
+    if (!result) return;
+
+    if (result.hitEnemies.length === 0) {
+      EventBus.emit(EVENTS.UI_LOG, `${result.spellName} — nenhum alvo adjacente.`);
+      return;
     }
-  }
 
-  private _updateProjectiles(): void {
-    if (!this._dungeon) return;
-    for (let i = this._projectiles.length - 1; i >= 0; i--) {
-      const proj = this._projectiles[i];
-      if (!proj.active) { this._projectiles.splice(i, 1); continue; }
+    for (const enemy of result.hitEnemies) {
+      enemy.takeDamage(result.damage, this.events);
+      EventBus.emit(EVENTS.UI_LOG, `${result.spellName} causou ${result.damage} de dano!`);
 
-      proj.updateMovement(this._dungeon);
-
-      if (!proj.isAlive()) {
-        this._projectiles.splice(i, 1);
-        continue;
-      }
-
-      let hit = false;
-      for (const enemy of this._enemies) {
-        if (!enemy.alive || !enemy.sprite) continue;
-        if (proj.checkEnemyHit(enemy)) {
-          enemy.takeDamage(proj.damage);
-          EventBus.emit(EVENTS.UI_LOG, `Magia causou ${proj.damage} de dano!`);
-          if (!enemy.alive) {
-            const pos = enemy.getPixelPos();
-            this._showDamageText(pos, proj.damage, COLORS.XP_TEXT);
-            this._removeEnemySprite(enemy);
-            const xpGain = enemy.xpReward ?? 0;
-            if (xpGain > 0) {
-              this.xpSystem.addXP(this.player, xpGain);
-            }
-          } else {
-            this._showDamageText(enemy.getPixelPos(), proj.damage, COLORS.XP_TEXT);
-            if (enemy.sprite) this._flashSprite(enemy.sprite);
-          }
-          hit = true;
-          break;
-        }
-      }
-      if (hit && i < this._projectiles.length && this._projectiles[i] === proj) {
-        this._projectiles.splice(i, 1);
+      if (!enemy.alive) {
+        const pos = enemy.getPixelPos();
+        this._showDamageText(pos, result.damage, COLORS.XP_TEXT);
+        this._removeEnemySprite(enemy);
+        const xpGain = enemy.xpReward ?? 0;
+        if (xpGain > 0) this.xpSystem.addXP(this.player, xpGain);
+      } else {
+        this._syncEnemySprite(enemy);
+        this._showDamageText(enemy.getPixelPos(), result.damage, COLORS.XP_TEXT);
+        if (enemy.sprite) this._flashSprite(enemy.sprite);
       }
     }
   }
 
-  private _clearProjectiles(): void {
-    for (const p of this._projectiles) {
-      if (p.active) p.destroy();
-    }
-    this._projectiles = [];
-  }
 
   private _emitStatusState(): void {
     const p = this.player;
@@ -1325,6 +1363,14 @@ export class GameScene extends Phaser.Scene {
     // Responde com estado do inventário quando UIScene solicitar
     EventBus.on(EVENTS.INVENTORY_STATE_REQUESTED, () => {
       this._emitInventoryState();
+    }, this);
+
+    // Sincroniza aba local quando UIScene muda via clique
+    EventBus.on(EVENTS.INVENTORY_TAB_CHANGED, (data: { tab: 'inventory' | 'status' | 'spells'; _fromKeyboard?: boolean }) => {
+      if (!data._fromKeyboard) {
+        this._inventoryTab = data.tab;
+        this._spellsFocus = 'tabs';
+      }
     }, this);
 
     // Responde com estado de status quando solicitado

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -66,7 +66,7 @@ export class UIScene extends Phaser.Scene {
   private _tabBtnBgs:  Phaser.GameObjects.Rectangle[] = [];
   private _tabBtnTxts: Phaser.GameObjects.Text[]      = [];
 
-  // Barra de magias (lado direito)
+  // Barra de magias no footer (canto direito)
   private _spellBarContainer: Phaser.GameObjects.Container | null = null;
   private _spellBarSlots: Array<{
     bg: Phaser.GameObjects.Rectangle;
@@ -161,16 +161,17 @@ export class UIScene extends Phaser.Scene {
     EventBus.off(EVENTS.SPELL_CAST,                 undefined,            this);
   }
 
-  // ─── Spell Bar (lado direito) ─────────────────────────────────────────────
+  // ─── Spell Bar no footer (canto direito) ────────────────────────────────
 
   private _buildSpellBar(): void {
-    const sw = this.scale.width;
-    const sh = this.scale.height;
-    const barH   = this._actionBar.getHeight();
-    const slotH  = 28;
-    const slotW  = 110;
-    const pad    = 6;
-    const x      = sw - slotW - 8;
+    const sw       = this.scale.width;
+    const sh       = this.scale.height;
+    const barH     = this._actionBar.getHeight();   // 36
+    const slotSize = 20;
+    const slotGap  = 3;
+    const barY     = sh - barH;
+    const slotY    = barY + Math.floor((barH - slotSize) / 2);
+    const rightEdge = sw - 8;
     const DEPTH_SPELL_BAR = 205;
 
     this._spellBarContainer = this.add
@@ -181,33 +182,32 @@ export class UIScene extends Phaser.Scene {
     const slotKeys = ['J', 'K'] as const;
     this._spellBarSlots = [];
 
+    // Slots da direita para a esquerda: K é mais à direita, J fica à sua esquerda
     slotKeys.forEach((key, i) => {
-      const y = sh - barH - (slotKeys.length - i) * (slotH + 4) - 4;
+      const slotX = rightEdge - (slotKeys.length - i) * (slotSize + slotGap);
 
-      // Fundo do slot
       const bg = this.add
-        .rectangle(x, y, slotW, slotH, 0x111122, 0.92)
+        .rectangle(slotX, slotY, slotSize, slotSize, 0x222244)
         .setOrigin(0, 0)
         .setStrokeStyle(1, 0x334466);
 
-      // Tecla de atalho (J / K)
-      const keyTxt = this.add.text(x + pad, y + slotH / 2, `[${key}]`, {
-        fontSize: '9px', color: '#4499ff', fontFamily: 'monospace', fontStyle: 'bold',
-      }).setOrigin(0, 0.5);
+      // Tecla no canto superior esquerdo do slot
+      const keyTxt = this.add.text(slotX + 2, slotY + 1, key, {
+        fontSize: '6px', color: '#4499ff', fontFamily: 'monospace', fontStyle: 'bold',
+      });
 
-      // Nome da magia
-      const nameTxt = this.add.text(x + pad + 24, y + slotH / 2 - 4, '—', {
-        fontSize: '8px', color: '#667799', fontFamily: 'monospace',
-      }).setOrigin(0, 0.5);
+      // Nome abreviado da magia (max ~8 chars) centralizado
+      const nameTxt = this.add.text(slotX + slotSize / 2, slotY + 11, '—', {
+        fontSize: '6px', color: '#667799', fontFamily: 'monospace',
+      }).setOrigin(0.5, 0);
 
-      // Barra de cooldown (fundo)
+      // Barra de cooldown na base do slot
       const cdBar = this.add
-        .rectangle(x + pad, y + slotH - 6, slotW - pad * 2, 3, 0x222244)
+        .rectangle(slotX, slotY + slotSize - 3, slotSize, 3, 0x222244)
         .setOrigin(0, 0);
 
-      // Barra de cooldown (preenchimento)
       const cdBarFill = this.add
-        .rectangle(x + pad, y + slotH - 6, 0, 3, 0x4499ff)
+        .rectangle(slotX, slotY + slotSize - 3, 0, 3, 0x4499ff)
         .setOrigin(0, 0);
 
       this._spellBarContainer!.add([bg, keyTxt, nameTxt, cdBar, cdBarFill]);
@@ -217,17 +217,19 @@ export class UIScene extends Phaser.Scene {
 
   updateSpellBar(slots: Array<{ spellId: string | null; spellName: string; cooldownRatio: number }>): void {
     if (!this._spellBarContainer) return;
-    const maxW = 110 - 12; // slotW - pad*2
+    const slotSize = 20;
     slots.forEach((slot, i) => {
       const s = this._spellBarSlots[i];
       if (!s) return;
 
       const hasSpell = !!slot.spellId;
-      s.nameTxt.setText(hasSpell ? slot.spellName : '—');
+      // Abreviar nome para caber no slot 20px
+      const shortName = hasSpell ? slot.spellName.split(' ')[0].substring(0, 6) : '—';
+      s.nameTxt.setText(shortName);
       s.nameTxt.setStyle({ ...s.nameTxt.style, color: hasSpell ? '#aaddff' : '#445566' });
 
       const fillW = hasSpell && slot.cooldownRatio > 0
-        ? Math.round(maxW * slot.cooldownRatio)
+        ? Math.round(slotSize * slot.cooldownRatio)
         : 0;
       s.cdBarFill.setSize(fillW, 3);
       const ready = !hasSpell || slot.cooldownRatio === 0;
@@ -488,6 +490,11 @@ export class UIScene extends Phaser.Scene {
     EventBus.on(EVENTS.ITEM_EQUIPPED,   () => { this._inventoryPanel.markDirty(); }, this);
     EventBus.on(EVENTS.ITEM_UNEQUIPPED, () => { this._inventoryPanel.markDirty(); }, this);
 
+    EventBus.on(EVENTS.INVENTORY_TAB_CHANGED, (data: { tab: 'inventory' | 'status' | 'spells'; _fromKeyboard?: boolean }) => {
+      if (!this.sys.isActive() || !this._tabContainer?.visible || !data._fromKeyboard) return;
+      this._switchTab(data.tab);
+    }, this);
+
     EventBus.on(EVENTS.PLAYER_GOLD_CHANGED, (data: { gold: number }) => {
       if (!this.sys.isActive() || !this._goldLabel?.active) return;
       this._goldLabel.setText(`Ouro: ${data.gold}`);
@@ -544,6 +551,16 @@ export class UIScene extends Phaser.Scene {
       if (!this.sys.isActive()) return;
       if (this._spellsPanel.isVisible()) {
         EventBus.emit(EVENTS.SPELLS_STATE_REQUESTED, { timestamp: Date.now() });
+      }
+      this._spellsPanel.markDirty();
+    }, this);
+
+    EventBus.on(EVENTS.SPELLS_SELECTION_CHANGED, (data: { index: number }) => {
+      if (!this.sys.isActive() || !this._spellsPanel.isVisible() || !this._spellsData) return;
+      if (data.index >= 0) {
+        this._spellsPanel.selectByIndex(data.index, this._spellsData);
+      } else {
+        this._spellsPanel.clearSelection();
       }
       this._spellsPanel.markDirty();
     }, this);

--- a/src/systems/SpellCastingSystem.ts
+++ b/src/systems/SpellCastingSystem.ts
@@ -1,19 +1,32 @@
-import * as Phaser from 'phaser';
 import { SPELLS_DB } from '../config/spells.db';
 import { EventBus } from '../utils/EventBus';
 import { EVENTS } from '../utils/constants';
-import { Projectile } from '../entities/Projectile';
 import type { SpellSystem } from './SpellSystem';
 import type { Player } from '../entities/Player';
+import type { EnemySystem } from './EnemySystem';
+
+const ADJACENT = [
+  { dx:  0, dy: -1 },
+  { dx:  0, dy:  1 },
+  { dx: -1, dy:  0 },
+  { dx:  1, dy:  0 },
+];
+
+export type SpellCastResult = {
+  success: boolean;
+  damage: number;
+  spellName: string;
+  hitEnemies: EnemySystem[];
+};
 
 export class SpellCastingSystem {
   cast(
     slotIndex: 0 | 1,
     player: Player,
     spellSystem: SpellSystem,
-    scene: Phaser.Scene,
+    enemies: EnemySystem[],
     nowMs: number,
-  ): Projectile | null {
+  ): SpellCastResult | null {
     const slots = spellSystem.getSlots();
     const slot  = slots[slotIndex];
     if (!slot.spellId) return null;
@@ -23,11 +36,15 @@ export class SpellCastingSystem {
     if (!spellSystem.canCast(slotIndex, nowMs)) return null;
     if (player.mana < spell.manaCost) return null;
 
+    const targets = ADJACENT
+      .map(({ dx, dy }) => ({ tx: player.gridX + dx, ty: player.gridY + dy }))
+      .flatMap(({ tx, ty }) => enemies.filter(e => e.alive && e.gridX === tx && e.gridY === ty));
+
     player.mana = Math.max(0, player.mana - spell.manaCost);
     EventBus.emit(EVENTS.PLAYER_MANA_CHANGED, { mana: player.mana, maxMana: player.maxMana });
     spellSystem.recordCast(slotIndex, nowMs);
     EventBus.emit(EVENTS.SPELL_CAST, { slotIndex, spellId: spell.id });
 
-    return new Projectile(scene, player.x, player.y, spell, player.facingDir ?? 'down');
+    return { success: true, damage: spell.damage, spellName: spell.name, hitEnemies: targets };
   }
 }

--- a/src/ui/SpellsPanel.ts
+++ b/src/ui/SpellsPanel.ts
@@ -163,6 +163,11 @@ export class SpellsPanel {
     }
   }
 
+  clearSelection(): void {
+    this._selectedId = null;
+    this._dirty = true;
+  }
+
   render(vm: SpellsViewModel): void {
     if (!this._dirty) return;
     this._dirty = false;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -193,9 +193,10 @@ export const EVENTS = {
   STATUS_STATE_REQUESTED: 'status-state-requested',
   STATUS_STATE_RESPONSE:  'status-state-response',
   // Magias
-  SPELLS_STATE_REQUESTED: 'spells-state-requested',
-  SPELLS_STATE_RESPONSE:  'spells-state-response',
-  SPELL_EQUIP_REQUEST:    'spell-equip-request',
+  SPELLS_STATE_REQUESTED:   'spells-state-requested',
+  SPELLS_STATE_RESPONSE:    'spells-state-response',
+  SPELL_EQUIP_REQUEST:      'spell-equip-request',
+  SPELLS_SELECTION_CHANGED: 'spells-selection-changed',
 } as const;
 
 // --- Loja ---


### PR DESCRIPTION
## Descrição

Implementa o sistema de magias (v0.5.4): o jogador desbloqueia feitiços ao subir de nível, equipa dois slots (J/K) e os usa em combate melee-range — a magia atinge todos os inimigos adjacentes ao personagem. Inclui painel de magias integrado ao `I` com navegação por teclado e slots J/K visíveis no footer.

---

## Tipo de mudança

- [x] `feat` — nova funcionalidade
- [x] `fix` — correção de bug

---

## O que foi feito

- `SpellSystem`: gerencia desbloqueio por nível, equipamento e cooldown independente por slot
- `SpellCastingSystem`: mecânica melee-range — aplica dano em todos os inimigos nos 4 tiles cardinais adjacentes ao player; retorna `hitEnemies[]`
- `SpellsPanel` integrado ao painel `I`: mesmas dimensões do inventário; navegação por teclado (↓ entra na lista, ↑ na primeira magia volta às abas, Enter/E equipa no slot J, K equipa no slot K)
- `StatusPanel`: painel de atributos detalhados do player (STR/INT/DEX/CON/WIS/CHA, HP, Mana)
- `spells.db.ts` + `spell-progression.ts`: 5 magias data-driven com desbloqueio por nível (fire_bolt nv1 → blizzard nv20)
- Slots J/K movidos para dentro do footer (action bar), canto direito, tamanho 20×20 com barra de cooldown
- Barra de HP do inimigo sincronizada imediatamente após dano de magia
- Navegação por teclado no painel `I`: ←/→ trocam aba; ↓ em Magias entra na lista; ↑ na primeira magia volta às abas
- Testes corrigidos: `potion_poison` removido de `Item.ts` → substituído por `potion_mana`; HP ajustado para não ultrapassar cap com `POTION_HEAL_AMOUNT=25`; gold do shop 470→460

---

## Como testar

1. `npm install`
2. `npm run dev`
3. Entrar na dungeon e verificar que ao nível 1 o slot `fire_bolt` já está disponível
4. Pressionar `J` com um inimigo adjacente — confirmar dano no log e barra de HP atualizada
5. Pressionar `J` sem inimigo adjacente — confirmar mensagem "nenhum alvo adjacente" no log
6. Subir para nível 5 e verificar que `ice_shard` é desbloqueado automaticamente
7. Abrir `I` → aba Magias → pressionar ↓ para entrar na lista → ↑ para voltar às abas
8. Equipar magia com Enter (slot J) e com K (slot K); confirmar slots no footer atualizados
9. `npm test` — 125 testes passando

---

## Evidências

Test Files  10 passed (10)
Tests  125 passed (125)
Duration  763ms



---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/Vitor.md` (se usei IA neste PR)
- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser

---

## Observações

`SpellCastingSystem` usa `EnemySystem` (não a entity `Enemy`) porque `takeDamage` exige o `emitter` da cena como segundo argumento — usar o tipo errado causava o `TypeError: can't access property "emit", emitter is undefined`. A mecânica melee-range foi escolhida em vez de projétil para evitar bugs de ciclo de vida de sprite fora da cena. Navegação de abas usa flag `_fromKeyboard` no evento `INVENTORY_TAB_CHANGED` para evitar loop entre `GameScene` e `UIScene`.

