### PR TITLE
feat: correcao de bugs na luta e inventario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ## [Unreleased]
 
+### Fixed
+
+- Sprites de itens no chão da dungeon agora desaparecem corretamente após o jogador coletá-los: removidos os calls `setVisible(false).setActive(false)` antes de `destroy()` — em Phaser 4 desativar o sprite antes de destruí-lo impedia a remoção da display list; cache do andar (`_dungeonCache`) agora é atualizado após o filtro de coleta para manter consistência ao re-entrar no mesmo andar
+
+---
+
 ## [0.5.4] — 2026-05-12
 
 ### Added

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -1063,3 +1063,21 @@ Arquivos modificados:
 - `.kiro/steering/game-steering.md`
 - `docs/prompts/Vitor.md`
 
+---
+
+## Prompt 31
+Autor: Vitor
+Data: 2026-05-12
+
+Contexto:
+Correção de bug visual: sprites de itens no chão da dungeon não desapareciam após o jogador coletá-los. O item era adicionado ao inventário corretamente (lógica de coleta funcionando), mas o sprite permanecia visível na dungeon.
+
+Decisões tomadas:
+1. **Causa raiz identificada**: as chamadas `setVisible(false).setActive(false)` antes de `destroy()` em `_checkItemPickup` eram problemáticas no Phaser 4 — desativar o sprite antes de destruí-lo pode impedir que o objeto seja removido corretamente da display list do Phaser. A correção foi usar `item.sprite.destroy()` diretamente, sem as chamadas intermediárias.
+2. **Cache sincronizado**: após `this._items = this._items.filter(i => i.gridX !== null)`, o cache do andar (`_dungeonCache`) agora é atualizado com a referência filtrada (`cached.items = this._items`). Isso garante que ao re-entrar no mesmo andar, apenas os itens ainda no chão tenham sprites recriados.
+3. Em Phaser 4, `destroy()` é síncrono e remove o objeto da display list imediatamente — não requer `setVisible(false)` ou `setActive(false)` préviamente.
+
+Arquivos modificados:
+- `src/scenes/GameScene.ts`: `_checkItemPickup()` — removidos `setVisible(false).setActive(false)` antes de `destroy()` em ambos os branches (gold e regular items); cache atualizado após o filtro
+- `CHANGELOG.md`: entrada na seção `[Unreleased]` descrevendo a correção
+

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -640,7 +640,6 @@ export class GameScene extends Phaser.Scene {
         item.gridX = null;
         item.gridY = null;
         if (item.sprite) {
-          item.sprite.setVisible(false).setActive(false);
           item.sprite.destroy();
           item.sprite = null;
         }
@@ -659,7 +658,6 @@ export class GameScene extends Phaser.Scene {
       const slotIndex = this.player.inventory.items.findIndex(i => i === item);
 
       if (item.sprite) {
-        item.sprite.setVisible(false).setActive(false);
         item.sprite.destroy();
         item.sprite = null;
       }
@@ -669,6 +667,10 @@ export class GameScene extends Phaser.Scene {
     }
 
     this._items = this._items.filter(i => i.gridX !== null);
+
+    // Keep dungeon cache in sync so floor re-entry shows correct items
+    const cached = this._dungeonCache.get(this.floorManager.currentFloor);
+    if (cached) cached.items = this._items;
   }
 
   // ─── Input ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Descrição

Corrige bug visual onde sprites de itens no chão da dungeon não desapareciam após o jogador coletá-los. O item era adicionado ao inventário corretamente, mas o sprite permanecia visível na cena.

---

## Tipo de mudança

- [ ] `feat` — nova funcionalidade
- [x] `fix` — correção de bug
- [ ] `refactor` — refatoração sem mudança de comportamento
- [ ] `docs` — apenas documentação
- [ ] `chore` — CI, dependências, configuração

---

## O que foi feito

- Removidas as chamadas `setVisible(false).setActive(false)` antes de `destroy()` em `_checkItemPickup` — em Phaser 4, desativar o sprite antes de destruí-lo impede que o objeto seja removido corretamente da display list
- Cache do andar (`_dungeonCache`) atualizado após o filtro de coleta (`cached.items = this._items`) para garantir que ao re-entrar no mesmo andar apenas os itens já coletados não reapareçam

---

## Como testar

1. `npm install`
2. `npm run dev`
3. Entrar na dungeon e caminhar até um item no chão
4. Verificar que o sprite do item desaparece imediatamente ao coletar
5. Subir/descer de andar e retornar ao mesmo andar — os itens já coletados não devem reaparecer
6. Matar um inimigo próximo ao player e verificar que o loot dropado também some ao ser coletado

---

## Evidências

Test Files  10 passed (10)
Tests       125 passed (125)
Duration    816ms



---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/<MeuNome>.md` (se usei IA neste PR)
- [x] Segui o padrão de commits (Conventional Commits)
- [ ] Testei manualmente as alterações no browser

---

## Observações

A causa raiz foi o uso de `setActive(false)` antes de `destroy()`. No Phaser 4, objetos inativos podem ser ignorados pelo ciclo de remoção da display list, deixando o sprite visível mesmo após a destruição. A correção correta é chamar `destroy()` diretamente, sem desativar o objeto antes.