### PR TITLE
feat(narrative): add EventMemory and NarrativeService for emergent AI storytelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ## [Unreleased]
 
+### Added
+- **Narrativa Emergente com IA (Fase 6)**: sistema completo de memória de eventos e geração narrativa contextualizada
+- `src/systems/EventMemory.ts` — registra eventos importantes da run (`ENEMY_KILLED`, `FLOOR_CHANGED`, `PLAYER_NEAR_DEATH`, `PLAYER_DEATH`, etc.) com debounce anti-spam e filtragem de eventos importantes
+- `src/ai/NarrativeService.ts` — gera narrativa baseada nos eventos reais do jogador (não inventa); usa `AIService` com fallback automático se IA indisponível
+- Narrativa gerada ao descer de andar (não-bloqueante via `.then()`) e exibida no log da UI
+- História da run gerada ao morrer e exibida na tela de Game Over
+- `GameOverScene` atualizada para exibir a história narrativa da partida
+- Eventos `NARRATIVE_GENERATED` e `DEATH_STORY_GENERATED` adicionados ao `EVENTS`
+- 16 novos testes em `tests/event-memory.test.js` (141 testes total)
+
 ### Fixed
 
 - Sprites de itens no chão da dungeon agora desaparecem corretamente após o jogador coletá-los: removidos os calls `setVisible(false).setActive(false)` antes de `destroy()` — em Phaser 4 desativar o sprite antes de destruí-lo impedia a remoção da display list; cache do andar (`_dungeonCache`) agora é atualizado após o filtro de coleta para manter consistência ao re-entrar no mesmo andar

--- a/docs/prompts/Andrea.md
+++ b/docs/prompts/Andrea.md
@@ -69,3 +69,43 @@ Resultado:
 108 testes passando. Sistema de inventário completo e funcional seguindo o padrão roguelike clássico.
 
 Branch criada: `feature/inventory-system`
+
+## Prompt 4 — feat(narrative): Fase 6 — Narrativa Emergente com IA
+Autor: Andrea
+Data: 2026-05-05
+
+Prompt utilizado:
+> Arquivo fase_6_IA_3.md fornecido com especificação completa da Fase 6.
+
+O que foi feito:
+
+1. Criada branch `feature/narrative-system` a partir de `staging`.
+
+2. Criado `src/systems/EventMemory.ts`:
+   - Registra eventos da run: ENEMY_KILLED, FLOOR_CHANGED, PLAYER_NEAR_DEATH, PLAYER_DEATH, ITEM_FOUND, ITEM_USED, PLAYER_DAMAGED, PLAYER_HEALED, ELITE_ENEMY_FOUND
+   - Debounce anti-spam para eventos repetitivos
+   - `getImportantEvents()` filtra e deduplica eventos relevantes para a narrativa
+   - `toPromptLines()` serializa eventos em texto legível para o prompt da IA
+
+3. Criado `src/ai/NarrativeService.ts`:
+   - `generateNarrative(events)` — narrativa de andar (3–5 frases)
+   - `generateDeathStory(events)` — história da run para Game Over
+   - Prompts em português com restrição explícita de não inventar eventos
+   - Fallback automático se IA indisponível
+
+4. Atualizado `src/scenes/GameScene.ts`:
+   - Inicializa `EventMemory` e `NarrativeService` no `create()`
+   - Registra eventos: coleta de item, mudança de andar, morte de inimigo, dano ao player, quase-morte, uso de item
+   - Gera narrativa ao descer de andar (não-bloqueante)
+   - Passa eventos para `GameOverScene` ao morrer
+
+5. Atualizado `src/scenes/GameOverScene.ts`:
+   - Exibe história narrativa da run gerada pela IA
+   - Fallback para texto padrão se IA indisponível
+
+6. Criado `tests/event-memory.test.js` com 16 testes.
+
+Resultado:
+141 testes passando. Sistema de narrativa emergente completo e funcional.
+
+Branch criada: `feature/narrative-system`

--- a/src/ai/NarrativeService.ts
+++ b/src/ai/NarrativeService.ts
@@ -1,0 +1,151 @@
+/**
+ * NarrativeService.ts — Geração de narrativa emergente com IA
+ * Fase 6: Narrativa Emergente com IA (Memória + Contexto)
+ *
+ * Usa o histórico real do jogador (EventMemory) para gerar narrativa.
+ * NUNCA inventa eventos — só amplifica o que realmente aconteceu.
+ *
+ * PRINCÍPIOS:
+ * - Assíncrono e não-bloqueante (.then(), nunca await no loop)
+ * - Sempre tem fallback (jogo funciona sem IA)
+ * - Geração pontual: mudança de andar, eventos especiais, morte
+ */
+
+import { AIService } from './AIService';
+import type { GameEvent } from '../systems/EventMemory';
+
+/** Fallbacks narrativos para quando a IA não está disponível */
+const FALLBACK_NARRATIVES = [
+  'Uma jornada sombria se desenrola nas profundezas...',
+  'O eco dos seus passos ressoa pelas paredes úmidas.',
+  'A escuridão parece ganhar vida ao seu redor.',
+  'Cada passo te leva mais fundo no desconhecido.',
+  'As sombras guardam segredos que talvez seja melhor não descobrir.',
+];
+
+const FALLBACK_DEATH_STORIES = [
+  'Sua jornada terminou nas profundezas da masmorra. Mas a dungeon guarda sua memória.',
+  'O silêncio tomou conta. Mais um aventureiro consumido pelas sombras.',
+  'Sua história chegou ao fim — mas outras começarão onde a sua parou.',
+  'A masmorra venceu desta vez. Mas cada derrota é uma lição.',
+];
+
+export class NarrativeService {
+  private _aiService: AIService;
+  private _enabled: boolean;
+
+  constructor(aiService: AIService) {
+    this._aiService = aiService;
+    this._enabled = aiService['enabled'] ?? false;
+  }
+
+  // ─── Narrativa de andar / evento especial ─────────────────────────────────
+
+  /**
+   * Gera um trecho narrativo curto baseado nos eventos recentes.
+   * Usar com .then() — não bloqueia o jogo.
+   *
+   * @param events - Eventos importantes da run (máx 10)
+   * @returns Promise com texto narrativo (3–5 frases)
+   */
+  async generateNarrative(events: GameEvent[]): Promise<string> {
+    if (!this._enabled || events.length === 0) {
+      return this._randomFallback(FALLBACK_NARRATIVES);
+    }
+
+    try {
+      const prompt = this._buildNarrativePrompt(events);
+      const response = await this._aiService['callLLM'](prompt);
+      return response;
+    } catch (error) {
+      console.error('[NarrativeService] Erro ao gerar narrativa:', error);
+      return this._randomFallback(FALLBACK_NARRATIVES);
+    }
+  }
+
+  // ─── Narrativa de morte ───────────────────────────────────────────────────
+
+  /**
+   * Gera a "história da run" exibida na tela de Game Over.
+   * Usa todos os eventos importantes da partida.
+   *
+   * @param events - Eventos importantes de toda a run
+   * @returns Promise com texto da história (3–5 frases)
+   */
+  async generateDeathStory(events: GameEvent[]): Promise<string> {
+    if (!this._enabled || events.length === 0) {
+      return this._randomFallback(FALLBACK_DEATH_STORIES);
+    }
+
+    try {
+      const prompt = this._buildDeathStoryPrompt(events);
+      const response = await this._aiService['callLLM'](prompt);
+      return response;
+    } catch (error) {
+      console.error('[NarrativeService] Erro ao gerar história de morte:', error);
+      return this._randomFallback(FALLBACK_DEATH_STORIES);
+    }
+  }
+
+  // ─── Prompts ──────────────────────────────────────────────────────────────
+
+  private _buildNarrativePrompt(events: GameEvent[]): string {
+    const eventLines = events
+      .map(e => `- ${this._eventToText(e)}`)
+      .join('\n');
+
+    return `Você é um narrador de RPG dark fantasy.
+
+Baseado nos eventos abaixo, escreva um pequeno trecho narrativo (3 a 5 frases):
+
+Eventos:
+${eventLines}
+
+Regras:
+- Tom: sombrio e misterioso
+- Não invente eventos que não estão na lista
+- Não mencione mecânicas de jogo (HP, dano, etc.)
+- Escreva em português do Brasil`;
+  }
+
+  private _buildDeathStoryPrompt(events: GameEvent[]): string {
+    const eventLines = events
+      .map(e => `- ${this._eventToText(e)}`)
+      .join('\n');
+
+    return `Você é um narrador de RPG dark fantasy.
+
+Um aventureiro morreu. Baseado nos eventos abaixo, escreva a história desta run (3 a 5 frases):
+
+Eventos da jornada:
+${eventLines}
+
+Regras:
+- Tom: épico e melancólico
+- Não invente eventos que não estão na lista
+- Não mencione mecânicas de jogo (HP, dano, etc.)
+- Termine com uma frase sobre o legado ou o fim do aventureiro
+- Escreva em português do Brasil`;
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────
+
+  private _eventToText(event: GameEvent): string {
+    switch (event.type) {
+      case 'PLAYER_DAMAGED':     return `sofreu dano`;
+      case 'PLAYER_HEALED':      return `se curou`;
+      case 'ENEMY_KILLED':       return `derrotou ${event.data.enemyName ?? 'um inimigo'}`;
+      case 'ITEM_USED':          return `usou ${event.data.itemName ?? 'um item'}`;
+      case 'ITEM_FOUND':         return `encontrou ${event.data.itemName ?? 'um item'}`;
+      case 'FLOOR_CHANGED':      return `desceu para o andar ${event.data.floor ?? '?'}`;
+      case 'PLAYER_NEAR_DEATH':  return `quase morreu`;
+      case 'PLAYER_DEATH':       return `morreu no andar ${event.data.floor ?? '?'}`;
+      case 'ELITE_ENEMY_FOUND':  return `enfrentou um inimigo elite: ${event.data.name ?? 'desconhecido'}`;
+      default:                   return `evento desconhecido`;
+    }
+  }
+
+  private _randomFallback(list: string[]): string {
+    return list[Math.floor(Math.random() * list.length)];
+  }
+}

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -7,6 +7,7 @@
 
 export { AIService } from './AIService';
 export { AIIntegration } from './AIIntegration';
+export { NarrativeService } from './NarrativeService';
 export { AI_CONFIG } from './config';
 
 export type {

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -1,19 +1,27 @@
 import * as Phaser from 'phaser';
+import { EventBus } from '../utils/EventBus';
+import { EVENTS } from '../utils/constants';
+import { AIService } from '../ai/AIService';
+import { NarrativeService } from '../ai/NarrativeService';
+import { AI_CONFIG } from '../ai/config';
+import type { GameEvent } from '../systems/EventMemory';
 
 interface GameOverData {
   level: number;
   xp: number;
+  events?: GameEvent[];
 }
 
 export class GameOverScene extends Phaser.Scene {
   private playerData!: GameOverData;
+  private _storyText!: Phaser.GameObjects.Text;
 
   constructor() {
     super({ key: 'GameOverScene' });
   }
 
   init(data: GameOverData): void {
-    this.playerData = data ?? { level: 1, xp: 0 };
+    this.playerData = data ?? { level: 1, xp: 0, events: [] };
   }
 
   create(): void {
@@ -21,22 +29,37 @@ export class GameOverScene extends Phaser.Scene {
     const cx = width / 2;
     const cy = height / 2;
 
-    this.add.rectangle(cx, cy, width, height, 0x000000, 0.85);
+    this.add.rectangle(cx, cy, width, height, 0x000000, 0.92);
 
-    this.add.text(cx, cy - 80, 'GAME OVER', {
+    this.add.text(cx, cy - 110, 'GAME OVER', {
       fontSize: '36px', color: '#ff4444', fontFamily: 'monospace', fontStyle: 'bold',
     }).setOrigin(0.5);
 
-    this.add.text(cx, cy - 20, `Nível atingido: ${this.playerData.level}`, {
-      fontSize: '20px', color: '#ffffff', fontFamily: 'monospace',
+    this.add.text(cx, cy - 65, `Nível atingido: ${this.playerData.level}`, {
+      fontSize: '18px', color: '#ffffff', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    this.add.text(cx, cy + 15, `XP total: ${this.playerData.xp}`, {
-      fontSize: '20px', color: '#ffdd00', fontFamily: 'monospace',
+    this.add.text(cx, cy - 40, `XP total: ${this.playerData.xp}`, {
+      fontSize: '18px', color: '#ffdd00', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    const btn = this.add.text(cx, cy + 70, '[ Jogar Novamente ]', {
-      fontSize: '22px', color: '#00ff88', fontFamily: 'monospace',
+    // ─── Área da história narrativa ───────────────────────────────────────
+    this.add.text(cx, cy - 10, '— A sua história —', {
+      fontSize: '12px', color: '#aaaaaa', fontFamily: 'monospace',
+    }).setOrigin(0.5);
+
+    this._storyText = this.add.text(cx, cy + 10, 'Gerando narrativa...', {
+      fontSize: '11px',
+      color: '#cccccc',
+      fontFamily: 'monospace',
+      fontStyle: 'italic',
+      wordWrap: { width: width * 0.75 },
+      align: 'center',
+    }).setOrigin(0.5, 0);
+
+    // ─── Botão de reinício ────────────────────────────────────────────────
+    const btn = this.add.text(cx, cy + 110, '[ Jogar Novamente ]', {
+      fontSize: '20px', color: '#00ff88', fontFamily: 'monospace',
       backgroundColor: '#003322', padding: { x: 16, y: 8 },
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });
 
@@ -46,11 +69,47 @@ export class GameOverScene extends Phaser.Scene {
 
     this.input.keyboard!.once('keydown-ENTER', () => this._restart());
     this.input.keyboard!.once('keydown-SPACE', () => this._restart());
+
+    // ─── Gerar narrativa de morte ─────────────────────────────────────────
+    this._generateDeathStory();
+
+    // Ouvir se a GameScene já gerou a história antes desta cena abrir
+    EventBus.on(EVENTS.DEATH_STORY_GENERATED, (data: { story: string }) => {
+      this._setStory(data.story);
+    }, this);
+  }
+
+  shutdown(): void {
+    EventBus.off(EVENTS.DEATH_STORY_GENERATED, undefined, this);
+  }
+
+  private _generateDeathStory(): void {
+    const events = this.playerData.events ?? [];
+
+    if (events.length === 0) {
+      this._setStory('Uma jornada sombria chegou ao fim nas profundezas da masmorra.');
+      return;
+    }
+
+    const aiService       = new AIService(AI_CONFIG.API_KEY);
+    const narrativeService = new NarrativeService(aiService);
+
+    narrativeService.generateDeathStory(events)
+      .then((story) => {
+        this._setStory(story);
+      })
+      .catch(() => {
+        this._setStory('Uma jornada sombria chegou ao fim nas profundezas da masmorra.');
+      });
+  }
+
+  private _setStory(story: string): void {
+    if (this._storyText?.active) {
+      this._storyText.setText(story);
+    }
   }
 
   private _restart(): void {
-    // scene.start() já para a cena atual automaticamente.
-    // Chamar stop() antes causava double-stop e corrompia o estado do Phaser.
     this.scene.start('GameScene');
   }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -23,6 +23,12 @@ import { DifficultyScalingSystem } from '../systems/DifficultyScalingSystem';
 import { PlayerMetrics } from '../systems/PlayerMetrics';
 import { DifficultyManager } from '../systems/DifficultyManager';
 import { DungeonFeatureGenerator, type DungeonFeature } from '../generators/DungeonFeatureGenerator';
+import { AIService } from '../ai/AIService';
+import { AIIntegration } from '../ai/AIIntegration';
+import { NarrativeService } from '../ai/NarrativeService';
+import { AI_CONFIG } from '../ai/config';
+import { EventMemory } from '../systems/EventMemory';
+import type { GameEventType } from '../systems/EventMemory';
 import { EquipmentSystem } from '../systems/EquipmentSystem';
 import { ShopSystem } from '../systems/ShopSystem';
 import { SHOP_CATALOG } from '../config/shop.catalog';
@@ -70,6 +76,10 @@ export class GameScene extends Phaser.Scene {
   private _spellSystem!: SpellSystem;
   private _spellCastingSystem!: SpellCastingSystem;
   private gameState!: string;
+
+  // ─── Narrativa emergente (Fase 6) ─────────────────────────────────────────
+  private _eventMemory!: EventMemory;
+  private _narrativeService!: NarrativeService;
 
   // Cache de andares visitados (runtime — não serializado ainda)
   private _dungeonCache = new Map<number, {
@@ -163,6 +173,11 @@ export class GameScene extends Phaser.Scene {
     this._spellSystem         = new SpellSystem();
     this._spellCastingSystem  = new SpellCastingSystem();
     this._registerTransitions();
+
+    // ─── Narrativa emergente (Fase 6) ──────────────────────────────────────
+    this._eventMemory     = new EventMemory();
+    const aiService       = new AIService(AI_CONFIG.API_KEY);
+    this._narrativeService = new NarrativeService(aiService);
 
     // Player criado uma vez — moves between areas
     this.player = new Player(this, TOWN.START_X, TOWN.START_Y);
@@ -459,6 +474,19 @@ export class GameScene extends Phaser.Scene {
 
     EventBus.emit(EVENTS.AREA_CHANGED, { area: 'dungeon', floor, timestamp: Date.now() });
     EventBus.emit(EVENTS.UI_LOG, cached ? `Você está no andar ${floor}.` : `Você desce para o andar ${floor}. Cuidado!`);
+
+    // Registrar mudança de andar na memória narrativa
+    if (!cached) {
+      this._recordGameEvent('FLOOR_CHANGED', { floor });
+
+      // Gerar narrativa ao descer de andar (não-bloqueante)
+      const recentEvents = this._eventMemory.getImportantEvents(8);
+      this._narrativeService.generateNarrative(recentEvents)
+        .then((narrative) => {
+          EventBus.emit(EVENTS.UI_LOG, narrative);
+          EventBus.emit(EVENTS.NARRATIVE_GENERATED, { narrative, floor });
+        });
+    }
   }
 
   private _generateInitialItems(): void {
@@ -664,6 +692,8 @@ export class GameScene extends Phaser.Scene {
 
       EventBus.emit(EVENTS.UI_LOG, `Você pegou ${displayName}`);
       EventBus.emit(EVENTS.ITEM_PICKED_UP, { item, slotIndex });
+      // Registrar na memória narrativa
+      this._recordGameEvent('ITEM_FOUND', { itemName: displayName });
     }
 
     this._items = this._items.filter(i => i.gridX !== null);
@@ -839,6 +869,8 @@ export class GameScene extends Phaser.Scene {
       if (dropped && e.gridX === this.player.gridX && e.gridY === this.player.gridY) {
         anyDroppedOnPlayerTile = true;
       }
+      // Registrar morte de inimigo na memória narrativa
+      this._recordGameEvent('ENEMY_KILLED', { enemyName: e.aiName ?? 'Inimigo' });
     });
     // Coletar drops que caíram no mesmo tile que o player (o pickup anterior rodou antes dos drops)
     if (anyDroppedOnPlayerTile) this._checkItemPickup();
@@ -1100,6 +1132,17 @@ export class GameScene extends Phaser.Scene {
     }
 
     EventBus.emit(EVENTS.ITEM_USED, { itemIndex: this._inventorySelectedIndex });
+    // Registrar uso de item na memória narrativa
+    if (result.success) {
+      const usedItem = this.player.inventory.getItem(this._inventorySelectedIndex);
+      const itemName = usedItem
+        ? usedItem.getDisplayName(this.player.identifiedItems)
+        : result.messages[0] ?? 'item';
+      this._recordGameEvent('ITEM_USED', { itemName });
+      if (result.hpDelta > 0) {
+        this._recordGameEvent('PLAYER_HEALED', { amount: result.hpDelta });
+      }
+    }
     this._clampInventorySelection();
     this._emitInventoryState();
   }
@@ -1322,10 +1365,28 @@ export class GameScene extends Phaser.Scene {
     this.events.on(EVENTS.PLAYER_DIED, () => {
       this.gameState = GAME_STATE.GAME_OVER;
       EventBus.emit(EVENTS.UI_LOG, 'Você morreu.');
+
+      // Registrar evento de morte na memória
+      this._recordGameEvent('PLAYER_DEATH', {
+        floor: this.floorManager?.currentFloor ?? 1,
+        level: this.player.level,
+      });
+
+      // Gerar história da run de forma assíncrona (não bloqueia)
+      const importantEvents = this._eventMemory.getImportantEvents(10);
+      this._narrativeService.generateDeathStory(importantEvents)
+        .then((story) => {
+          EventBus.emit(EVENTS.DEATH_STORY_GENERATED, { story });
+        });
+
       this.cameras.main.flash(500, 255, 0, 0);
       this.time.delayedCall(600, () => {
         this.scene.stop('UIScene');
-        this.scene.start('GameOverScene', { level: this.player.level, xp: this.player.xp });
+        this.scene.start('GameOverScene', {
+          level: this.player.level,
+          xp: this.player.xp,
+          events: this._eventMemory.getImportantEvents(10),
+        });
       });
     });
 
@@ -1358,6 +1419,12 @@ export class GameScene extends Phaser.Scene {
     this.events.on(EVENTS.DAMAGE_PLAYER, (data: { pos: { x: number; y: number }; damage: number }) => {
       this._showDamageText(data.pos, data.damage, COLORS.DAMAGE_TEXT);
       this._flashSprite(this.player);
+      // Registrar dano na memória narrativa
+      this._recordGameEvent('PLAYER_DAMAGED', { damage: data.damage });
+      // Verificar quase-morte (HP <= 20% do máximo)
+      if (this.player.hp > 0 && this.player.hp <= Math.floor(this.player.maxHp * 0.2)) {
+        this._recordGameEvent('PLAYER_NEAR_DEATH', { hp: this.player.hp });
+      }
     });
 
     EventBus.on(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
@@ -1449,6 +1516,12 @@ export class GameScene extends Phaser.Scene {
         this._emitInventorySelectionChanged();
       }
     }, this);
+  }
+
+  // ─── Narrativa: registro de eventos ─────────────────────────────────────
+
+  private _recordGameEvent(type: GameEventType, data: Record<string, unknown> = {}): void {
+    this._eventMemory.addEvent({ type, timestamp: Date.now(), data });
   }
 
   private _handleDialogInput(): void {

--- a/src/systems/EventMemory.ts
+++ b/src/systems/EventMemory.ts
@@ -1,0 +1,155 @@
+/**
+ * EventMemory.ts — Memória de eventos da partida
+ * Fase 6: Narrativa Emergente com IA
+ *
+ * Registra eventos importantes da run e os disponibiliza
+ * para o NarrativeService gerar narrativa contextualizada.
+ *
+ * PRINCÍPIO: A IA nunca inventa — só narra o que realmente aconteceu.
+ */
+
+export type GameEventType =
+  | 'PLAYER_DAMAGED'
+  | 'PLAYER_HEALED'
+  | 'ENEMY_KILLED'
+  | 'ITEM_USED'
+  | 'ITEM_FOUND'
+  | 'FLOOR_CHANGED'
+  | 'PLAYER_NEAR_DEATH'
+  | 'PLAYER_DEATH'
+  | 'ELITE_ENEMY_FOUND';
+
+export interface GameEvent {
+  type: GameEventType;
+  timestamp: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: Record<string, any>;
+}
+
+/** Eventos considerados "importantes" para a narrativa */
+const IMPORTANT_TYPES = new Set<GameEventType>([
+  'PLAYER_NEAR_DEATH',
+  'PLAYER_DEATH',
+  'ELITE_ENEMY_FOUND',
+  'FLOOR_CHANGED',
+  'ENEMY_KILLED',
+  'ITEM_FOUND',
+]);
+
+/** Máximo de eventos armazenados na memória */
+const MAX_EVENTS = 100;
+
+/** Mínimo de ms entre dois eventos do mesmo tipo (evita spam) */
+const DEBOUNCE_MS: Partial<Record<GameEventType, number>> = {
+  PLAYER_DAMAGED:    500,
+  PLAYER_HEALED:     500,
+  ENEMY_KILLED:      200,
+};
+
+export class EventMemory {
+  private _events: GameEvent[] = [];
+  private _lastTimestampByType: Partial<Record<GameEventType, number>> = {};
+
+  // ─── Adicionar ───────────────────────────────────────────────────────────
+
+  addEvent(event: GameEvent): void {
+    const debounce = DEBOUNCE_MS[event.type];
+    if (debounce !== undefined) {
+      const last = this._lastTimestampByType[event.type] ?? 0;
+      if (event.timestamp - last < debounce) return; // ignorar duplicata rápida
+    }
+
+    this._lastTimestampByType[event.type] = event.timestamp;
+    this._events.push(event);
+
+    // Manter tamanho máximo (FIFO)
+    if (this._events.length > MAX_EVENTS) {
+      this._events.shift();
+    }
+  }
+
+  // ─── Consulta ────────────────────────────────────────────────────────────
+
+  /** Retorna os N eventos mais recentes */
+  getRecentEvents(limit = 10): GameEvent[] {
+    return this._events.slice(-limit);
+  }
+
+  /**
+   * Retorna eventos importantes para a narrativa.
+   * Prioriza: morte, quase-morte, elites, mudança de andar, itens raros.
+   * Remove eventos repetitivos do mesmo tipo consecutivo.
+   */
+  getImportantEvents(limit = 10): GameEvent[] {
+    const important = this._events.filter(e => IMPORTANT_TYPES.has(e.type));
+
+    // Deduplicar: remover eventos do mesmo tipo consecutivos
+    const deduped: GameEvent[] = [];
+    let lastType: GameEventType | null = null;
+    for (const event of important) {
+      if (event.type !== lastType) {
+        deduped.push(event);
+        lastType = event.type;
+      }
+    }
+
+    return deduped.slice(-limit);
+  }
+
+  /** Retorna todos os eventos (para debug) */
+  getAllEvents(): GameEvent[] {
+    return [...this._events];
+  }
+
+  /** Conta quantas vezes um tipo de evento ocorreu */
+  countByType(type: GameEventType): number {
+    return this._events.filter(e => e.type === type).length;
+  }
+
+  /** Verifica se algum evento do tipo ocorreu */
+  hasEvent(type: GameEventType): boolean {
+    return this._events.some(e => e.type === type);
+  }
+
+  /** Reseta a memória (nova partida) */
+  reset(): void {
+    this._events = [];
+    this._lastTimestampByType = {};
+  }
+
+  // ─── Serialização para prompt ─────────────────────────────────────────────
+
+  /**
+   * Converte eventos em linhas de texto legíveis para o prompt da IA.
+   * Máximo de `limit` eventos, simplificados.
+   */
+  toPromptLines(limit = 10): string[] {
+    const events = this.getImportantEvents(limit);
+    return events.map(e => this._eventToText(e));
+  }
+
+  private _eventToText(event: GameEvent): string {
+    switch (event.type) {
+      case 'PLAYER_DAMAGED':
+        return `Jogador sofreu ${event.data.damage ?? '?'} de dano`;
+      case 'PLAYER_HEALED':
+        return `Jogador se curou ${event.data.amount ?? '?'} de HP`;
+      case 'ENEMY_KILLED':
+        return `Jogador derrotou ${event.data.enemyName ?? 'um inimigo'}`;
+      case 'ITEM_USED':
+        return `Jogador usou ${event.data.itemName ?? 'um item'}`;
+      case 'ITEM_FOUND':
+        return `Jogador encontrou ${event.data.itemName ?? 'um item'}`;
+      case 'FLOOR_CHANGED':
+        return `Jogador desceu para o andar ${event.data.floor ?? '?'}`;
+      case 'PLAYER_NEAR_DEATH':
+        return `Jogador quase morreu (HP muito baixo: ${event.data.hp ?? '?'})`;
+      case 'PLAYER_DEATH':
+        return `Jogador morreu no andar ${event.data.floor ?? '?'}`;
+      case 'ELITE_ENEMY_FOUND':
+        return `Jogador encontrou inimigo elite: ${event.data.name ?? 'desconhecido'}`;
+      default:
+        return `Evento: ${event.type}`;
+    }
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -197,6 +197,9 @@ export const EVENTS = {
   SPELLS_STATE_RESPONSE:    'spells-state-response',
   SPELL_EQUIP_REQUEST:      'spell-equip-request',
   SPELLS_SELECTION_CHANGED: 'spells-selection-changed',
+  // Narrativa emergente (Fase 6)
+  NARRATIVE_GENERATED:      'narrative-generated',
+  DEATH_STORY_GENERATED:    'death-story-generated',
 } as const;
 
 // --- Loja ---

--- a/tests/event-memory.test.js
+++ b/tests/event-memory.test.js
@@ -1,0 +1,142 @@
+/**
+ * event-memory.test.js — Testes do EventMemory
+ * Valida o registro, filtragem e serialização de eventos da run.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventMemory } from '../src/systems/EventMemory';
+
+function makeEvent(type, data = {}, timestamp = Date.now()) {
+  return { type, timestamp, data };
+}
+
+describe('EventMemory — addEvent', () => {
+  it('adiciona evento corretamente', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: 'Goblin' }));
+    expect(mem.getAllEvents()).toHaveLength(1);
+  });
+
+  it('respeita debounce para PLAYER_DAMAGED', () => {
+    const mem = new EventMemory();
+    const now = Date.now();
+    mem.addEvent(makeEvent('PLAYER_DAMAGED', { damage: 5 }, now));
+    mem.addEvent(makeEvent('PLAYER_DAMAGED', { damage: 5 }, now + 100)); // dentro do debounce
+    expect(mem.getAllEvents()).toHaveLength(1);
+  });
+
+  it('permite dois PLAYER_DAMAGED com intervalo suficiente', () => {
+    const mem = new EventMemory();
+    const now = Date.now();
+    mem.addEvent(makeEvent('PLAYER_DAMAGED', { damage: 5 }, now));
+    mem.addEvent(makeEvent('PLAYER_DAMAGED', { damage: 5 }, now + 600)); // fora do debounce
+    expect(mem.getAllEvents()).toHaveLength(2);
+  });
+
+  it('não aplica debounce para FLOOR_CHANGED', () => {
+    const mem = new EventMemory();
+    const now = Date.now();
+    mem.addEvent(makeEvent('FLOOR_CHANGED', { floor: 1 }, now));
+    mem.addEvent(makeEvent('FLOOR_CHANGED', { floor: 2 }, now + 10));
+    expect(mem.getAllEvents()).toHaveLength(2);
+  });
+});
+
+describe('EventMemory — getRecentEvents', () => {
+  it('retorna os N eventos mais recentes', () => {
+    const mem = new EventMemory();
+    for (let i = 0; i < 5; i++) {
+      mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: `Inimigo ${i}` }, Date.now() + i * 1000));
+    }
+    expect(mem.getRecentEvents(3)).toHaveLength(3);
+  });
+
+  it('retorna todos se limit > total', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ITEM_FOUND', { itemName: 'Poção' }));
+    expect(mem.getRecentEvents(10)).toHaveLength(1);
+  });
+});
+
+describe('EventMemory — getImportantEvents', () => {
+  it('filtra apenas eventos importantes', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('PLAYER_DAMAGED', { damage: 5 }));   // não importante
+    mem.addEvent(makeEvent('PLAYER_NEAR_DEATH', { hp: 5 }));    // importante
+    mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: 'X' })); // importante
+
+    const important = mem.getImportantEvents();
+    expect(important.every(e => ['PLAYER_NEAR_DEATH', 'ENEMY_KILLED'].includes(e.type))).toBe(true);
+  });
+
+  it('deduplica eventos consecutivos do mesmo tipo', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: 'A' }, Date.now()));
+    mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: 'B' }, Date.now() + 1000));
+    // Dois ENEMY_KILLED consecutivos → apenas 1 após deduplicação
+    expect(mem.getImportantEvents()).toHaveLength(1);
+  });
+
+  it('não deduplica eventos de tipos diferentes', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: 'A' }, Date.now()));
+    mem.addEvent(makeEvent('FLOOR_CHANGED', { floor: 2 }, Date.now() + 1000));
+    mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: 'B' }, Date.now() + 2000));
+    expect(mem.getImportantEvents()).toHaveLength(3);
+  });
+});
+
+describe('EventMemory — countByType e hasEvent', () => {
+  it('conta eventos por tipo', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ENEMY_KILLED', {}, Date.now()));
+    mem.addEvent(makeEvent('ENEMY_KILLED', {}, Date.now() + 1000));
+    expect(mem.countByType('ENEMY_KILLED')).toBe(2);
+  });
+
+  it('hasEvent retorna true quando evento existe', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('PLAYER_DEATH', { floor: 3 }));
+    expect(mem.hasEvent('PLAYER_DEATH')).toBe(true);
+  });
+
+  it('hasEvent retorna false quando evento não existe', () => {
+    const mem = new EventMemory();
+    expect(mem.hasEvent('ELITE_ENEMY_FOUND')).toBe(false);
+  });
+});
+
+describe('EventMemory — toPromptLines', () => {
+  it('converte eventos em linhas de texto legíveis', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ENEMY_KILLED', { enemyName: 'Goblin' }));
+    mem.addEvent(makeEvent('FLOOR_CHANGED', { floor: 2 }));
+    const lines = mem.toPromptLines();
+    expect(lines.some(l => l.includes('Goblin'))).toBe(true);
+    expect(lines.some(l => l.includes('andar 2'))).toBe(true);
+  });
+
+  it('retorna array vazio quando não há eventos importantes', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('PLAYER_DAMAGED', { damage: 5 })); // não importante
+    expect(mem.toPromptLines()).toHaveLength(0);
+  });
+});
+
+describe('EventMemory — reset', () => {
+  it('limpa todos os eventos', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ENEMY_KILLED', {}));
+    mem.addEvent(makeEvent('FLOOR_CHANGED', { floor: 2 }));
+    mem.reset();
+    expect(mem.getAllEvents()).toHaveLength(0);
+  });
+
+  it('permite adicionar eventos após reset', () => {
+    const mem = new EventMemory();
+    mem.addEvent(makeEvent('ENEMY_KILLED', {}));
+    mem.reset();
+    mem.addEvent(makeEvent('FLOOR_CHANGED', { floor: 1 }));
+    expect(mem.getAllEvents()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Descrição

Implementação completa da Fase 6: sistema de narrativa emergente com IA. O jogo agora registra os eventos reais da partida e usa o histórico do jogador para gerar narrativa contextualizada — a IA nunca inventa eventos, apenas amplifica o que realmente aconteceu.

---

## Tipo de mudança

- [x] `feat` — nova funcionalidade
- [ ] `fix` — correção de bug
- [ ] `refactor` — refatoração sem mudança de comportamento
- [ ] `docs` — apenas documentação
- [ ] `chore` — CI, dependências, configuração

---

## O que foi feito

**Novos arquivos:**
- `src/systems/EventMemory.ts` — registra eventos da run com debounce, filtragem de importantes e serialização para prompt
- `src/ai/NarrativeService.ts` — gera narrativa de andar e história de morte usando AIService com fallback
- `tests/event-memory.test.js` — 16 testes cobrindo todos os cenários

**Arquivos modificados:**
- `src/scenes/GameScene.ts` — inicializa EventMemory/NarrativeService, registra eventos em pontos-chave, gera narrativa ao descer de andar
- `src/scenes/GameOverScene.ts` — exibe história narrativa da run gerada pela IA
- `src/utils/constants.ts` — eventos `NARRATIVE_GENERATED` e `DEATH_STORY_GENERATED`
- `src/ai/index.ts` — exporta NarrativeService

**Fluxo completo:**
```
Evento ocorre → EventMemory registra →
Trigger (andar/morte) → NarrativeService gera texto →
UI exibe mensagem / GameOver exibe história
```

---

## Como testar

1. `npm install`
2. `npm test` — 141 testes devem passar
3. `npm run dev` → explorar a dungeon, descer andares e morrer para ver a narrativa

---

## Evidências

```
Test Files  11 passed (11)
     Tests  141 passed (141)
  Duration  380ms
```

---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/Andrea.md`
- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser