### PR TITLE
feat(ui): add run stats to game over screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 - Testes guia para `LogSystem` (`tests/log-system.test.js`): 10 testes prontos + 6 exercícios completados
 - Testes guia para `PlayerMetrics` (`tests/player-metrics.test.js`): 11 testes prontos + 7 exercícios completados
 - Cobertura completa de LogSystem (buffer, limite máximo, isDirty, buildViewModel, clear) e PlayerMetrics (contadores, score de performance, janela deslizante, reset)
+- **Tela de Game Over com estatísticas da partida**: ao morrer, o jogador vê nível alcançado, XP total, andares explorados, inimigos mortos, dano causado, dano recebido, turnos sobrevividos e itens usados — dados coletados pelo `PlayerMetrics` e passados via `scene.start()`
 
 ### Fixed
 

--- a/docs/prompts/Rafael.md
+++ b/docs/prompts/Rafael.md
@@ -15,3 +15,16 @@
 - `CombatSystem.resolve()` emite os eventos com posição em pixels via `getPixelPos()` opcional
 - `GameScene._flashSprite()`: método reutilizável para qualquer sprite
 - Fix: script `test` no `package.json` ajustado para Windows (Node.js v21)
+
+## feature/game-over-stats
+
+**Objetivo:** Melhorar a tela de Game Over com estatísticas da partida.
+
+**Prompt utilizado:**
+> "Pense como um desenvolvedor de jogos senior e sugira alguma melhoria de nível iniciante."
+> Escolha: Tela de Game Over com estatísticas da run.
+
+**O que foi implementado:**
+- `GameOverScene` atualizada com painel de estatísticas: nível, XP, andares explorados, inimigos mortos, dano causado, dano recebido, turnos sobrevividos e itens usados
+- `GameScene` passa os dados do `PlayerMetrics` e `DungeonFloorManager` via `scene.start()` ao transicionar para o Game Over
+- Interface `GameOverData` estendida com os novos campos opcionais de métricas

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -7,9 +7,16 @@ import { AI_CONFIG } from '../ai/config';
 import type { GameEvent } from '../systems/EventMemory';
 
 interface GameOverData {
-  level: number;
-  xp: number;
-  events?: GameEvent[];
+  level:          number;
+  xp:             number;
+  events?:        GameEvent[];
+  // Métricas da partida
+  turnsSurvived?: number;
+  damageDealt?:   number;
+  damageTaken?:   number;
+  enemiesKilled?: number;
+  itemsUsed?:     number;
+  floorsReached?: number;
 }
 
 export class GameOverScene extends Phaser.Scene {
@@ -27,44 +34,77 @@ export class GameOverScene extends Phaser.Scene {
   create(): void {
     const { width, height } = this.scale;
     const cx = width / 2;
-    const cy = height / 2;
 
-    this.add.rectangle(cx, cy, width, height, 0x000000, 0.92);
+    // Fundo escuro
+    this.add.rectangle(cx, height / 2, width, height, 0x000000, 0.95);
 
-    this.add.text(cx, cy - 110, 'GAME OVER', {
-      fontSize: '36px', color: '#ff4444', fontFamily: 'monospace', fontStyle: 'bold',
+    // ─── Título ───────────────────────────────────────────────────────────
+    this.add.text(cx, 40, '☠  VOCÊ MORREU  ☠', {
+      fontSize: '32px', color: '#ff4444', fontFamily: 'monospace', fontStyle: 'bold',
     }).setOrigin(0.5);
 
-    this.add.text(cx, cy - 65, `Nível atingido: ${this.playerData.level}`, {
-      fontSize: '18px', color: '#ffffff', fontFamily: 'monospace',
-    }).setOrigin(0.5);
+    // ─── Painel de estatísticas ───────────────────────────────────────────
+    const panelW = Math.min(420, width * 0.85);
+    const panelH = 220;
+    const panelX = cx - panelW / 2;
+    const panelY = 90;
 
-    this.add.text(cx, cy - 40, `XP total: ${this.playerData.xp}`, {
-      fontSize: '18px', color: '#ffdd00', fontFamily: 'monospace',
-    }).setOrigin(0.5);
+    // Fundo e borda do painel
+    this.add.rectangle(cx, panelY + panelH / 2, panelW, panelH, 0x111122, 0.9);
+    this.add.rectangle(cx, panelY + panelH / 2, panelW, panelH)
+      .setStrokeStyle(1, 0x4444aa);
+
+    const stats = [
+      { label: 'Nível alcançado',     value: this.playerData.level },
+      { label: 'XP total',            value: this.playerData.xp },
+      { label: 'Andares explorados',  value: this.playerData.floorsReached ?? 1 },
+      { label: 'Inimigos mortos',     value: this.playerData.enemiesKilled ?? 0 },
+      { label: 'Dano causado',        value: this.playerData.damageDealt ?? 0 },
+      { label: 'Dano recebido',       value: this.playerData.damageTaken ?? 0 },
+      { label: 'Turnos sobrevividos', value: this.playerData.turnsSurvived ?? 0 },
+      { label: 'Itens usados',        value: this.playerData.itemsUsed ?? 0 },
+    ];
+
+    const colLabelX = panelX + 20;
+    const colValueX = panelX + panelW - 20;
+    const lineH     = 24;
+    const startY    = panelY + 16;
+
+    stats.forEach((stat, i) => {
+      const y = startY + i * lineH;
+      this.add.text(colLabelX, y, stat.label, {
+        fontSize: '13px', color: '#aaaacc', fontFamily: 'monospace',
+      }).setOrigin(0, 0);
+      this.add.text(colValueX, y, String(stat.value), {
+        fontSize: '13px', color: '#ffffff', fontFamily: 'monospace', fontStyle: 'bold',
+      }).setOrigin(1, 0);
+    });
 
     // ─── Área da história narrativa ───────────────────────────────────────
-    this.add.text(cx, cy - 10, '— A sua história —', {
-      fontSize: '12px', color: '#aaaaaa', fontFamily: 'monospace',
+    const storyY = panelY + panelH + 16;
+
+    this.add.text(cx, storyY, '— A sua história —', {
+      fontSize: '11px', color: '#666688', fontFamily: 'monospace',
     }).setOrigin(0.5);
 
-    this._storyText = this.add.text(cx, cy + 10, 'Gerando narrativa...', {
+    this._storyText = this.add.text(cx, storyY + 18, 'Gerando narrativa...', {
       fontSize: '11px',
       color: '#cccccc',
       fontFamily: 'monospace',
       fontStyle: 'italic',
-      wordWrap: { width: width * 0.75 },
+      wordWrap: { width: panelW },
       align: 'center',
     }).setOrigin(0.5, 0);
 
     // ─── Botão de reinício ────────────────────────────────────────────────
-    const btn = this.add.text(cx, cy + 110, '[ Jogar Novamente ]', {
+    const btnY = height - 50;
+    const btn = this.add.text(cx, btnY, '[ Jogar Novamente ]', {
       fontSize: '20px', color: '#00ff88', fontFamily: 'monospace',
       backgroundColor: '#003322', padding: { x: 16, y: 8 },
     }).setOrigin(0.5).setInteractive({ useHandCursor: true });
 
     btn.on('pointerover', () => btn.setColor('#ffffff'));
-    btn.on('pointerout', () => btn.setColor('#00ff88'));
+    btn.on('pointerout',  () => btn.setColor('#00ff88'));
     btn.on('pointerdown', () => this._restart());
 
     this.input.keyboard!.once('keydown-ENTER', () => this._restart());
@@ -73,7 +113,6 @@ export class GameOverScene extends Phaser.Scene {
     // ─── Gerar narrativa de morte ─────────────────────────────────────────
     this._generateDeathStory();
 
-    // Ouvir se a GameScene já gerou a história antes desta cena abrir
     EventBus.on(EVENTS.DEATH_STORY_GENERATED, (data: { story: string }) => {
       this._setStory(data.story);
     }, this);
@@ -91,16 +130,12 @@ export class GameOverScene extends Phaser.Scene {
       return;
     }
 
-    const aiService       = new AIService(AI_CONFIG.API_KEY);
+    const aiService        = new AIService(AI_CONFIG.API_KEY);
     const narrativeService = new NarrativeService(aiService);
 
     narrativeService.generateDeathStory(events)
-      .then((story) => {
-        this._setStory(story);
-      })
-      .catch(() => {
-        this._setStory('Uma jornada sombria chegou ao fim nas profundezas da masmorra.');
-      });
+      .then((story) => this._setStory(story))
+      .catch(()     => this._setStory('Uma jornada sombria chegou ao fim nas profundezas da masmorra.'));
   }
 
   private _setStory(story: string): void {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1383,9 +1383,16 @@ export class GameScene extends Phaser.Scene {
       this.time.delayedCall(600, () => {
         this.scene.stop('UIScene');
         this.scene.start('GameOverScene', {
-          level: this.player.level,
-          xp: this.player.xp,
-          events: this._eventMemory.getImportantEvents(10),
+          level:         this.player.level,
+          xp:            this.player.xp,
+          events:        this._eventMemory.getImportantEvents(10),
+          // Métricas da partida
+          turnsSurvived: this.playerMetrics.turnsSurvived,
+          damageDealt:   this.playerMetrics.damageDealt,
+          damageTaken:   this.playerMetrics.damageTaken,
+          enemiesKilled: this.playerMetrics.enemiesKilled,
+          itemsUsed:     this.playerMetrics.itemsUsed,
+          floorsReached: this.floorManager?.currentFloor ?? 1,
         });
       });
     });


### PR DESCRIPTION
## O que foi feito

Melhora a tela de Game Over exibindo as estatísticas completas da partida, transformando a morte em uma experiência informativa e motivadora para tentar novamente.

## Mudanças

- `GameOverScene`: novo painel de estatísticas com 8 métricas — nível, XP, andares explorados, inimigos mortos, dano causado, dano recebido, turnos sobrevividos e itens usados
- `GameScene`: passa os dados do `PlayerMetrics` e `DungeonFloorManager` via `scene.start()` ao transicionar para o Game Over
- Interface `GameOverData` estendida com os novos campos opcionais de métricas
- Narrativa de IA mantida abaixo do painel de stats

## Testado

- 175/175 testes passando
- Hook pre-commit validado (testes + commitlint + arquivos obrigatórios)
