### PR TITLE
Feature/melhorias gerais 3

### DIFF
--- a/.kiro/specs/enemy.spec.md
+++ b/.kiro/specs/enemy.spec.md
@@ -7,17 +7,39 @@ Inimigos são entidades hostis posicionadas na dungeon. No MVP, possuem comporta
 
 ## Atributos
 
-| Atributo | Tipo   | Valor Padrão | Descrição                        |
-|----------|--------|--------------|----------------------------------|
-| hp       | number | 30           | Pontos de vida atuais            |
-| maxHp    | number | 30           | Pontos de vida máximos           |
-| attack   | number | 8            | Dano base causado ao player      |
-| xpReward | number | 25           | XP concedido ao player ao morrer |
-| gridX    | number | —            | Posição X no grid                |
-| gridY    | number | —            | Posição Y no grid                |
-| alive    | boolean| true         | Se o inimigo está vivo           |
+| Atributo    | Tipo          | Valor Padrão | Descrição                                                        |
+|-------------|---------------|--------------|------------------------------------------------------------------|
+| hp          | number        | —            | Pontos de vida atuais (derivado de `EnemyDef.hpBase` × escala)  |
+| maxHp       | number        | —            | Pontos de vida máximos                                           |
+| attack      | number        | —            | Dano base causado ao player (`EnemyDef.damageBase` × escala)    |
+| xpReward    | number        | —            | XP concedido ao player ao morrer (`EnemyDef.xpBase` × escala)   |
+| gridX       | number        | —            | Posição X no grid                                                |
+| gridY       | number        | —            | Posição Y no grid                                                |
+| alive       | boolean       | true         | Se o inimigo está vivo                                           |
+| category    | EnemyCategory | `'undead'`   | Categoria DawnLike — determina o par de spritesheets (*0/*1)     |
+| frameIndex  | number        | 0            | Índice do frame no spritesheet (mesmo em *0.png e *1.png)        |
+| enemyDefId  | string        | `'skeleton'` | ID da definição em `enemies.config.ts`                           |
+| enemyName   | string        | `'Inimigo'`  | Nome de exibição base (pode ser sobrescrito por `aiName`)        |
+| animKey     | string        | `''`         | Chave da animação Phaser pré-calculada em spawn via `buildAnimKey()` |
 
 ---
+
+## Spawn Procedural
+
+Os atributos base de cada inimigo são definidos em `src/config/enemies.config.ts` via `EnemyDef[]`. A função `pickEnemyDef(floor)` escolhe aleatoriamente uma definição válida para o andar atual (filtrada pelo campo `minFloor`). HP, ATK e XP são então escalados pelos multiplicadores de `DifficultyScalingSystem`.
+
+`EnemyCategory` determina o par de spritesheets DawnLike (`CATEGORY_TEXTURE_KEYS`):
+
+| Categoria   | Spritesheet *0        | Spritesheet *1        |
+|-------------|----------------------|-----------------------|
+| `undead`    | `undead` (Undead0)   | `undead1` (Undead1)   |
+| `humanoid`  | `humanoid0`          | `humanoid1`           |
+| `pest`      | `pest0`              | `pest1`               |
+| `misc`      | `misc0`              | `misc1`               |
+| `reptile`   | `reptile0`           | `reptile1`            |
+| `demon`     | `demon0`             | `demon1`              |
+
+A chave de animação (`animKey`) é construída por `buildAnimKey(category, frameIndex)` no momento do spawn e pré-armazenada — nunca reconstruída por frame. Animações são registradas globalmente em `BootScene._registerEnemyAnims()` com ping-pong de 2 fps entre os dois frames da categoria.
 
 ## Inputs
 

--- a/.kiro/specs/loot.spec.md
+++ b/.kiro/specs/loot.spec.md
@@ -2,30 +2,71 @@
 
 ## Descrição
 
-O LootSystem gerencia o drop de itens quando inimigos morrem. A lógica de probabilidade
-vive exclusivamente no sistema — a cena só registra o handler de `ITEM_DROPPED` para
-criar o sprite correspondente.
+O `LootSystem` gerencia dois tipos de loot: drops de inimigos ao morrer e loot de baús na dungeon.
+Toda lógica de probabilidade vive exclusivamente no sistema — a cena registra handlers de eventos
+para criar sprites e processar resultados.
 
 ---
 
-## Tabela de Drop
+## Drop de Inimigos
 
-| Resultado      | Probabilidade | ItemType       |
-|----------------|---------------|----------------|
-| Nada           | 40%           | —              |
-| Poção de Cura  | 30%           | `potion_heal`  |
-| Poção de Veneno| 20%           | `potion_poison`|
-| Ouro           | 10%           | `gold`         |
+### Tabela de Drop por Andar
 
-Constantes em `LOOT` (`src/utils/constants.ts`):
+| Andar | Nada  | Poção | Ouro  |
+|-------|-------|-------|-------|
+| 1     | 50%   | 8%    | 42%   |
+| 2     | 47%   | 8%    | 45%   |
+| 3     | 44%   | 7%    | 49%   |
+| 4     | 41%   | 7%    | 52%   |
+| 5+    | 38%   | 6%    | 56%   |
+
+### Valor de Ouro
+
+- Fórmula: `base = 5 + floor × 6`, variação ±30%
+- Inimigos elite recebem multiplicador 1.8×
+- Modificadores de classe (`luckMultiplier`, `extraDropChance`) do `ClassRulesEngine`
+
+### Frame Visual de Ouro (`Money.png`)
+
+| goldAmount    | Frame | Constante         |
+|---------------|-------|-------------------|
+| `< 20`        | 10    | `GOLD_SMALL`      |
+| `20 – 49`     | 9     | `GOLD_MEDIUM`     |
+| `≥ 50`        | 8     | `GOLD_LARGE`      |
+
+---
+
+## Loot de Baús (`rollChestLoot`)
+
+### Interface
+
 ```ts
-LOOT = {
-  CHANCE_NOTHING: 0.40,
-  CHANCE_HEAL:    0.30,
-  CHANCE_POISON:  0.20,
-  CHANCE_GOLD:    0.10,
+interface ChestLootResult {
+  type: 'gold' | 'potion' | 'equipment' | 'mimic';
+  item?: Item;
+  mimicDamage?: number;
 }
 ```
+
+### Tabela por Profundidade
+
+| Andar  | Gold  | Poção | Mímica | Equipamento |
+|--------|-------|-------|--------|-------------|
+| 1–2    | 60%   | 40%   | —      | —           |
+| 3–5    | 50%   | 30%   | 20%    | —           |
+| 6+     | 30%   | 20%   | —      | 50%         |
+
+- **Ouro de baú**: sempre maior que drop de inimigo (`pickGoldAmount(floor + 1..+3)`)
+- **Mímica**: dano direto ao player de 15–25; sprite do baú destruído, `metadata.opened = true`
+- **Equipamento**: sorteia pool por tier (mid / advanced / elite) com raridade e bônus escalados pelo andar
+
+### Pools de Equipamento
+
+| Tier      | Andar mínimo | Exemplos                              |
+|-----------|-------------|---------------------------------------|
+| Mid       | 1–5         | Espada de Ferro, Capacete de Couro    |
+| Advanced  | 6–9         | Espada de Aço, Capacete de Ferro      |
+| Elite     | 10+         | Espada de Obsidiana, Capacete de Mithril |
 
 ---
 
@@ -33,29 +74,36 @@ LOOT = {
 
 ```ts
 class LootSystem {
-  roll(gridX: number, gridY: number): Item | null
+  roll(gridX, gridY, floor?, elite?, classDef?): Item | null
+  rollChestLoot(floor: number): ChestLootResult
 }
 ```
 
-| Método  | Descrição                                                                          |
-|---------|------------------------------------------------------------------------------------|
-| `roll()`| Sorteia drop; se resultado ≠ nada, cria `Item` na posição e emite `ITEM_DROPPED`  |
-
 ---
 
-## Fluxo
+## Fluxo — Drop de Inimigo
 
 ```
-Inimigo morre (CombatSystem retorna enemiesDied)
-  → GameScene itera enemiesDied
-  → lootSystem.roll(enemy.gridX, enemy.gridY)
-    → Math.random() determina tipo
-    → se tipo != null: new Item(id, type, gridX, gridY)
-    → EventBus.emit(EVENTS.ITEM_DROPPED, { item })
+Inimigo morre → GameScene.result.enemiesDied
+  → lootSystem.roll(e.gridX, e.gridY, floor, e.isElite, player.classDef)
+    → sorteia tipo baseado na tabela do andar
+    → se gold: define goldAmount, Item criado, ITEM_DROPPED emitido
+    → se poção: Item criado, ITEM_DROPPED emitido
     → retorna Item (ou null)
-  → GameScene._handleItemDropped(data)
-    → _spawnDroppedItem(item) — cria sprite no mapa
-    → item adicionado a this._items
+  → GameScene._handleItemDropped → _spawnDroppedItem → item em _items com sprite
+```
+
+## Fluxo — Baú
+
+```
+Player pisa em feature.type === 'chest' (metadata.opened === false)
+  → GameScene._checkChestInteraction()
+    → lootSystem.rollChestLoot(floor)
+    → mimic  → player.hp -= mimicDamage; log; retorna
+    → gold   → item.gridX/Y = player.gridX/Y; _spawnDroppedItem(); _checkItemPickup()
+    → potion → idem gold
+    → equip  → player.inventory.addItem(item); ITEM_PICKED_UP emitido
+    → chest sprite destruído; _chestSprites.delete(key); feature.metadata.opened = true
 ```
 
 ---
@@ -65,32 +113,44 @@ Inimigo morre (CombatSystem retorna enemiesDied)
 - R1: Toda lógica de probabilidade fica em `LootSystem` — cenas não calculam chances
 - R2: `LootSystem` não importa nem referencia nenhuma Scene (apenas `EventBus` e `Item`)
 - R3: IDs de itens gerados por loot são sequenciais: `loot_0`, `loot_1`, …
-- R4: Drops só ocorrem na dungeon — `GameScene` só registra o handler enquanto em `dungeon`
+- R4: Drops de inimigos só ocorrem na dungeon — `GameScene` só registra o handler em `dungeon`
 - R5: Item dropado começa não-identificado (`identified: false`), igual a itens de dungeon
+- R6: Equipamentos de baú NÃO emitem `ITEM_DROPPED` — vão direto ao inventário
+- R7: `goldAmount` é propriedade formal de `Item` (`goldAmount?: number`)
 
 ---
 
 ## Eventos
 
-| Evento        | Payload      | Quem emite    | Quem escuta |
-|---------------|--------------|---------------|-------------|
-| `ITEM_DROPPED`| `{ item: Item }` | LootSystem | GameScene   |
+| Evento        | Payload              | Quem emite              | Quem escuta |
+|---------------|----------------------|-------------------------|-------------|
+| `ITEM_DROPPED`| `{ item: Item }`     | LootSystem (drop inimigo) | GameScene  |
 
 ---
 
 ## Cenários Testáveis
 
 ### Cenário 1 — Drop de poção de cura
-- **Dado**: `Math.random()` retorna 0.15 (< CHANCE_HEAL 0.30)
-- **Quando**: `lootSystem.roll(5, 5)` chamado
-- **Então**: `Item` criado com `type = 'potion_heal'`, `gridX = 5`, `gridY = 5`; `ITEM_DROPPED` emitido
+- **Dado**: floor 1, `Math.random()` retorna 0.51 (> nothing 0.50, dentro de potion 0.08)
+- **Quando**: `lootSystem.roll(5, 5, 1)` chamado
+- **Então**: `Item` com `type = 'potion_heal_light'` criado; `ITEM_DROPPED` emitido
 
 ### Cenário 2 — Sem drop
-- **Dado**: `Math.random()` retorna 0.05 (< CHANCE_NOTHING 0.40)
-- **Quando**: `lootSystem.roll(3, 7)` chamado
+- **Dado**: floor 1, `Math.random()` retorna 0.30 (< nothing 0.50)
+- **Quando**: `lootSystem.roll(3, 7, 1)` chamado
 - **Então**: retorna `null`, `ITEM_DROPPED` não emitido
 
-### Cenário 3 — Drop de ouro
-- **Dado**: `Math.random()` retorna 0.92 (>= 0.90, que é HEAL+POISON+GOLD threshold)
-- **Quando**: `lootSystem.roll(2, 2)` chamado
-- **Então**: `Item` criado com `type = 'gold'`; sprite usa `Money.png` frame 0
+### Cenário 3 — Drop de ouro, frame visual correto
+- **Dado**: floor 3, `Math.random()` retorna 0.80 (> nothing+potion, gold), `goldAmount >= 50`
+- **Quando**: `lootSystem.roll(2, 2, 3)` chamado; `_getItemVisual('gold', item.goldAmount)` chamado
+- **Então**: frame retornado é `DAWNLIKE_FRAMES.GOLD_LARGE` (8)
+
+### Cenário 4 — Baú em andar 5, retorno mímica
+- **Dado**: floor 5, `Math.random()` retorna 0.85 (> 0.80)
+- **Quando**: `lootSystem.rollChestLoot(5)` chamado
+- **Então**: `{ type: 'mimic', mimicDamage: N }` retornado com `15 <= N <= 25`
+
+### Cenário 5 — Baú em andar 8, retorno equipamento
+- **Dado**: floor 8, `Math.random()` retorna 0.25 (< 0.50)
+- **Quando**: `lootSystem.rollChestLoot(8)` chamado
+- **Então**: `{ type: 'equipment', item }` com `item.slotId` definido e `item.bonuses` escalados para floor 8

--- a/.kiro/specs/product.md
+++ b/.kiro/specs/product.md
@@ -12,6 +12,19 @@ O projeto é de contexto acadêmico e serve como demonstração de arquitetura m
 - Desenvolvedores e avaliadores acadêmicos interessados em arquitetura de jogos com JS/Phaser
 - Entusiastas de jogos browser-based sem necessidade de instalação
 
+## Fluxo de Entrada
+
+```
+BootScene (preload de assets + registro de animações)
+    ↓ 200ms
+MainMenuScene  →  [Novo Jogo]  →  GameScene
+               →  [Créditos]  →  CreditsScene  →  [Voltar]  →  MainMenuScene
+```
+
+- `MainMenuScene`: fundo `game_bg.png`, botões "Novo Jogo" / "Créditos", rodapé "Equipe 7 / vX.Y.Z" (versão lida dinamicamente do `package.json` via `__APP_VERSION__`)
+- `CreditsScene`: exibe roles e nomes da equipe (Bardo, Magos, Paladinos); botão voltar
+- `DEV_CONFIG.devMode = true` faz o `BootScene` pular o menu e ir direto à `GameScene`
+
 ## Core Gameplay
 
 O loop central é turn-based e tile-based:
@@ -118,6 +131,8 @@ Input do jogador → Resolve ação (mover/atacar/item/magia/esperar) → Turno 
 - Agression score (0–1) pelo `DifficultyManager`: alto → raio 1.5×, perseguição garantida
 - Variantes elite geradas por IA generativa (nome, habilidade especial, descrição narrativa)
 - Recompensa de XP ao morrer
+- **Spawn procedural por categoria**: `pickEnemyDef(floor)` seleciona um `EnemyDef` de `enemies.config.ts` filtrado por `minFloor`; atributos base (HP/ATK/XP) escalados por `DifficultyScalingSystem`
+- **Animação ping-pong**: cada inimigo toca uma animação 2fps entre os dois frames DawnLike de sua categoria (*0/*1); registradas globalmente em `BootScene._registerEnemyAnims()`; sprites criados em `GameScene._buildEnemySprite()` com fallback para `SPRITES.ENEMY` se textura ausente
 
 ### Progressão
 - XP necessário: `100 × N × (N + 1) / 2`

--- a/.kiro/specs/product.md
+++ b/.kiro/specs/product.md
@@ -76,13 +76,18 @@ Input do jogador → Resolve ação (mover/atacar/item/magia/esperar) → Turno 
 | NPCController | FSM Idle → Wander para NPCs da cidade; `customWanderBounds` por NPC |
 | InteractiveObjectSystem | Detecta proximidade player↔NPC; respeita `houseBounds`; dispara SHOP_OPENED ou DIALOG_OPENED |
 | CityDecorationSystem | Renderização de objetos do mundo com Y-sort automático |
-| LootSystem | Drop probability data-driven (40% nada, 30% heal, 20% poison, 10% gold) |
+| LootSystem | Drop probability data-driven por andar; `rollChestLoot()` para baús (ouro/poção/mímica/equipamento por tier) |
 | WorldSystem | Cache singleton: estado de dungeon e itens persistem dentro da sessão |
 | MapTransitionSystem | Orquestra transições town ↔ dungeon ↔ bonus |
 
+### Classes de Herói
+- Selecionadas na tela de menu antes de iniciar a partida
+- Cada classe define `statBonus` aplicado via `Player.applyClassBonus()`: atributos reais calculados como `BASE_STAT + bonus`, `recalcStats()` chamado em seguida, HP/Mana restaurados ao máximo
+- `classDef` é a fonte de verdade para regras de combate (corpo a corpo, arco, magia) via `ClassRulesEngine`
+
 ### Funcionalidades do Jogador
-- 6 atributos: STR, INT, DEX, CON, WIS, CHA
-- HP (`CON × 5 + Level × 3`) e Mana (`WIS × 4 + INT × 2`) derivados dos atributos; stats recalculados ao equipar/desequipar
+- 6 atributos: STR, INT, DEX, CON, WIS, CHA — inicializados com `BASE_STATS` + bônus da classe
+- HP (`CON × 5 + Level × 3`) e Mana (`WIS × 5 + INT × 2`) derivados dos atributos; stats recalculados ao equipar/desequipar
 - Movimento por teclado (setas ou WASD) no grid; cooldown 150ms por tile
 - Gold (começa com 500) exibido no HUD; atualizado em tempo real
 - 2 slots de magia (J/K) com cooldown independente
@@ -102,8 +107,9 @@ Input do jogador → Resolve ação (mover/atacar/item/magia/esperar) → Turno 
 
 ### Dungeon
 - Geração por BSP (Binary Space Partitioning) com corredores L-shaped
-- Múltiplos andares com cache de estado por andar: inimigos reiniciam, itens persistem
+- Múltiplos andares com cache de estado por andar: inimigos reiniciam, itens e baús persistem
 - Escadas bidirecionais: descida (andar N+1), subida (andar N-1), retorno à cidade pelo andar 1
+- **Baús**: 1–2 por andar gerados em rooms intermediárias; loot escalado por profundidade (ouro → poção → mímica → equipamento); baú aberto não reaparece ao re-entrar
 - **Autotiling semântico**: `AutoTileResolver` interpreta vizinhos cardinais e escolhe frame — face, cantos externos, cantos côncavos, corpo sólido
 - **Temas visuais por andar**: andares 1–2 Dungeon (pedra cinza), 3–4 Mine (terra), 5–6 Underworld (pedra escura), 7+ Underworld Boss (mix abismo)
 - `DungeonRenderer` emite `RenderCommand[]` — `GameScene` apenas cria sprites; arquitetura extensível para novas categorias (water, lava, chasm)

--- a/.kiro/specs/structure.md
+++ b/.kiro/specs/structure.md
@@ -18,10 +18,11 @@ dungeon-of-echoes/
 │   ├── main.ts
 │   │
 │   ├── config/
-│   │   ├── constants.ts        ← EVENTS, SHOP, TAVERN, TILE, COLORS, UI, INVENTORY…
+│   │   ├── constants.ts        ← EVENTS, SHOP, TAVERN, TILE, COLORS, UI, INVENTORY…; DEV_CONFIG (godMode, devMode)
 │   │   ├── town.config.ts      ← TownNPCDef[], TownBuildingDef[], TownConfig
 │   │   ├── sprites-config.ts   ← FLOOR_ATLAS, LAYER_*, DAWNLIKE_FRAMES
-│   │   └── shop.catalog.ts     ← SHOP_CATALOG[], createItemFromCatalogEntry(), buildBonusText()
+│   │   ├── shop.catalog.ts     ← SHOP_CATALOG[], createItemFromCatalogEntry(), buildBonusText()
+│   │   └── enemies.config.ts   ← EnemyDef[], EnemyCategory, CATEGORY_TEXTURE_KEYS, pickEnemyDef(), buildAnimKey()
 │   │
 │   ├── types/
 │   │   ├── town.ts             ← NPCInstanceDef, ProcessedTownLayout, DialogMenuOption
@@ -35,7 +36,9 @@ dungeon-of-echoes/
 │   │   └── CityLayoutProcessor.ts
 │   │
 │   ├── scenes/
-│   │   ├── BootScene.ts        ← Pré-carregamento de assets
+│   │   ├── BootScene.ts        ← Pré-carregamento de assets; transita para MainMenuScene (ou GameScene se devMode)
+│   │   ├── MainMenuScene.ts    ← Menu principal: fundo game_bg.png, botões Novo Jogo / Créditos, rodapé Equipe 7 + versão
+│   │   ├── CreditsScene.ts     ← Tela de créditos com roles e nomes da equipe; botão voltar ao menu
 │   │   ├── GameScene.ts        ← Orquestra sistemas; sem lógica de domínio
 │   │   ├── UIScene.ts          ← HUD e painéis via dirty flag; sem lógica de domínio
 │   │   └── GameOverScene.ts
@@ -86,7 +89,9 @@ Cenas Phaser que gerenciam o ciclo de vida visual do jogo. Não contêm lógica 
 
 | Arquivo | Responsabilidade |
 |---------|-----------------|
-| `BootScene.ts` | Pré-carregamento de assets, inicialização do RNG, transição para GameScene |
+| `BootScene.ts` | Pré-carregamento de assets, registro de animações; transita para `MainMenuScene` (ou `GameScene` se `DEV_CONFIG.devMode`) |
+| `MainMenuScene.ts` | Menu principal: fundo `game_bg.png`, botões "Novo Jogo" / "Créditos", rodapé "Equipe 7 + versão" |
+| `CreditsScene.ts` | Exibe roles e nomes da equipe; botão voltar ao `MainMenuScene` |
 | `GameScene.ts` | Loop principal; captura input via `InputModeManager`; delega para sistemas; sem lógica de domínio |
 | `UIScene.ts` | HUD persistente + painéis (inventory, shop, dialog, log, action bar); dirty flag por painel |
 | `GameOverScene.ts` | Exibe resumo da partida (andar, XP, nível) |
@@ -126,9 +131,10 @@ Cenas Phaser que gerenciam o ciclo de vida visual do jogo. Não contêm lógica 
 
 | Arquivo | Conteúdo |
 |---------|---------|
-| `constants.js` | `TILE_SIZE`, `GRID_W`, `GRID_H`, `VISION_RADIUS`, `XP_BASE`, etc. |
+| `constants.ts` | `TILE_SIZE`, `GRID_W`, `GRID_H`, `VISION_RADIUS`, `XP_BASE`, etc.; `DEV_CONFIG` com `godMode` e `devMode` |
 | `town.config.ts` | `TownConfig` com layout fixo da cidade e `biomeOverrides?` por tile key |
 | `sprites-config.ts` | `FLOOR_ATLAS` (bioma→frames+pesos), `OBJECT_ATLAS`, `NPC_ATLAS`; constantes `LAYER_GROUND`, `LAYER_WORLD_BASE`, `LAYER_OVERHEAD`, `LAYER_UI_LABELS` |
+| `enemies.config.ts` | `EnemyDef[]` com atributos base, `EnemyCategory`, `CATEGORY_TEXTURE_KEYS` (par DawnLike *0/*1), `pickEnemyDef(floor)`, `buildAnimKey()` |
 
 ### Configuração — `/src/config/`
 Constantes globais que evitam magic numbers espalhados pelo código.

--- a/.kiro/specs/tech.md
+++ b/.kiro/specs/tech.md
@@ -48,6 +48,7 @@ Benefícios diretos para este projeto:
 - Build otimizado para produção com tree-shaking nativo
 - Configuração mínima para projetos Phaser (sem webpack boilerplate)
 - Suporte nativo a ES Modules sem configuração adicional
+- `define: { __APP_VERSION__ }` em `vite.config.ts` expõe a versão de `package.json` ao código cliente; declarada em `src/vite-env.d.ts`; usada em `MainMenuScene` para exibição dinâmica no rodapé
 
 ### Vitest
 - API compatível com Jest — curva de aprendizado mínima
@@ -188,7 +189,7 @@ O MVP não usa:
 | Sem IA generativa | Fora do escopo do MVP; hooks preparados para expansão |
 | Sem backend | Jogo 100% client-side; sem servidor necessário |
 | Sem sistema de save | Permadeath intencional; simplifica implementação |
-| Sem animações complexas | Sprites simples ou formas geométricas são suficientes |
+| Animações limitadas a ping-pong 2fps por inimigo | Registradas globalmente em `BootScene._registerEnemyAnims()`; sem timelines ou tweens por entidade |
 | Sem banco de dados | Estado apenas em memória durante a sessão |
 | API key de IA exposta no frontend | Aceitável para protótipo acadêmico; inaceitável em produção |
 | Sem pipelines/shaders customizados | Fora do escopo; usar API padrão do Phaser 4 |

--- a/.kiro/steering/game-steering.md
+++ b/.kiro/steering/game-steering.md
@@ -66,6 +66,7 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 - **Variação de body walls deve ser mínima** — `bodyFrames` de `wall_edge` contém 1 frame; silhueta legível tem prioridade absoluta sobre detalhe de textura
 - **`BONUS_AREA_OVERRIDES` é estritamente isolado de `MANUAL_MAP_OVERRIDES`** — nunca cruzar importações entre `BonusAreaData.ts` e `TileProperties.ts`
 - **`DEV_CONFIG.godMode`** em `constants.ts` — flag de desenvolvimento; `CombatSystem` consulta antes de aplicar dano ao player; manter `false` em produção
+- **`DEV_CONFIG.devMode`** em `constants.ts` — quando `true`, `BootScene` transita diretamente para `GameScene` pulando o `MainMenuScene`; útil em desenvolvimento; manter `false` em produção
 - **Magias são data-driven** — `spells.db.ts` é a única fonte de verdade para atributos de magia; `spell-progression.ts` define quando cada magia é desbloqueada; nunca hardcodar IDs ou dano em Systems
 - **`SpellCastingSystem` nunca importa `SpellSystem` diretamente** — recebe instância como parâmetro em `cast()`; retorna `SpellCastResult` com `hitEnemies: EnemySystem[]`
 - **Magias são melee-range** — `SpellCastingSystem.cast()` verifica os 4 tiles cardinais adjacentes ao player e aplica dano em todos os inimigos encontrados; sem projétil
@@ -77,8 +78,10 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 
 ```
 /src
-  /scenes       → Cenas Phaser (Boot, Game, GameOver, UI, VisualRegression*)
+  /scenes       → Cenas Phaser (Boot, MainMenu, Credits, Game, GameOver, UI, VisualRegression*)
                    * VisualRegressionScene existe exclusivamente para regressão de autotiling; não é cena de produção
+                   * Fluxo normal: BootScene → MainMenuScene → GameScene
+                   * Com devMode=true: BootScene → GameScene (pula menu)
   /systems      → Lógica de jogo (sem dependência de Phaser):
                    TurnManager, CombatSystem, EnemySystem, XPSystem
                    InventorySystem, EquipmentSystem, ShopSystem
@@ -94,7 +97,7 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
   /generators   → DungeonGenerator, DungeonFeatureGenerator, CityLayoutProcessor, TileVariantResolver
   /config       → constants.ts, town.config.ts, sprites-config.ts, shop.catalog.ts
                    spells.db.ts, spell-progression.ts, dungeon-themes.ts, difficulty.config.ts
-                   BonusAreaData.ts, TileProperties.ts
+                   BonusAreaData.ts, TileProperties.ts, enemies.config.ts
   /types        → town.ts, equipment.ts, viewmodels.ts, input.ts, spells.ts, difficulty.ts
   /utils        → EventBus, constants
   /ui           → InventoryPanel, ShopPanel, DialogPanel, LogPanel, ActionBarPanel, SpellsPanel, StatusPanel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,17 +48,45 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ---
 
-## [Unreleased]
+## [0.6.0] — 2026-05-16
 
 ### Added
+
+#### Classes de Herói com Bônus de Atributo
+
+- **`Player.applyClassBonus(classDef)`**: aplica os bônus de `classDef.statBonus` aos campos individuais de atributo (`str`, `intel`, `dex`, `con`, `wis`), chama `recalcStats()` e restaura HP/Mana ao máximo — garante que cada classe inicie com os stats corretos
+- `GameScene` chama `applyClassBonus()` após atribuir a classe selecionada ao Player, corrigindo o bug em que todas as classes iniciavam com STR/INT/DEX/WIS = 10 e CON = 18 independente da classe
+
+#### Sistema de Drops Visuais de Ouro por Quantidade
+
+- **Frames de ouro por tier** em `DAWNLIKE_FRAMES` (`constants.ts`): `GOLD_SMALL: 10` (moeda única, `goldAmount < 20`), `GOLD_MEDIUM: 9` (pilha média, 20–49), `GOLD_LARGE: 8` (pilha grande, ≥ 50) — todos da Row 2 de `Money.png`
+- `_getItemVisual()` em `GameScene` seleciona o frame correto baseado em `goldAmount` do item; gold dropado por inimigos agora escala visualmente com a quantidade
+- Valor de ouro escalado por andar: `base = 5 + floor × 6` com ±30% de variação aleatória; inimigos elite dropamd 1.8× mais ouro
+
+#### Sistema de Baús nas Dungeons
+
+- **`FeatureType.chest`** em `DungeonFeatureGenerator`: além de escadas, cada andar spawna 1–2 baús em rooms intermediárias (excluindo a primeira e última sala), armazenados com `metadata: { opened: false }`
+- **Renderização de baú**: `_renderDungeonFeatures()` cria sprite com frame `DAWNLIKE_FRAMES.CHEST` (14) para cada baú não aberto; sprites rastreados em `_chestSprites: Map<string, Phaser.GameObjects.Sprite>` para destruição controlada
+- **`LootSystem.rollChestLoot(floor)`**: loot de baú por tier de andar:
+  - Andar 1–2: 60% ouro (maior que drop comum) | 40% poção
+  - Andar 3–5: 50% ouro | 30% poção | 20% mímica (player toma 15–25 de dano)
+  - Andar 6+: 50% equipamento gerado para o andar | 30% ouro | 20% poção forte
+- **`_checkChestInteraction()`** em `GameScene`: ao pisar em baú não aberto, processa resultado — mímica aplica dano direto, ouro/poção são criados e coletados imediatamente, equipamento vai direto ao inventário; sprite do baú destruído e `metadata.opened = true` persiste no cache do andar
+- Baús abertos não reaparecem ao re-entrar no mesmo andar
+- Equipamentos de baú com 3 pools por tier de andar (mid/advanced/elite) e raridade escalada com profundidade
+
+#### Testes e Cobertura
+
 - Testes guia para `LogSystem` (`tests/log-system.test.js`): 10 testes prontos + 6 exercícios completados
 - Testes guia para `PlayerMetrics` (`tests/player-metrics.test.js`): 11 testes prontos + 7 exercícios completados
-- Cobertura completa de LogSystem (buffer, limite máximo, isDirty, buildViewModel, clear) e PlayerMetrics (contadores, score de performance, janela deslizante, reset)
+- Cobertura completa de `LogSystem` (buffer, limite máximo, isDirty, buildViewModel, clear) e `PlayerMetrics` (contadores, score de performance, janela deslizante, reset)
 - **Tela de Game Over com estatísticas da partida**: ao morrer, o jogador vê nível alcançado, XP total, andares explorados, inimigos mortos, dano causado, dano recebido, turnos sobrevividos e itens usados — dados coletados pelo `PlayerMetrics` e passados via `scene.start()`
 
 ### Fixed
 
-- Sprites de itens no chão da dungeon agora desaparecem corretamente após o jogador coletá-los: removidos os calls `setVisible(false).setActive(false)` antes de `destroy()` — em Phaser 4 desativar o sprite antes de destruí-lo impedia a remoção da display list; cache do andar (`_dungeonCache`) agora é atualizado após o filtro de coleta para manter consistência ao re-entrar no mesmo andar
+- **Classes não aplicavam bônus de atributo ao iniciar**: `player.classDef` era atribuído mas `statBonus` nunca aplicado aos campos individuais; corrigido com `applyClassBonus()` chamado na inicialização
+- **Sprites de moeda de ouro não desapareciam ao coletar**: `_spawnDroppedItem()` tornada idempotente — destrói sprite existente antes de criar novo e guarda com `includes()` check para não adicionar o mesmo item a `_items` duas vezes; `goldAmount` declarada como propriedade formal em `Item` (era assignment dinâmico sem declaração de tipo)
+- Sprites de itens no chão da dungeon desaparecem corretamente após coleta: cache do andar (`_dungeonCache`) atualizado após o filtro de coleta para manter consistência ao re-entrar no mesmo andar
 
 ---
 
@@ -596,7 +624,7 @@ procedural de masmorras, combate turno-a-turno e progressão de personagem.
 
 ---
 
-[Unreleased]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.4...HEAD
+[0.6.0]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.1...v0.5.2

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,10 +1,10 @@
 # PRD — Product Requirements Document
 # Dungeon of Echoes
 
-**Versão:** 0.5.4  
-**Data:** 2026-05-12  
+**Versão:** 0.6.0  
+**Data:** 2026-05-16  
 **Equipe:** Equipe 7 — IA para DEVs SCTEC T2  
-**Status:** v0.5.4 entregue — Sistema de Magias melee-range, dois slots J/K no footer, navegação por teclado no painel de magias
+**Status:** v0.6.0 entregue — Classes de herói com bônus de atributo, drops visuais de ouro por quantidade e sistema de baús com loot por profundidade
 
 ---
 
@@ -238,7 +238,7 @@ Os requisitos abaixo são derivados diretamente das specs em `.kiro/specs/`.
 
 ## 9. Escopo
 
-### Dentro do escopo (v0.5.3 — estado atual)
+### Dentro do escopo (v0.6.0 — estado atual)
 
 - [x] Geração procedural de dungeon (salas + corredores BSP, 40×40 tiles)
 - [x] Player controlável (4 direções, turn-based real via TurnManager)
@@ -258,9 +258,12 @@ Os requisitos abaixo são derivados diretamente das specs em `.kiro/specs/`.
 - [x] Área bônus (30×22 tiles) com renderer próprio, debug idêntico à cidade e overrides isolados
 - [x] `DEV_CONFIG.godMode` para testes sem risco de morte
 - [x] Integração com IA generativa (AIService — descrições atmosféricas de itens e inimigos elite)
-- [x] Game Over com tela de resultado e restart
-- [x] 125+ testes unitários
+- [x] Game Over com tela de resultado e restart (estatísticas completas via PlayerMetrics)
+- [x] 125+ testes unitários (+ testes guia de LogSystem e PlayerMetrics)
 - [x] Dashboard estático de acompanhamento do projeto
+- [x] Classes de herói com bônus de atributo aplicados ao iniciar (`applyClassBonus`)
+- [x] Drops de ouro com tier visual (GOLD_SMALL/MEDIUM/LARGE) baseados em quantidade
+- [x] Baús nas dungeons: geração procedural, loot por profundidade, interação com mímica
 
 ### Fora do escopo (planejado para versões futuras)
 
@@ -368,7 +371,18 @@ Os requisitos abaixo são derivados diretamente das specs em `.kiro/specs/`.
 - [x] XPSystem integrado: desbloqueia magias automaticamente ao subir de nível
 - [x] Barra de HP do inimigo atualizada imediatamente após dano de magia
 
-### v0.6.0 — FOG of War (planejado)
+### v0.6.0 — Classes, Drops Visuais e Baús (entregue em 2026-05-16)
+- [x] `Player.applyClassBonus()`: aplica `statBonus` da classe selecionada aos atributos reais; `recalcStats()` + restauro de HP/Mana
+- [x] Drops de ouro com tier visual: `GOLD_SMALL` / `GOLD_MEDIUM` / `GOLD_LARGE` baseados em `goldAmount` (frames da Row 2 de `Money.png`)
+- [x] `DungeonFeatureGenerator`: tipo `chest` — 1–2 baús por andar em rooms intermediárias com `metadata.opened`
+- [x] `LootSystem.rollChestLoot()`: loot de baú por profundidade (ouro/poção/mímica/equipamento)
+- [x] `GameScene._checkChestInteraction()`: interação completa com baú (dano de mímica, coleta de ouro/poção, equipamento direto ao inventário)
+- [x] `Item.goldAmount` declarada como propriedade formal (era assignment dinâmico sem tipagem)
+- [x] `_spawnDroppedItem()` idempotente: evita sprites duplicados e dupla inserção em `_items`
+- [x] Tela de Game Over com estatísticas completas da partida via `PlayerMetrics`
+- [x] Testes guia para `LogSystem` e `PlayerMetrics` com exercícios
+
+### v0.7.0 — FOG of War (planejado)
 - [ ] FOG of War: HIDDEN / VISIBLE / REVEALED por tile
 - [ ] Minimap com estado de exploração
 

--- a/docs/characters-sprites-rendering.md
+++ b/docs/characters-sprites-rendering.md
@@ -1,0 +1,461 @@
+# Characters Sprites Rendering — Documentação Técnica
+
+> Documento de referência para entender, manter e aprimorar o sistema de renderização de sprites de inimigos.
+> Estado atual: v1.0.0 — Sistema data-driven com distribuição por andar e animações ping-pong DawnLike.
+
+---
+
+## 1. Visão Geral
+
+O sistema transforma uma **definição de inimigo em memória** (`EnemySystem`) em um **sprite Phaser animado** com textura e animação corretas para o andar atual da dungeon.
+
+Fluxo resumido:
+
+```
+enemies.config.ts       BootScene.preload()         BootScene.create()
+(catálogo de defs)  →  (carrega spritesheets)   →  (registra animações)
+        ↓
+EnemySystem.createEnemies(floor)     →   EnemyDef selecionado por pickEnemyDef()
+        ↓
+GameScene._buildEnemySprite()        →   sprite.play(animKey)
+```
+
+---
+
+## 2. Estrutura de Assets DawnLike
+
+### 2.1 Localização
+
+```
+public/assets/dawnlike/Characters/
+  Pest0.png       Pest1.png
+  Misc0.png       Misc1.png
+  Reptile0.png    Reptile1.png
+  Undead0.png     Undead1.png
+  Humanoid0.png   Humanoid1.png
+  Demon0.png      Demon1.png
+  (+ outros não usados por inimigos: Avian, Cat, Dog, Elemental, Plant, Quadraped, Rodent, Slime)
+```
+
+### 2.2 Convenção de Pares *0 / *1
+
+O DawnLike organiza animações em pares de arquivos:
+
+| Arquivo | Papel |
+|---------|-------|
+| `{Categoria}0.png` | Frame base (posição inicial do ciclo) |
+| `{Categoria}1.png` | Frame alternativo (posição oposta do ciclo) |
+
+**Regra crítica:** o mesmo índice `N` em `*0.png` e `*1.png` representa **o mesmo inimigo** em fases opostas do movimento. A animação alterna entre os dois.
+
+### 2.3 Grid de Frames
+
+Todos os spritesheets de personagens seguem o grid:
+
+```
+frameWidth:  16px
+frameHeight: 16px
+colunas:     8
+```
+
+Mapeamento de linha para índice base:
+
+```
+Linha 0 → frames  0– 7
+Linha 1 → frames  8–15
+Linha 2 → frames 16–23
+Linha 3 → frames 24–31
+...
+Linha N → frames N*8 .. N*8+7
+```
+
+`frameIndex` em `EnemyDef` é sempre o **primeiro frame da linha** (múltiplo de 8), garantindo que *0 e *1 apontem para o mesmo inimigo.
+
+---
+
+## 3. Catálogo de Inimigos (`enemies.config.ts`)
+
+### 3.1 Tipos
+
+```typescript
+type EnemyCategory = 'pest' | 'misc' | 'reptile' | 'undead' | 'humanoid' | 'demon';
+type EnemyRarity   = 'common' | 'uncommon' | 'rare';
+```
+
+### 3.2 Interface EnemyDef
+
+```typescript
+interface EnemyDef {
+  id:          string;         // identificador imutável
+  category:    EnemyCategory;  // define o par de spritesheets
+  frameIndex:  number;         // índice no grid (múltiplo de 8)
+  name:        string;         // nome de exibição base
+  hpBase:      number;         // HP antes dos multiplicadores
+  damageBase:  number;         // ATK antes dos multiplicadores
+  xpBase:      number;         // XP antes do multiplicador de andar
+  rarity:      EnemyRarity;    // peso na seleção procedural
+  dungeonMin:  number;         // andar mínimo (inclusivo)
+  dungeonMax:  number;         // andar máximo (99 = sem limite)
+  description?: string;        // lore opcional
+}
+```
+
+### 3.3 Catálogo Atual
+
+| id | category | frameIndex | name | Andares | Raridade |
+|----|----------|-----------|------|---------|----------|
+| `rat` | pest | 0 | Rato Feroz | 1–2 | common |
+| `spider` | pest | 8 | Aranha Venenosa | 1–2 | common |
+| `centipede` | pest | 16 | Centopeia Gigante | 1–2 | uncommon |
+| `slime` | misc | 0 | Gosma | 1–2 | common |
+| `mushroom_stalker` | misc | 8 | Cogumelo Ambulante | 1–2 | uncommon |
+| `lizard` | reptile | 0 | Lagarto das Pedras | 1–2 | common |
+| `serpent` | reptile | 8 | Serpente das Ruínas | 1–2 | uncommon |
+| `skeleton` | undead | 0 | Esqueleto | 3–4 | common |
+| `zombie` | undead | 8 | Zumbi | 3–4 | common |
+| `ghost` | undead | 16 | Fantasma Sombrio | 3–4 | rare |
+| `goblin` | humanoid | 0 | Goblin | 5+ | common |
+| `orc` | humanoid | 8 | Orc Guerreiro | 5+ | uncommon |
+| `dark_elf` | humanoid | 16 | Elfo das Sombras | 5+ | rare |
+| `imp` | demon | 0 | Imp | 5+ | common |
+| `demon_lord` | demon | 8 | Senhor Demônio | 6+ | rare |
+
+---
+
+## 4. Carregamento de Assets (`BootScene.ts`)
+
+### 4.1 Chaves de Textura Registradas
+
+```typescript
+// Já existentes antes deste sistema (não recarregadas):
+'undead'    → Undead0.png   (SPRITES.ENEMY — alias legado)
+'humanoid0' → Humanoid0.png (NPC_ATLAS — NPCs da cidade)
+
+// Carregadas pelo sistema de inimigos:
+'pest0'     → Pest0.png
+'pest1'     → Pest1.png
+'misc0'     → Misc0.png
+'misc1'     → Misc1.png
+'reptile0'  → Reptile0.png
+'reptile1'  → Reptile1.png
+'undead1'   → Undead1.png
+'humanoid1' → Humanoid1.png
+'demon0'    → Demon0.png
+'demon1'    → Demon1.png
+```
+
+### 4.2 Mapeamento Categoria → Chaves
+
+Definido em `CATEGORY_TEXTURE_KEYS` (enemies.config.ts):
+
+```typescript
+const CATEGORY_TEXTURE_KEYS: Record<EnemyCategory, [string, string]> = {
+  pest:     ['pest0',     'pest1'],
+  misc:     ['misc0',     'misc1'],
+  reptile:  ['reptile0',  'reptile1'],
+  undead:   ['undead',    'undead1'],   // alias legado para Undead0
+  humanoid: ['humanoid0', 'humanoid1'],
+  demon:    ['demon0',    'demon1'],
+};
+```
+
+### 4.3 Deduplicação de Loads
+
+O preload usa o mesmo `Set<string> loaded` compartilhado com `FLOOR_ATLAS`, `OBJECT_ATLAS` e `NPC_ATLAS`, garantindo que nenhuma textura seja carregada duas vezes por sessão:
+
+```typescript
+for (const [key, file] of pairs) {
+  if (loaded.has(key)) continue;
+  this.load.spritesheet(key, `${chars}/${file}`, frameConfig);
+  loaded.add(key);
+}
+```
+
+---
+
+## 5. Sistema de Animações
+
+### 5.1 Estratégia Ping-Pong
+
+Cada animação usa exatamente **2 frames**: o frame de índice `N` em `*0.png` e o frame de índice `N` em `*1.png`:
+
+```typescript
+frames: [
+  { key: 'pest0', frame: 12 },
+  { key: 'pest1', frame: 12 },
+]
+```
+
+Phaser itera os frames em loop (`repeat: -1`), alternando continuamente entre os dois arquivos.
+
+### 5.2 Chave de Animação
+
+Gerada pela função `buildAnimKey()` (enemies.config.ts):
+
+```typescript
+function buildAnimKey(category, frameIndex, variant = 'idle'): string {
+  return `enemy.${category}.${variant}.${frameIndex}`;
+}
+```
+
+**Exemplos:**
+```
+enemy.pest.idle.0
+enemy.pest.idle.8
+enemy.undead.idle.16
+enemy.demon.idle.0
+```
+
+O segmento `variant` está reservado para extensão futura:
+
+| variant | Uso pretendido |
+|---------|---------------|
+| `idle` | Respiração / ciclo de espera (atual) |
+| `walk` | Movimento em direção ao player |
+| `attack` | Frame de ataque |
+| `hit` | Frame de recebimento de dano |
+| `death` | Animação de morte |
+
+### 5.3 Registro Global
+
+Animações são registradas **uma única vez** em `BootScene.create()` via `_registerEnemyAnims()`:
+
+```typescript
+for (const def of ENEMY_DEFS) {
+  const [tex0, tex1] = CATEGORY_TEXTURE_KEYS[def.category];
+  const animKey = buildAnimKey(def.category, def.frameIndex);
+
+  // Idempotente: não recria se já existir
+  if (!this.anims.exists(animKey)) {
+    this.anims.create({
+      key: animKey,
+      frames: [
+        { key: tex0, frame: def.frameIndex },
+        { key: tex1, frame: def.frameIndex },
+      ],
+      frameRate: 2,   // lento — adequado para turn-based
+      repeat: -1,
+    });
+  }
+}
+```
+
+**Total de animações criadas:** 1 por entrada em `ENEMY_DEFS` (~15 atualmente).
+
+O `AnimationManager` do Phaser é **global por cena** — múltiplos sprites reusam a mesma definição sem duplicação de memória.
+
+### 5.4 Parâmetros de Animação
+
+| Parâmetro | Valor | Justificativa |
+|-----------|-------|---------------|
+| `frameRate` | 2 | Ritmo visual turn-based; muito rápido seria confuso |
+| `repeat` | -1 | Infinito — animação nunca para |
+| Frames por ciclo | 2 | Suficiente para indicar vida; mínimo de memória |
+
+---
+
+## 6. Distribuição Procedural por Andar
+
+### 6.1 Regras de Categoria
+
+```
+Andares 1–2 → pest, misc, reptile
+Andares 3–4 → undead
+Andares 5+  → humanoid, demon
+```
+
+Implementado em `FLOOR_CATEGORY_RULES` (enemies.config.ts) como array de objetos `{ minFloor, maxFloor, categories }`.
+
+### 6.2 Seleção Ponderada (`pickEnemyDef`)
+
+```
+1. Filtra ENEMY_DEFS pelas categorias do andar
+2. Filtra pelo intervalo dungeonMin ≤ floor ≤ dungeonMax
+3. Aplica weighted random por RARITY_WEIGHTS
+```
+
+**Pesos de raridade:**
+```
+common:   100   (~67% do peso total em um pool típico)
+uncommon:  40   (~27%)
+rare:      10   (~6%)
+```
+
+**Fallbacks em cascata** (logados apenas em `import.meta.env.DEV`):
+1. Pool ideal: categoria + faixa correta
+2. Pool relaxado: apenas faixa de dungeon
+3. Pool global: primeiro inimigo definido
+
+### 6.3 Weighted Random
+
+```typescript
+function weightedRandom<T>(items, getWeight): T {
+  const total = items.reduce((sum, item) => sum + getWeight(item), 0);
+  let roll = Math.random() * total;
+  for (const item of items) {
+    roll -= getWeight(item);
+    if (roll <= 0) return item;
+  }
+  return items[items.length - 1]; // guarda contra floating point
+}
+```
+
+---
+
+## 7. Ciclo de Vida de um Sprite de Inimigo
+
+### 7.1 Spawn
+
+```typescript
+// EnemySystem.createEnemies(dungeon, playerPos, difficulty)
+const def = pickEnemyDef(floor);
+
+enemy.category   = def.category;
+enemy.frameIndex = def.frameIndex;
+enemy.enemyDefId = def.id;
+enemy.enemyName  = def.name;
+enemy.animKey    = buildAnimKey(def.category, def.frameIndex);
+
+// HP/ATK escalam pelos multiplicadores de difficulty.config.ts
+enemy.hp     = round(def.hpBase     × hpScale);
+enemy.attack = round(def.damageBase × atkScale);
+enemy.xp     = round(def.xpBase     × xpScale);
+```
+
+### 7.2 Criação do Sprite (`_buildEnemySprite`)
+
+```typescript
+// GameScene._buildEnemySprite(enemy)
+
+// 1. Resolve textura com fallback
+const [tex0] = CATEGORY_TEXTURE_KEYS[enemy.category];
+const texKey = this.textures.exists(tex0) ? tex0 : SPRITES.ENEMY;
+
+// 2. Cria sprite no frameIndex correto
+enemy.sprite = this.add.sprite(pos.x, pos.y, texKey, enemy.frameIndex).setDepth(5);
+
+// 3. Toca animação se registrada
+if (enemy.animKey && this.anims.exists(enemy.animKey)) {
+  enemy.sprite.play(enemy.animKey);
+}
+
+// 4. Barras de HP (sem alteração em relação ao sistema anterior)
+enemy.hpBarBg = this.add.rectangle(..., 0x330000).setDepth(6);
+enemy.hpBar   = this.add.rectangle(..., 0xff2222).setDepth(6);
+```
+
+### 7.3 Sync por Turno
+
+`_syncEnemySprite(enemy)` — **sem alteração**. Atualiza posição e proporção da barra de HP. A animação continua tocando automaticamente pelo Phaser.
+
+### 7.4 Feedback de Dano
+
+`_flashSprite(sprite)` — **sem alteração**. Flash vermelho de 160ms. O tint é limpo após o flash; a animação retoma normalmente.
+
+### 7.5 Destruição
+
+`_removeEnemySprite(enemy)` — **sem alteração**. Destroi sprite e barras, seta `null`.
+
+---
+
+## 8. Fórmulas de Scaling
+
+```
+HP final     = round(def.hpBase     × enemyHpMultiplier)
+ATK final    = round(def.damageBase × enemyAtkMultiplier)
+XP final     = round(def.xpBase     × (1 + (floor - 1) × 0.5))
+
+Elite HP     = HP final  × 1.5   ← AIIntegration (não alterado)
+Elite ATK    = ATK final × 1.5   ← AIIntegration (não alterado)
+```
+
+Multiplicadores por andar (`difficulty.config.ts`):
+
+| Andar | HP mult | ATK mult |
+|-------|---------|----------|
+| 1 | 1.00× | 1.00× |
+| 2 | 1.30× | 1.20× |
+| 3 | 1.70× | 1.40× |
+| 4 | 2.20× | 1.65× |
+| 5 | 2.80× | 1.90× |
+| 6+ | +0.40/andar | +0.20/andar |
+
+---
+
+## 9. Campos Adicionados ao EnemySystem
+
+| Campo | Tipo | Descrição |
+|-------|------|-----------|
+| `category` | `EnemyCategory` | Categoria DawnLike |
+| `frameIndex` | `number` | Índice do frame no spritesheet |
+| `enemyDefId` | `string` | ID da entrada em ENEMY_DEFS |
+| `enemyName` | `string` | Nome base (fallback do aiName elite) |
+| `animKey` | `string` | Chave pré-calculada da animação Phaser |
+
+**Compatibilidade:** todos os campos têm valores default e são sobrescritos por `createEnemies()`. O sistema de elites (`AIIntegration`) sobrescreve `aiName` e multiplica `hp`/`attack` — sem conflito.
+
+---
+
+## 10. Observabilidade (DEV)
+
+Logs emitidos apenas quando `import.meta.env.DEV === true` (Vite dev server):
+
+| Local | Mensagem |
+|-------|----------|
+| `BootScene._loadEnemySpritesheets` | Lista de chaves de textura registradas |
+| `BootScene._registerEnemyAnims` | Quantidade de animações criadas |
+| `enemies.config.pickEnemyDef` | Aviso se pool ideal vazio (fallback ativado) |
+| `enemies.config.getAllowedCategories` | Aviso se andar sem regra de categoria |
+
+---
+
+## 11. Easter Egg Platino
+
+O easter egg `DragonDePlatino (CC-BY 4.0)` presente em `GameScene._spawnPlatino()` usa:
+
+```typescript
+SPRITES.PLATINO    → 'reptiles'   (Reptile0.png carregado separadamente)
+DAWNLIKE_FRAMES.PLATINO → 0
+```
+
+Não está vinculado ao sistema de inimigos. Preservado integralmente. Aparece na última sala de cada dungeon com opacidade 0.55 e crédito visível.
+
+---
+
+## 12. Pontos de Atenção para Aprimoramento Futuro
+
+### 12.1 Validação Visual de frameIndex
+
+Os índices atuais (0, 8, 16...) foram escolhidos por convenção de linha, mas **cada spritesheet pode ter variações de layout**. Antes de adicionar novos inimigos, inspecionar o PNG correspondente para confirmar que o índice aponta para o sprite correto.
+
+Sugestão futura: criar um modo de debug que renderiza todos os frames de uma categoria lado a lado.
+
+### 12.2 Colisão Visual com NPCs da Cidade
+
+`humanoid0` é compartilhado entre NPCs da cidade (mercador, guarda, etc.) e inimigos `humanoid` da dungeon. O frame 0 do `humanoid0` pode ser visualmente idêntico ao mercador. Ao adicionar mais variantes, reservar frames altos (linha 3+) exclusivamente para inimigos.
+
+### 12.3 Extensões Previstas
+
+| Funcionalidade | O que adicionar |
+|---------------|-----------------|
+| Animação `walk` | Novo par de frames + `buildAnimKey(cat, frame, 'walk')` |
+| Animação `attack` | Idem para `'attack'` |
+| Bosses | Campo `isBoss?: boolean` em `EnemyDef` + pool separado em `pickEnemyDef` |
+| Elite visual | Tint dourado no sprite ao setar `isElite = true` em `_buildEnemySprite` |
+| Resistências | Campo `resistances?: ElementalType[]` em `EnemyDef` |
+| Loot tables | Campo `lootTableId?: string` em `EnemyDef` |
+| Bioma visual | Mapear `category` → paleta de tint por bioma de dungeon |
+| Object pooling | `_buildEnemySprite` já está isolado; adicionar pool em `_createEnemySprites` |
+
+---
+
+## 13. Arquivos de Referência
+
+| Arquivo | Responsabilidade |
+|---------|-----------------|
+| [src/config/enemies.config.ts](../src/config/enemies.config.ts) | Catálogo, distribuição, weighted random, buildAnimKey |
+| [src/scenes/BootScene.ts](../src/scenes/BootScene.ts) | Preload de texturas, registro de animações |
+| [src/systems/EnemySystem.ts](../src/systems/EnemySystem.ts) | Campos de identidade visual, factory `createEnemies` |
+| [src/scenes/GameScene.ts](../src/scenes/GameScene.ts) | Criação e ciclo de vida dos sprites |
+| [src/vite-env.d.ts](../src/vite-env.d.ts) | Tipagem de `import.meta.env` para logs DEV |
+| [docs/dungeon-sprite-rendering.md](dungeon-sprite-rendering.md) | Sistema de renderização de tiles (referência complementar) |

--- a/docs/prompts/Vitor.md
+++ b/docs/prompts/Vitor.md
@@ -712,14 +712,14 @@ O mapa da cidade (Town.tmx) apresentava tiles problemáticos: animais estáticos
 Objetivo:
 Implementar um sistema de override por coordenada que permita ajustes manuais rápidos no mapa, com aliases de GID amigáveis e modo debug visual.
 
-Tarefas realizadas:
+Tarefas:
 1. Criar `TILE_GID` em `TileProperties.ts` com ~70 aliases de TMX GID organizados por tileset
 2. Criar `MANUAL_MAP_OVERRIDES` com suporte a `forceGid`, `forceGidLike`, `overlayGid` e `walkable`
 3. Implementar `DEBUG_SHOW_COORDINATES` no renderer com textos estáticos por tile e label interativo ao clicar
 4. Corrigir frames pretos do Tree0.png (frames 0–47 vazios, árvores visíveis a partir do frame 48)
 5. Corrigir GIDs incorretos no `TILE_GID` (frame index vs TMX GID real)
 
-Arquivos modificados:
+Arquivos a modificar:
 - `src/config/TileProperties.ts` — TILE_GID, MANUAL_MAP_OVERRIDES
 - `src/systems/TownTMXRenderer.ts` — DEBUG_SHOW_COORDINATES, lógica de override, fix árvores
 - `docs/guia-sprites.md` — seção "Override Manual por Coordenada"
@@ -734,13 +734,13 @@ A área de padding (fundo escuro com flores) fora dos limites do TMX (20×15) n�
 Objetivo:
 Expandir o loop de grama de preenchimento para suportar MANUAL_MAP_OVERRIDES e DEBUG_SHOW_COORDINATES em todas as 750 células (30×25), incluindo as de padding com coordenadas negativas.
 
-Tarefas realizadas:
+Tarefas:
 1. Refatorar o loop de grama em TownTMXRenderer.ts para verificar MANUAL_MAP_OVERRIDES por coordenada (incluindo chaves negativas como "-5,-3")
 2. Renderizar tile customizado via forceGid quando override presente; grama padrão caso contrário
 3. Exibir DEBUG_SHOW_COORDINATES em todas as células de padding
 4. Respeitar walkable: false nos overrides de padding (padrão é walkable)
 
-Arquivos modificados:
+Arquivos a modificar:
 - `src/systems/TownTMXRenderer.ts` — loop de grama expandido com override e debug
 
 ## Prompt 21
@@ -753,7 +753,7 @@ O modo DEBUG_SHOW_COORDINATES exibia coordenadas nos tiles mas não havia feedba
 Objetivo:
 Melhorar o ferramental de debug de tiles para facilitar a identificação e configuração de overrides no mapa da cidade.
 
-Tarefas realizadas:
+Tarefas:
 1. Adicionar console.log ao clicar num tile com coordenadas TMX, world, forceGid das layers Tiles e Sprites, e override atual
 2. Corrigir cálculo de coordenadas do clique usando pointer.worldX/worldY em vez de cálculo manual incorreto
 3. Adicionar botão toggle "[ coords: ON/OFF ]" na UIScene para mostrar/esconder os labels de coordenada dinamicamente sem interromper o console.log
@@ -761,7 +761,7 @@ Tarefas realizadas:
 5. Corrigir overlayGid para funcionar também no loop de padding (coordenadas negativas como "-1,8")
 6. Adicionar carregamento do spritesheet Decor0.png no BootScene (estava ausente, impedindo renderização de GIDs 2136–2311)
 
-Arquivos modificados:
+Arquivos a modificar:
 - `src/systems/TownTMXRenderer.ts` — console.log de clique, botão toggle, overlayGid no loop de padding
 - `src/scenes/BootScene.ts` — carregamento de decor0
 - `src/config/TileProperties.ts` — ajustes de overrides
@@ -787,18 +787,18 @@ Objetivo:
 8. `TMX_REMOVED_POSITIONS` expandido para cobrir sprites estáticos (não só NPCs)
 9. Estalajadeiro com `interactRange: 2` para interação do balcão
 
-Tarefas realizadas:
+Tarefas:
 1. Remover `TOWN_DUNGEON_EXITS` de constants.ts; adicionar `entrarDungeon?` ao `TileOverride`
-2. `GameScene._loadTown()`: escaneia `MANUAL_MAP_OVERRIDES` por `entrarDungeon:true`, computa game coords, registra spawn de retorno dinamicamente
-3. `GameScene._checkAreaTransition()`: usa `_dungeonEntryTiles` em vez de array hardcoded
-4. `TownTMXRenderer`: pit0 não sobrepõe tile com `forceGid`; check de `TMX_REMOVED_POSITIONS` movido para antes de todo rendering de sprite
-5. `TownTMXRenderer`: fórmula do clique substituída por `cam.getWorldPoint()`; debug exibe `→ game(x,y)`
-6. `NPCController.getAllNPCs()`: retorna `{...n.def, gridX: n.gridX, gridY: n.gridY}` com posição atual
-7. `TileOverride`: adicionados `npcName?` e `interaction?`; sprites com interaction viram sign NPCs no renderer
-8. `TownTMXData`: removidos Ajudante e Viajante via `TMX_REMOVED_POSITIONS`; guardas com `wanderBounds` restritos a `maxX:16, maxY:17`
+2. Em `GameScene._loadTown()`: escanear `MANUAL_MAP_OVERRIDES` por `entrarDungeon:true`, computar game coords, registrar spawn de retorno dinamicamente
+3. Em `GameScene._checkAreaTransition()`: usar `_dungeonEntryTiles` em vez de array hardcoded
+4. Em `TownTMXRenderer`: não sobrepor tile com `forceGid` no pit0; mover check de `TMX_REMOVED_POSITIONS` para antes de todo rendering de sprite
+5. Em `TownTMXRenderer`: substituir fórmula do clique por `cam.getWorldPoint()`; exibir `→ game(x,y)` no debug
+6. Em `NPCController.getAllNPCs()`: retornar `{...n.def, gridX: n.gridX, gridY: n.gridY}` com posição atual
+7. Em `TileOverride`: adicionar `npcName?` e `interaction?`; sprites com interaction viram sign NPCs no renderer
+8. Em `TownTMXData`: remover Ajudante e Viajante via `TMX_REMOVED_POSITIONS`; restringir guardas com `wanderBounds` a `maxX:16, maxY:17`
 
-Arquivos modificados:
-- `src/utils/constants.ts` — removido TOWN_DUNGEON_EXITS, TOWN.BONUS_ENTRY_Y = 0
+Arquivos a modificar:
+- `src/utils/constants.ts` — remover TOWN_DUNGEON_EXITS, TOWN.BONUS_ENTRY_Y = 0
 - `src/config/TileProperties.ts` — TileOverride com entrarDungeon, npcName, interaction; MANUAL_MAP_OVERRIDES com placa
 - `src/config/TownTMXData.ts` — TMX_REMOVED_POSITIONS expandido, overrides de NPC atualizados
 - `src/scenes/GameScene.ts` — _dungeonEntryTiles, scan de entrarDungeon, pit0 condicional
@@ -817,12 +817,12 @@ Objetivo:
 2. Atualizar `.kiro/specs/product.md` com placa interativa, `entrarDungeon` data-driven, `interactRange` e debug
 3. Atualizar `.kiro/steering/game-steering.md` com 5 novas restrições arquiteturais
 
-Tarefas realizadas:
-1. `world.spec.md`: pipeline substituído por `TownTMXRenderer + MANUAL_MAP_OVERRIDES`; NPCs com posições TMX, `interactRange` e comportamento corretos; transição cidade→dungeon documenta `_dungeonEntryTiles`
-2. `product.md`: seções Cidade e NPCs atualizadas — placa, `entrarDungeon`, `interactRange`, debug de tiles
-3. `game-steering.md`: adicionadas restrições para `interactRange`, objetos estáticos interativos, entradas data-driven, `TMX_REMOVED_POSITIONS` e `getAllNPCs()`
+Tarefas:
+1. Em `world.spec.md`: substituir pipeline por `TownTMXRenderer + MANUAL_MAP_OVERRIDES`; atualizar NPCs com posições TMX, `interactRange` e comportamento corretos; documentar transição cidade→dungeon via `_dungeonEntryTiles`
+2. Em `product.md`: atualizar seções Cidade e NPCs — placa, `entrarDungeon`, `interactRange`, debug de tiles
+3. Em `game-steering.md`: adicionar restrições para `interactRange`, objetos estáticos interativos, entradas data-driven, `TMX_REMOVED_POSITIONS` e `getAllNPCs()`
 
-Arquivos modificados:
+Arquivos a modificar:
 - `.kiro/specs/world.spec.md` — pipeline, NPCs, transição data-driven
 - `.kiro/specs/product.md` — seções Cidade e NPCs
 - `.kiro/steering/game-steering.md` — novas restrições arquiteturais
@@ -840,15 +840,17 @@ Objetivo:
 3. Criar `BonusAreaRenderer` com debug idêntico ao `TownTMXRenderer` (labels, toggle, clique → console)
 4. Corrigir condição de saída da área bônus (estava hardcoded em `gridY >= 9`)
 
-Tarefas realizadas:
-1. `src/config/BonusAreaData.ts` criado: `BONUS_W=30`, `BONUS_H=22`, `BONUS_AREA_OVERRIDES`, `BONUS_AREA_NPCS`
-2. `src/systems/BonusAreaRenderer.ts` criado: renderiza chão com suporte a `forceGid`, labels de coord, toggle ON/OFF, clique exibe `[DEBUG bonus] (x,y)` e override atual
-3. `GameScene._loadBonusArea()` reescrito para delegar ao `BonusAreaRenderer` (igual ao `_loadTown` com `TownTMXRenderer`)
-4. Condição de saída corrigida: `gridY >= 9` → `gridY >= BONUS_H - 1`
+Tarefas:
+1. Criar `src/config/BonusAreaData.ts`: `BONUS_W=30`, `BONUS_H=22`, `BONUS_AREA_OVERRIDES`, `BONUS_AREA_NPCS`
+2. Criar `src/systems/BonusAreaRenderer.ts`: renderizar chão com suporte a `forceGid`, labels de coord, toggle ON/OFF, clique exibe `[DEBUG bonus] (x,y)` e override atual
+3. Reescrever `GameScene._loadBonusArea()` para delegar ao `BonusAreaRenderer` (igual ao `_loadTown` com `TownTMXRenderer`)
+4. Corrigir condição de saída: `gridY >= 9` → `gridY >= BONUS_H - 1`
 
-Arquivos modificados:
-- `src/config/BonusAreaData.ts` — novo, config isolada da área bônus
-- `src/systems/BonusAreaRenderer.ts` — novo, renderer com debug completo
+Arquivos a criar:
+- `src/config/BonusAreaData.ts` — config isolada da área bônus
+- `src/systems/BonusAreaRenderer.ts` — renderer com debug completo
+
+Arquivos a modificar:
 - `src/scenes/GameScene.ts` — `_loadBonusArea()` reescrito, import de `BonusAreaRenderer`, condição de saída corrigida
 
 ---
@@ -861,15 +863,15 @@ Limpeza de arquivos de documentação obsoletos da raiz do repositório.
 Objetivo:
 Remover `KIRO_RESUMO.md`, `IMPLEMENTATION_SUMMARY.md`, `fase_3.md` e `fase_5.md` — conteúdo já migrado para `.kiro/` e `docs/`.
 
-Tarefas realizadas:
-1. Arquivos deletados e staged para remoção
-2. CHANGELOG.md e Vitor.md atualizados para o commit passar
+Tarefas:
+1. Deletar e fazer stage para remoção dos arquivos obsoletos
+2. Atualizar CHANGELOG.md e Vitor.md para o commit passar
 
-Arquivos modificados:
-- `KIRO_RESUMO.md` — removido
-- `IMPLEMENTATION_SUMMARY.md` — removido
-- `fase_3.md` — removido
-- `fase_5.md` — removido
+Arquivos a modificar:
+- `KIRO_RESUMO.md` — remover
+- `IMPLEMENTATION_SUMMARY.md` — remover
+- `fase_3.md` — remover
+- `fase_5.md` — remover
 
 ---
 
@@ -884,16 +886,18 @@ Objetivo:
 3. Temas visuais distintos por faixa de andares (dungeon/mine/underworld/boss)
 4. Preparar extensão futura (water, lava, chasm) sem alterar renderer
 
-Tarefas realizadas:
-1. `dungeon-themes.ts` reestruturado: `TileCategory`, `AutoTileSet` (face, cornerOuter_TL/TR, bodyFrames, cornerInner_TL/TR), `DungeonTheme` com `autoTileSets`; 4 temas com frames corretos de Wall.png e Floor.png
-2. `AutoTileResolver` criado: interpreta vizinhos cardinais, resolve `TileRenderData`; sem objetos Phaser
-3. `DungeonRenderer` criado: itera grid, delega ao resolver, emite `RenderCommand[]`
-4. `GameScene._loadDungeonFloor()`: loop inline substituído por `DungeonRenderer.buildCommands()`; imports de `pickFloorFrame`/`pickWallFrame` removidos
+Tarefas:
+1. Reestruturar `dungeon-themes.ts`: `TileCategory`, `AutoTileSet` (face, cornerOuter_TL/TR, bodyFrames, cornerInner_TL/TR), `DungeonTheme` com `autoTileSets`; 4 temas com frames corretos de Wall.png e Floor.png
+2. Criar `AutoTileResolver`: interpretar vizinhos cardinais, resolver `TileRenderData`; sem objetos Phaser
+3. Criar `DungeonRenderer`: iterar grid, delegar ao resolver, emitir `RenderCommand[]`
+4. Em `GameScene._loadDungeonFloor()`: substituir loop inline por `DungeonRenderer.buildCommands()`; remover imports de `pickFloorFrame`/`pickWallFrame`
 
-Arquivos modificados:
-- `src/config/dungeon-themes.ts` — reescrito com AutoTileSet e 4 temas
-- `src/systems/AutoTileResolver.ts` — novo
-- `src/systems/DungeonRenderer.ts` — novo
+Arquivos a criar:
+- `src/systems/AutoTileResolver.ts`
+- `src/systems/DungeonRenderer.ts`
+
+Arquivos a modificar:
+- `src/config/dungeon-themes.ts` — reescrever com AutoTileSet e 4 temas
 - `src/scenes/GameScene.ts` — delegação ao DungeonRenderer, `width: W, height: H` restaurados
 
 ---
@@ -907,13 +911,13 @@ Objetivo:
 1. Corrigir sprite de item não desaparecendo ao coletar
 2. Adicionar flag `godMode` em configuração de desenvolvimento
 
-Tarefas realizadas:
-1. `_checkItemPickup()`: substituído `delayedCall(0, s.destroy)` por `item.sprite?.destroy()` imediato
-2. Loop de recriação de sprites em `_loadDungeonFloor()`: adicionado `item.sprite?.destroy()` antes de criar novo sprite
-3. `constants.ts`: adicionado `DEV_CONFIG = { godMode: false }` ao final do arquivo
-4. `CombatSystem`: importado `DEV_CONFIG`; dano ao player condicionado a `!DEV_CONFIG.godMode`
+Tarefas:
+1. Em `_checkItemPickup()`: substituir `delayedCall(0, s.destroy)` por `item.sprite?.destroy()` imediato
+2. No loop de recriação de sprites em `_loadDungeonFloor()`: adicionar `item.sprite?.destroy()` antes de criar novo sprite
+3. Em `constants.ts`: adicionar `DEV_CONFIG = { godMode: false }` ao final do arquivo
+4. Em `CombatSystem`: importar `DEV_CONFIG`; condicionar dano ao player a `!DEV_CONFIG.godMode`
 
-Arquivos modificados:
+Arquivos a modificar:
 - `src/scenes/GameScene.ts` — destroy imediato, destroy antes de recriar
 - `src/utils/constants.ts` — DEV_CONFIG
 - `src/systems/CombatSystem.ts` — godMode check
@@ -928,15 +932,15 @@ Após implementação do autotiling semântico, godMode e correções de bugs, a
 Objetivo:
 Manter documentação sincronizada com o estado atual do código.
 
-Tarefas realizadas:
-1. `CHANGELOG.md`: nova seção `[0.5.2]` com Added, Fixed e Changed
-2. `docs/guia-sprites.md`: seção de dungeon reescrita para API de autotiling; tabela resumo atualizada
-3. `docs/PRD.md`: versão 0.5.2, status atualizado, seção dungeon com múltiplos andares/temas, escopo expandido
-4. `.kiro/steering/game-steering.md`: estrutura de pastas e 6 novas restrições arquiteturais
-5. `.kiro/specs/product.md`: tabela de sistemas e seção Dungeon atualizadas; área bônus documentada
-6. `.kiro/specs/world.spec.md`: tabela de áreas e transições expandida com área bônus e múltiplos andares
+Tarefas:
+1. Em `CHANGELOG.md`: adicionar nova seção `[0.5.2]` com Added, Fixed e Changed
+2. Em `docs/guia-sprites.md`: reescrever seção de dungeon para API de autotiling; atualizar tabela resumo
+3. Em `docs/PRD.md`: atualizar para versão 0.5.2, status e seção dungeon com múltiplos andares/temas, expandir escopo
+4. Em `.kiro/steering/game-steering.md`: atualizar estrutura de pastas e adicionar 6 novas restrições arquiteturais
+5. Em `.kiro/specs/product.md`: atualizar tabela de sistemas e seção Dungeon; documentar área bônus
+6. Em `.kiro/specs/world.spec.md`: expandir tabela de áreas e transições com área bônus e múltiplos andares
 
-Arquivos modificados:
+Arquivos a modificar:
 - `CHANGELOG.md`
 - `docs/guia-sprites.md`
 - `docs/PRD.md`
@@ -967,7 +971,7 @@ Requisitos principais submetidos ao agente:
 - Ferramental dev: DebugOverlayRenderer (semantic/variant/bitmask), MaskFrequencyLogger, VisualRegressionScene
 - Filosofia: validação visual iterativa > completude teórica; quando em dúvida, remover variação
 
-Constraints técnicas adicionais (refinamentos iterativos durante o planejamento):
+Decisões técnicas:
 - LUT não pode ser chain de set() com overwrites — deve ser classifyVariant() pura
 - Diagonais sem cardinais de suporte devem ser sanitizadas (fechadas)
 - WALL_EDGE deve ter espessura de exatamente 1 tile (cardinais apenas para classificação)
@@ -977,19 +981,19 @@ Constraints técnicas adicionais (refinamentos iterativos durante o planejamento
 - MaskFrequencyLogger para diagnóstico de distribuição de masks em runtime
 - VisualRegressionScene determinística para screenshot comparison após mudanças
 
-Tarefas realizadas:
-1. `TileSemanticsProvider.ts` (novo): interface TileSemantics, tabela extensível, getTileSemantics()
-2. `SemanticClassifier.ts` (novo): classifyGrid() com 4 vizinhos cardinais, SemanticValue enum, SemanticGrid type
-3. `WallVariantLUT.ts` (novo): BIT constants, sanitizeMask(), WallVariant enum (7 variantes), classifyVariant() pura, buildWallVariantLUT(), computeRawMask()
-4. `dungeon-themes.ts` (modificado): TileCategory estendido com wall_edge/void/string; BitmaskFrameSet interface; AutoTileSet com bitmaskFrames?/voidFrame?; wall_edge + bitmaskFrames para todos os 4 temas; body = 1 frame por tema
-5. `AutoTileResolver.ts` (modificado): nova assinatura resolve(grid, sem, ...); resolveCategory usa SemanticGrid; branch wall_edge com bitmask; fallback legado preservado; _computeRawMask, _frameForVariant adicionados
-6. `DungeonRenderer.ts` (modificado): integra classifyGrid(); skip VOID sem RenderCommand; passa sem para resolver
-7. `GameScene.ts` (modificado): setBackgroundColor(0x000000) em _loadDungeonFloor()
-8. `DebugOverlayRenderer.ts` (novo): modos semantic/variant/bitmask, atlas-agnostic via DEBUG_FRAMES
-9. `MaskFrequencyLogger.ts` (novo): record() por tile, report() com top masks + variant totals + unused count
-10. `VisualRegressionScene.ts` (novo): grid hardcoded 20×15 cobrindo casos críticos, toggle de modos via teclas 1–4, L para log
+Tarefas:
+1. Criar `TileSemanticsProvider.ts`: interface TileSemantics, tabela extensível, getTileSemantics()
+2. Criar `SemanticClassifier.ts`: classifyGrid() com 4 vizinhos cardinais, SemanticValue enum, SemanticGrid type
+3. Criar `WallVariantLUT.ts`: BIT constants, sanitizeMask(), WallVariant enum (7 variantes), classifyVariant() pura, buildWallVariantLUT(), computeRawMask()
+4. Modificar `dungeon-themes.ts`: estender TileCategory com wall_edge/void/string; adicionar BitmaskFrameSet interface; incluir AutoTileSet com bitmaskFrames?/voidFrame?; wall_edge + bitmaskFrames para todos os 4 temas; body = 1 frame por tema
+5. Modificar `AutoTileResolver.ts`: nova assinatura resolve(grid, sem, ...); resolveCategory usa SemanticGrid; branch wall_edge com bitmask; preservar fallback legado; adicionar _computeRawMask, _frameForVariant
+6. Modificar `DungeonRenderer.ts`: integrar classifyGrid(); skip VOID sem RenderCommand; passar sem para resolver
+7. Modificar `GameScene.ts`: chamar setBackgroundColor(0x000000) em _loadDungeonFloor()
+8. Criar `DebugOverlayRenderer.ts`: modos semantic/variant/bitmask, atlas-agnostic via DEBUG_FRAMES
+9. Criar `MaskFrequencyLogger.ts`: record() por tile, report() com top masks + variant totals + unused count
+10. Criar `VisualRegressionScene.ts`: grid hardcoded 20×15 cobrindo casos críticos, toggle de modos via teclas 1–4, L para log
 
-Arquivos criados:
+Arquivos a criar:
 - `src/systems/TileSemanticsProvider.ts`
 - `src/systems/SemanticClassifier.ts`
 - `src/systems/WallVariantLUT.ts`
@@ -997,7 +1001,7 @@ Arquivos criados:
 - `src/systems/MaskFrequencyLogger.ts`
 - `src/scenes/VisualRegressionScene.ts`
 
-Arquivos modificados:
+Arquivos a modificar:
 - `src/config/dungeon-themes.ts`
 - `src/systems/AutoTileResolver.ts`
 - `src/systems/DungeonRenderer.ts`
@@ -1021,26 +1025,26 @@ Branch `feature/game-structure-fixes`. Implementação do sistema de magias inte
 Objetivo:
 Adicionar sistema de magias jogável: desbloqueio por nível, dois slots equipáveis (J/K), mecânica melee-range (sem projétil), painel de magias integrado ao `I`, slots no footer e navegação por teclado.
 
-Decisões técnicas tomadas com IA:
-- Magias melee-range (4 cardinais adjacentes) em vez de projétil — eliminado `Projectile` para evitar bugs de ciclo de vida do sprite fora da cena
+Decisões técnicas:
+- Magias melee-range (4 cardinais adjacentes) em vez de projétil — eliminar `Projectile` para evitar bugs de ciclo de vida do sprite fora da cena
 - `SpellCastingSystem` tipado com `EnemySystem` (não `Enemy`) para compatibilidade com `takeDamage(amount, emitter)`
 - `hitEnemies: EnemySystem[]` em vez de `hitEnemy | null` — dano em todos os adjacentes simultâneo
 - Slots J/K movidos para dentro do footer (action bar), tamanho 20×20, mesmo padrão dos slots de poção
 - Navegação por teclado no painel de magias: estado `_spellsFocus: 'tabs' | 'list'` em GameScene; `SPELLS_SELECTION_CHANGED` sincroniza visual no SpellsPanel
 - `INVENTORY_TAB_CHANGED` com flag `_fromKeyboard` para distinguir origem teclado vs clique e evitar loop de eventos
 
-Tarefas realizadas:
-1. `SpellSystem.ts` (novo): desbloqueio, equipamento, cooldown por slot
-2. `SpellCastingSystem.ts` (novo/reescrito): cast melee — 4 tiles cardinais, retorna `SpellCastResult` com `hitEnemies[]`
-3. `SpellsPanel.ts` (novo): painel integrado ao `I`, 85%×80%, `clearSelection()` adicionado
-4. `StatusPanel.ts` (novo): atributos detalhados do player
-5. `spells.db.ts` + `spell-progression.ts` + `types/spells.ts` (novos): definições data-driven
-6. `GameScene.ts` (modificado): `_castSpell()` melee, `_inventoryTab`, `_spellsFocus`, `_spellsSelectedIndex`, navegação ←/→/↑/↓ no painel
-7. `UIScene.ts` (modificado): slots J/K no footer (20×20), `SPELLS_SELECTION_CHANGED` ouvido, `INVENTORY_TAB_CHANGED` com `_fromKeyboard`
-8. `constants.ts` (modificado): `SPELLS_SELECTION_CHANGED` adicionado
-9. Testes corrigidos: `potion_poison` → `potion_mana`; HP ajustado para cap de `POTION_HEAL_AMOUNT=25`; gold do shop 470→460
+Tarefas:
+1. Criar `SpellSystem.ts`: desbloqueio, equipamento, cooldown por slot
+2. Criar `SpellCastingSystem.ts`: cast melee — 4 tiles cardinais, retornar `SpellCastResult` com `hitEnemies[]`
+3. Criar `SpellsPanel.ts`: painel integrado ao `I`, 85%×80%, adicionar `clearSelection()`
+4. Criar `StatusPanel.ts`: atributos detalhados do player
+5. Criar `spells.db.ts` + `spell-progression.ts` + `types/spells.ts`: definições data-driven
+6. Modificar `GameScene.ts`: implementar `_castSpell()` melee, `_inventoryTab`, `_spellsFocus`, `_spellsSelectedIndex`, navegação ←/→/↑/↓ no painel
+7. Modificar `UIScene.ts`: adicionar slots J/K no footer (20×20), ouvir `SPELLS_SELECTION_CHANGED`, tratar `INVENTORY_TAB_CHANGED` com `_fromKeyboard`
+8. Modificar `constants.ts`: adicionar `SPELLS_SELECTION_CHANGED`
+9. Corrigir testes: `potion_poison` → `potion_mana`; HP ajustado para cap de `POTION_HEAL_AMOUNT=25`; gold do shop 470→460
 
-Arquivos criados:
+Arquivos a criar:
 - `src/systems/SpellSystem.ts`
 - `src/systems/SpellCastingSystem.ts`
 - `src/ui/SpellsPanel.ts`
@@ -1050,7 +1054,7 @@ Arquivos criados:
 - `src/types/spells.ts`
 - `.kiro/specs/spells.spec.md`
 
-Arquivos modificados:
+Arquivos a modificar:
 - `src/scenes/GameScene.ts`
 - `src/scenes/UIScene.ts`
 - `src/entities/Player.ts`
@@ -1072,12 +1076,108 @@ Data: 2026-05-12
 Contexto:
 Correção de bug visual: sprites de itens no chão da dungeon não desapareciam após o jogador coletá-los. O item era adicionado ao inventário corretamente (lógica de coleta funcionando), mas o sprite permanecia visível na dungeon.
 
-Decisões tomadas:
-1. **Causa raiz identificada**: as chamadas `setVisible(false).setActive(false)` antes de `destroy()` em `_checkItemPickup` eram problemáticas no Phaser 4 — desativar o sprite antes de destruí-lo pode impedir que o objeto seja removido corretamente da display list do Phaser. A correção foi usar `item.sprite.destroy()` diretamente, sem as chamadas intermediárias.
-2. **Cache sincronizado**: após `this._items = this._items.filter(i => i.gridX !== null)`, o cache do andar (`_dungeonCache`) agora é atualizado com a referência filtrada (`cached.items = this._items`). Isso garante que ao re-entrar no mesmo andar, apenas os itens ainda no chão tenham sprites recriados.
-3. Em Phaser 4, `destroy()` é síncrono e remove o objeto da display list imediatamente — não requer `setVisible(false)` ou `setActive(false)` préviamente.
+Decisões técnicas:
+1. **Causa raiz**: as chamadas `setVisible(false).setActive(false)` antes de `destroy()` em `_checkItemPickup` são problemáticas no Phaser 4 — desativar o sprite antes de destruí-lo pode impedir que o objeto seja removido corretamente da display list do Phaser. Usar `item.sprite.destroy()` diretamente, sem as chamadas intermediárias.
+2. **Cache sincronizado**: após `this._items = this._items.filter(i => i.gridX !== null)`, atualizar o cache do andar (`_dungeonCache`) com a referência filtrada (`cached.items = this._items`). Isso garante que ao re-entrar no mesmo andar, apenas os itens ainda no chão tenham sprites recriados.
+3. Em Phaser 4, `destroy()` é síncrono e remove o objeto da display list imediatamente — não requer `setVisible(false)` ou `setActive(false)` previamente.
 
-Arquivos modificados:
-- `src/scenes/GameScene.ts`: `_checkItemPickup()` — removidos `setVisible(false).setActive(false)` antes de `destroy()` em ambos os branches (gold e regular items); cache atualizado após o filtro
-- `CHANGELOG.md`: entrada na seção `[Unreleased]` descrevendo a correção
+Tarefas:
+1. Em `_checkItemPickup()`: remover `setVisible(false).setActive(false)` antes de `destroy()` em ambos os branches (gold e regular items)
+2. Após o filtro de items, atualizar o cache: `cached.items = this._items`
+3. Em `CHANGELOG.md`: adicionar entrada na seção `[Unreleased]` descrevendo a correção
 
+Arquivos a modificar:
+- `src/scenes/GameScene.ts` — `_checkItemPickup()` corrigido e cache atualizado após o filtro
+- `CHANGELOG.md` — entrada na seção `[Unreleased]`
+
+---
+
+## Prompt 32 — fix(classes): aplicar bônus de atributo da classe selecionada ao iniciar o jogo
+Autor: Vitor
+Data: 2026-05-16
+
+Contexto:
+Ao iniciar uma nova partida com qualquer classe diferente do Guerreiro padrão, todos os personagens começam com os mesmos atributos base (STR/INT/DEX/WIS = 10, CON = 18). O campo `classDef.statBonus` existe e contém os bônus corretos por classe, mas nenhum código chama `recalcStats()` com esses bônus — o `player.classDef` é atribuído, mas os campos individuais de atributo (`str`, `intel`, `dex`, `con`, `wis`) nunca são atualizados.
+
+Objetivo:
+Garantir que a classe selecionada pelo jogador aplique corretamente seus bônus de atributo ao Player na inicialização da partida.
+
+Tarefas:
+1. Em `src/entities/Player.ts`, adicionar método `applyClassBonus(classDef: PlayerClassDef)`:
+   - Para cada stat em `classDef.statBonus`, calcular `BASE_STATS.<STAT> + bonus` e atribuir ao campo correspondente do Player
+   - Chamar `recalcStats()` após aplicar todos os atributos
+   - Restaurar `this.hp = this.maxHp` e `this.mana = this.maxMana` após recalcular
+2. Em `src/scenes/GameScene.ts`, na função que inicializa o Player com a classe selecionada:
+   - Após `this.player.classDef = classDef`, chamar `this.player.applyClassBonus(classDef)`
+
+Requisitos:
+- Os valores de `BASE_STATS` não devem ser mutados — apenas os campos individuais do Player recebem o valor calculado
+- `recalcStats()` deve ser chamado depois de todos os atributos ajustados para derivar `maxHp`, `maxMana`, `attack`, `critChance`, `cdReduction` e `spellBonus` corretamente
+- HP e Mana do player devem refletir os novos máximos imediatamente ao entrar no jogo
+
+Arquivos a modificar:
+- `src/entities/Player.ts` — novo método `applyClassBonus(classDef: PlayerClassDef)`
+- `src/scenes/GameScene.ts` — chamada a `applyClassBonus()` ao iniciar com classe selecionada
+
+---
+
+## Prompt 33 — feat(loot): drops visuais por quantidade de ouro e sistema de baús na dungeon
+Autor: Vitor
+Data: 2026-05-16
+
+Contexto:
+O spritesheet `Money.png` é 128×128 pixels com frames 16×16 (8 colunas × 8 linhas = 64 frames). A Row 2 (linha de índice 1, frames 8 a 15) contém representações visuais de quantidades de ouro e um baú vermelho fechado. Atualmente todos os drops de ouro usam frame 0 (frame errado). Não existem baús nas dungeons.
+
+Objetivo:
+1. Usar frames da Row 2 para mostrar a quantidade visual de ouro dropado por inimigos
+2. Implementar baús gerados proceduralmente nas dungeons com sistema de loot por profundidade
+3. Corrigir a propriedade `goldAmount` que está sendo atribuída dinamicamente em `LootSystem` sem declaração formal na classe `Item`
+
+Especificação de frames (Money.png, 0-indexed):
+- Frame 8 (Row 2, Col 1): pilha grande — usar quando `goldAmount >= 50`
+- Frame 9 (Row 2, Col 2): pilha média — usar quando `20 <= goldAmount < 50`
+- Frame 10 (Row 2, Col 3): moeda única — usar quando `goldAmount < 20`
+- Frame 14 (Row 2, Col 7): baú vermelho fechado
+
+Tarefas:
+1. `src/utils/constants.ts` — substituir `GOLD: 0` por:
+   ```ts
+   GOLD_SMALL:  10,  // moeda única
+   GOLD_MEDIUM:  9,  // pilha média
+   GOLD_LARGE:   8,  // pilha grande
+   CHEST:       14,  // baú fechado
+   ```
+2. `src/entities/Item.ts` — declarar `goldAmount?: number` como propriedade formal da classe
+3. `src/systems/LootSystem.ts`:
+   - Escalar o valor de ouro dropado por inimigos com o andar (base + andar × 6, ±30% de variação)
+   - Adicionar interface `ChestLootResult` e método `rollChestLoot(floor: number): ChestLootResult`
+   - Loot de baú por profundidade:
+     - Andar 1–2: 60% ouro | 40% poção
+     - Andar 3–5: 50% ouro | 30% poção | 20% mímica (player toma 15–25 de dano)
+     - Andar 6+: 50% equipamento (gerado para o andar) | 30% ouro | 20% poção forte
+   - Para equipamentos: sortear pool adequada ao andar, atribuir `name`, `slotId`, `rarity`, `bonuses` e `price` proporcionais ao andar
+4. `src/generators/DungeonFeatureGenerator.ts`:
+   - Adicionar `'chest'` ao union `FeatureType`
+   - Após gerar as escadas, spawnar 1–2 baús em rooms intermediárias (excluindo rooms 0 e última)
+   - Excluir posições já ocupadas por escadas e `startPos`; adicionar `metadata: { opened: false }` a cada baú
+5. `src/scenes/GameScene.ts`:
+   - Adicionar campo `_chestSprites = new Map<string, Phaser.GameObjects.Sprite>()` para rastrear sprites de baús
+   - `_cleanup()`: destruir e limpar `_chestSprites`
+   - `_getItemVisual(type, goldAmount?)`: selecionar frame baseado nos limiares de `goldAmount`; adicionar `default` case no switch
+   - `_renderDungeonFeatures()`: para features `chest` não abertas, criar sprite com frame `DAWNLIKE_FRAMES.CHEST` e registrar em `_chestSprites`
+   - Novo método `_checkChestInteraction()`: ao pisar em feature `chest` não aberta, chamar `lootSystem.rollChestLoot()`, processar resultado (mímica → dano, ouro/poção → spawn+coleta, equipamento → inventário), destruir sprite do baú, marcar `metadata.opened = true`
+   - Chamar `_checkChestInteraction()` imediatamente após `_checkItemPickup()` no fluxo de movimento (`result.playerMoved`)
+6. `src/ui/ActionBarPanel.ts` — atualizar referência de `DAWNLIKE_FRAMES.GOLD` para `DAWNLIKE_FRAMES.GOLD_SMALL`
+
+Requisitos:
+- `_spawnDroppedItem()` deve ser idempotente: destruir sprite existente antes de criar novo; não adicionar o mesmo item a `_items` duas vezes (`includes()` check)
+- Baús abertos não devem reaparecer ao re-entrar no andar (flag `metadata.opened` persiste no cache)
+- Equipamentos de baú não emitem `ITEM_DROPPED` — são adicionados diretamente ao inventário
+
+Arquivos a modificar:
+- `src/utils/constants.ts`
+- `src/entities/Item.ts`
+- `src/systems/LootSystem.ts`
+- `src/generators/DungeonFeatureGenerator.ts`
+- `src/scenes/GameScene.ts`
+- `src/ui/ActionBarPanel.ts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jogo-dungeon-of-echoes",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "type": "module",
   "description": "Dungeon of Echoes – RPG 2D tile-based com geração procedural",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepare": "husky"
   },
   "keywords": [
-    "phaser3",
+    "phaser4",
     "rpg",
     "dungeon",
     "roguelike",

--- a/src/config/enemies.config.ts
+++ b/src/config/enemies.config.ts
@@ -1,0 +1,412 @@
+// Créditos: DragonDePlatino — Dawnlike 16×16 (CC-BY 4.0)
+// Catálogo data-driven de inimigos. Para adicionar um novo inimigo, basta
+// inserir uma entrada em ENEMY_DEFS. Sistemas centrais (spawn, animação,
+// scaling) lêem automaticamente este arquivo.
+
+// ─── Tipos ────────────────────────────────────────────────────────────────────
+
+/**
+ * Categoria que determina qual par de spritesheets DawnLike é usado
+ * e em quais andares o inimigo pode aparecer.
+ *
+ * Spritesheet: {Categoria}0.png / {Categoria}1.png
+ */
+export type EnemyCategory =
+  | 'pest'
+  | 'misc'
+  | 'reptile'
+  | 'undead'
+  | 'humanoid'
+  | 'demon';
+
+/** Raridade que determina o peso na seleção procedural. */
+export type EnemyRarity = 'common' | 'uncommon' | 'rare';
+
+// ─── Pesos de Raridade ────────────────────────────────────────────────────────
+// Valores maiores = aparece mais frequentemente no pool aleatório.
+
+export const RARITY_WEIGHTS: Readonly<Record<EnemyRarity, number>> = {
+  common:   100,
+  uncommon:  40,
+  rare:      10,
+};
+
+// ─── Definição de Inimigo ─────────────────────────────────────────────────────
+
+export interface EnemyDef {
+  /**
+   * Identificador único e imutável.
+   * Não renomear após criação — pode ser referenciado por sistemas de loot,
+   * eventos narrativos e saves futuros.
+   */
+  readonly id: string;
+
+  /** Categoria que define o par de spritesheets DawnLike. */
+  readonly category: EnemyCategory;
+
+  /**
+   * Índice do frame no spritesheet (mesmo índice em *0.png e *1.png).
+   * Os spritesheets DawnLike têm 8 colunas: linha N começa no frame N*8.
+   */
+  readonly frameIndex: number;
+
+  /** Nome de exibição padrão. Pode ser sobrescrito por AIIntegration em elites. */
+  readonly name: string;
+
+  /** HP base, antes dos multiplicadores de dificuldade e elite. */
+  readonly hpBase: number;
+
+  /** Dano base, antes dos multiplicadores de dificuldade e elite. */
+  readonly damageBase: number;
+
+  /** XP base, antes do multiplicador de andar. */
+  readonly xpBase: number;
+
+  /** Raridade usada na seleção ponderada. */
+  readonly rarity: EnemyRarity;
+
+  /** Andar mínimo de spawn (inclusivo). */
+  readonly dungeonMin: number;
+
+  /** Andar máximo de spawn (inclusivo). Use 99 para sem limite prático. */
+  readonly dungeonMax: number;
+
+  // ── Extensões futuras (opcionais, não usadas ainda) ───────────────────────
+  /** Texto de lore para bosses, elites ou UI futura. */
+  readonly description?: string;
+  // resistances?: ElementalType[];
+  // skills?: SkillId[];
+  // lootTableId?: string;
+  // faction?: FactionId;
+  // elementalType?: ElementalType;
+  // isBoss?: boolean;
+  // isEliteVariant?: boolean;
+}
+
+// ─── Catálogo de Inimigos ─────────────────────────────────────────────────────
+// frameIndex segue o padrão DawnLike de 8 colunas: linha 0 = frame 0, linha 1 = frame 8, etc.
+// Os valores de hpBase/damageBase são multiplicados pelos scalers de difficulty.config.ts.
+
+export const ENEMY_DEFS: readonly EnemyDef[] = [
+  // ── PEST (Andares 1–2) ────────────────────────────────────────────────────
+  {
+    id:          'rat',
+    category:    'pest',
+    frameIndex:  0,
+    name:        'Rato Feroz',
+    hpBase:      18,
+    damageBase:  4,
+    xpBase:      15,
+    rarity:      'common',
+    dungeonMin:  1,
+    dungeonMax:  2,
+    description: 'Um rato faminto que habita os corredores mais rasos.',
+  },
+  {
+    id:          'spider',
+    category:    'pest',
+    frameIndex:  8,
+    name:        'Aranha Venenosa',
+    hpBase:      22,
+    damageBase:  5,
+    xpBase:      18,
+    rarity:      'common',
+    dungeonMin:  1,
+    dungeonMax:  2,
+    description: 'Sua mordida deixa rastros de veneno lento.',
+  },
+  {
+    id:          'centipede',
+    category:    'pest',
+    frameIndex:  16,
+    name:        'Centopeia Gigante',
+    hpBase:      20,
+    damageBase:  6,
+    xpBase:      20,
+    rarity:      'uncommon',
+    dungeonMin:  1,
+    dungeonMax:  2,
+  },
+
+  // ── MISC (Andares 1–2) ────────────────────────────────────────────────────
+  {
+    id:          'slime',
+    category:    'misc',
+    frameIndex:  0,
+    name:        'Gosma',
+    hpBase:      25,
+    damageBase:  4,
+    xpBase:      16,
+    rarity:      'common',
+    dungeonMin:  1,
+    dungeonMax:  2,
+    description: 'Criatura amorfa sem intelecto, mas persistente.',
+  },
+  {
+    id:          'mushroom_stalker',
+    category:    'misc',
+    frameIndex:  8,
+    name:        'Cogumelo Ambulante',
+    hpBase:      20,
+    damageBase:  5,
+    xpBase:      17,
+    rarity:      'uncommon',
+    dungeonMin:  1,
+    dungeonMax:  2,
+  },
+
+  // ── REPTILE (Andares 1–2) ─────────────────────────────────────────────────
+  {
+    id:          'lizard',
+    category:    'reptile',
+    frameIndex:  0,
+    name:        'Lagarto das Pedras',
+    hpBase:      28,
+    damageBase:  7,
+    xpBase:      22,
+    rarity:      'common',
+    dungeonMin:  1,
+    dungeonMax:  2,
+  },
+  {
+    id:          'serpent',
+    category:    'reptile',
+    frameIndex:  8,
+    name:        'Serpente das Ruínas',
+    hpBase:      26,
+    damageBase:  8,
+    xpBase:      24,
+    rarity:      'uncommon',
+    dungeonMin:  1,
+    dungeonMax:  2,
+    description: 'Cobra rápida que se esconde entre pedras.',
+  },
+
+  // ── UNDEAD (Andares 3–4) ──────────────────────────────────────────────────
+  {
+    id:          'skeleton',
+    category:    'undead',
+    frameIndex:  0,
+    name:        'Esqueleto',
+    hpBase:      35,
+    damageBase:  10,
+    xpBase:      30,
+    rarity:      'common',
+    dungeonMin:  3,
+    dungeonMax:  4,
+    description: 'Ossos reanimados por magia antiga.',
+  },
+  {
+    id:          'zombie',
+    category:    'undead',
+    frameIndex:  8,
+    name:        'Zumbi',
+    hpBase:      45,
+    damageBase:  9,
+    xpBase:      32,
+    rarity:      'common',
+    dungeonMin:  3,
+    dungeonMax:  4,
+  },
+  {
+    id:          'ghost',
+    category:    'undead',
+    frameIndex:  16,
+    name:        'Fantasma Sombrio',
+    hpBase:      30,
+    damageBase:  12,
+    xpBase:      40,
+    rarity:      'rare',
+    dungeonMin:  3,
+    dungeonMax:  4,
+    description: 'Espírito errante aprisionado nestas câmaras.',
+  },
+
+  // ── HUMANOID (Andares 5+) ─────────────────────────────────────────────────
+  {
+    id:          'goblin',
+    category:    'humanoid',
+    frameIndex:  0,
+    name:        'Goblin',
+    hpBase:      50,
+    damageBase:  13,
+    xpBase:      45,
+    rarity:      'common',
+    dungeonMin:  5,
+    dungeonMax:  99,
+  },
+  {
+    id:          'orc',
+    category:    'humanoid',
+    frameIndex:  8,
+    name:        'Orc Guerreiro',
+    hpBase:      65,
+    damageBase:  15,
+    xpBase:      55,
+    rarity:      'uncommon',
+    dungeonMin:  5,
+    dungeonMax:  99,
+    description: 'Grande e violento, resistência elevada.',
+  },
+  {
+    id:          'dark_elf',
+    category:    'humanoid',
+    frameIndex:  16,
+    name:        'Elfo das Sombras',
+    hpBase:      55,
+    damageBase:  17,
+    xpBase:      60,
+    rarity:      'rare',
+    dungeonMin:  5,
+    dungeonMax:  99,
+  },
+
+  // ── DEMON (Andares 5+) ────────────────────────────────────────────────────
+  {
+    id:          'imp',
+    category:    'demon',
+    frameIndex:  0,
+    name:        'Imp',
+    hpBase:      60,
+    damageBase:  16,
+    xpBase:      58,
+    rarity:      'common',
+    dungeonMin:  5,
+    dungeonMax:  99,
+  },
+  {
+    id:          'demon_lord',
+    category:    'demon',
+    frameIndex:  8,
+    name:        'Senhor Demônio',
+    hpBase:      80,
+    damageBase:  20,
+    xpBase:      80,
+    rarity:      'rare',
+    dungeonMin:  6,
+    dungeonMax:  99,
+    description: 'Uma presença antiga que exala poder corrompido.',
+  },
+] as const;
+
+// ─── Distribuição por Andar ───────────────────────────────────────────────────
+
+interface FloorCategoryRule {
+  readonly minFloor: number;
+  readonly maxFloor: number;
+  readonly categories: readonly EnemyCategory[];
+}
+
+const FLOOR_CATEGORY_RULES: readonly FloorCategoryRule[] = [
+  { minFloor: 1, maxFloor: 2, categories: ['pest', 'misc', 'reptile'] },
+  { minFloor: 3, maxFloor: 4, categories: ['undead'] },
+  { minFloor: 5, maxFloor: 99, categories: ['humanoid', 'demon'] },
+];
+
+// ─── Chaves de Textura por Categoria ─────────────────────────────────────────
+// DawnLike usa pares: {Categoria}0.png (frame base) e {Categoria}1.png (frame alternativo).
+// Nota: Undead0.png é carregado como 'undead' (SPRITES.ENEMY) por compatibilidade legada.
+
+export const CATEGORY_TEXTURE_KEYS: Readonly<Record<EnemyCategory, readonly [string, string]>> = {
+  pest:     ['pest0',     'pest1'],
+  misc:     ['misc0',     'misc1'],
+  reptile:  ['reptile0',  'reptile1'],
+  undead:   ['undead',    'undead1'],   // 'undead' é o alias legado de Undead0.png
+  humanoid: ['humanoid0', 'humanoid1'],
+  demon:    ['demon0',    'demon1'],
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Seleção aleatória ponderada.
+ * Items com peso maior têm proporcionalmente mais chance de ser selecionados.
+ */
+export function weightedRandom<T>(items: readonly T[], getWeight: (item: T) => number): T {
+  if (items.length === 0) throw new Error('[EnemyConfig] weightedRandom: lista vazia.');
+
+  const total = items.reduce((sum, item) => sum + getWeight(item), 0);
+  let roll = Math.random() * total;
+
+  for (const item of items) {
+    roll -= getWeight(item);
+    if (roll <= 0) return item;
+  }
+
+  return items[items.length - 1];
+}
+
+/**
+ * Retorna as categorias de inimigos permitidas para o andar.
+ * Emite aviso em DEV se nenhuma regra cobrir o andar (não deve ocorrer).
+ */
+export function getAllowedCategories(floor: number): readonly EnemyCategory[] {
+  const rule = FLOOR_CATEGORY_RULES.find(r => floor >= r.minFloor && floor <= r.maxFloor);
+  if (!rule) {
+    if (import.meta.env.DEV) {
+      console.warn(`[EnemyConfig] Sem regra de categoria para andar ${floor}. Usando 'pest'.`);
+    }
+    return ['pest'];
+  }
+  return rule.categories;
+}
+
+/**
+ * Seleciona proceduralmente um EnemyDef válido para o andar.
+ *
+ * Respeita:
+ * - Categorias permitidas para o andar (FLOOR_CATEGORY_RULES)
+ * - Faixa dungeonMin / dungeonMax do inimigo
+ * - Raridade ponderada (RARITY_WEIGHTS)
+ *
+ * Fallbacks em cascata (logs apenas em DEV):
+ *   1. Pool ideal:    categoria correta + dentro da faixa
+ *   2. Pool relaxado: qualquer inimigo dentro da faixa
+ *   3. Pool global:   primeiro inimigo definido (never happens in normal play)
+ */
+export function pickEnemyDef(floor: number): EnemyDef {
+  const allowedCategories = getAllowedCategories(floor);
+
+  // Pool ideal
+  let pool: readonly EnemyDef[] = ENEMY_DEFS.filter(
+    def => allowedCategories.includes(def.category)
+        && floor >= def.dungeonMin
+        && floor <= def.dungeonMax,
+  );
+
+  if (pool.length === 0) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        `[EnemyConfig] Pool vazio para andar ${floor} com categorias [${allowedCategories.join(', ')}].`
+        + ' Usando fallback de faixa.',
+      );
+    }
+    // Fallback relaxado: qualquer inimigo dentro da faixa de andar
+    pool = ENEMY_DEFS.filter(def => floor >= def.dungeonMin && floor <= def.dungeonMax);
+  }
+
+  if (pool.length === 0) {
+    if (import.meta.env.DEV) {
+      console.warn(`[EnemyConfig] Pool completamente vazio para andar ${floor}. Usando primeiro inimigo.`);
+    }
+    return ENEMY_DEFS[0] as EnemyDef;
+  }
+
+  return weightedRandom(pool, def => RARITY_WEIGHTS[def.rarity]);
+}
+
+/**
+ * Gera a chave de animação Phaser para um inimigo.
+ *
+ * Formato: `enemy.{category}.{variant}.{frameIndex}`
+ *
+ * Exemplos:
+ *   enemy.pest.idle.0
+ *   enemy.undead.idle.16
+ *   enemy.demon.walk.8     (quando variantes adicionais forem implementadas)
+ *
+ * O segmento `variant` reserva extensão futura: idle | walk | attack | death | hit.
+ */
+export function buildAnimKey(category: EnemyCategory, frameIndex: number, variant = 'idle'): string {
+  return `enemy.${category}.${variant}.${frameIndex}`;
+}

--- a/src/config/player-classes.config.ts
+++ b/src/config/player-classes.config.ts
@@ -1,0 +1,146 @@
+import type { EquipmentSlotId } from '../types/equipment';
+
+export type PlayerClass = 'base' | 'guerreiro' | 'arqueiro' | 'mago';
+
+export interface PlayerClassDef {
+  id: PlayerClass;
+  label: string;
+  description: string;
+  frame: number;
+
+  /** Bônus de stats aplicados uma vez na criação do personagem */
+  statBonus: { str?: number; dex?: number; intel?: number; con?: number; wis?: number };
+  /** Ganho de stat por nível (além do crescimento padrão) */
+  statGrowthPerLevel: { str?: number; dex?: number; intel?: number; con?: number; wis?: number };
+
+  // ── Combate ────────────────────────────────────────────────────────────────
+  attackType: 'melee' | 'ranged' | 'magic';
+  /** Alcance de ataque em tiles (1 = corpo a corpo) */
+  attackRange: number;
+  /** Multiplicador de dano físico recebido (< 1 = mais resistente, > 1 = mais frágil) */
+  physicalDamageReceived: number;
+  /** Cooldown de movimento em ms */
+  moveCooldownMs: number;
+  /** Permite ataques corpo a corpo */
+  canMelee: boolean;
+
+  // ── Equipamentos ───────────────────────────────────────────────────────────
+  /** Slots de equipamento proibidos para esta classe */
+  forbiddenSlots: EquipmentSlotId[];
+
+  // ── Loot / economia ────────────────────────────────────────────────────────
+  /** Multiplicador sobre a chance de drop (> 1 = mais drops) */
+  luckMultiplier: number;
+  /** Chance adicional de dropar um segundo item [0–1] */
+  extraDropChance: number;
+
+  // ── Flechas (Arqueiro) ─────────────────────────────────────────────────────
+  usesArrows: boolean;
+  startingArrows: number;
+
+  // ── Magias ─────────────────────────────────────────────────────────────────
+  /** Multiplicador no custo de mana das magias (< 1 = mais barato) */
+  manaCostMultiplier: number;
+  /** Mana regenerada por turno */
+  manaRegenPerTurn: number;
+  /** IDs de magias exclusivas desta classe (outras classes não desbloqueiam) */
+  exclusiveSpells: string[];
+
+  // ── IA inimiga ─────────────────────────────────────────────────────────────
+  /**
+   * Bias de aproximação dos inimigos [0–1].
+   * 0 = comportamento normal; 1 = inimigos sempre perseguem ativamente.
+   */
+  enemyApproachBias: number;
+}
+
+export const PLAYER_CLASSES: PlayerClassDef[] = [
+  {
+    id: 'base',
+    label: 'Aventureiro',
+    description: 'Equilibrado. Bom começo para qualquer caminho.',
+    frame: 24,
+    statBonus: {},
+    statGrowthPerLevel: {},
+    attackType: 'melee',
+    attackRange: 1,
+    physicalDamageReceived: 1.0,
+    moveCooldownMs: 150,
+    canMelee: true,
+    forbiddenSlots: [],
+    luckMultiplier: 1.4,
+    extraDropChance: 0.15,
+    usesArrows: false,
+    startingArrows: 0,
+    manaCostMultiplier: 1.0,
+    manaRegenPerTurn: 0,
+    exclusiveSpells: [],
+    enemyApproachBias: 0,
+  },
+  {
+    id: 'guerreiro',
+    label: 'Guerreiro',
+    description: '+3 FOR, +2 CON. Tanque corpo a corpo.',
+    frame: 25,
+    statBonus: { str: 3, con: 2 },
+    statGrowthPerLevel: { str: 1, con: 1 },
+    attackType: 'melee',
+    attackRange: 1,
+    physicalDamageReceived: 0.70,
+    moveCooldownMs: 210,
+    canMelee: true,
+    forbiddenSlots: [],
+    luckMultiplier: 1.0,
+    extraDropChance: 0.0,
+    usesArrows: false,
+    startingArrows: 0,
+    manaCostMultiplier: 1.3,
+    manaRegenPerTurn: 0,
+    exclusiveSpells: [],
+    enemyApproachBias: 0,
+  },
+  {
+    id: 'arqueiro',
+    label: 'Arqueiro',
+    description: '+3 DES. Críticos frequentes e ataques à distância.',
+    frame: 26,
+    statBonus: { dex: 3 },
+    statGrowthPerLevel: { dex: 1 },
+    attackType: 'ranged',
+    attackRange: 4,
+    physicalDamageReceived: 1.30,
+    moveCooldownMs: 130,
+    canMelee: false,
+    forbiddenSlots: ['sword', 'shield'],
+    luckMultiplier: 1.0,
+    extraDropChance: 0.0,
+    usesArrows: true,
+    startingArrows: 100,
+    manaCostMultiplier: 1.0,
+    manaRegenPerTurn: 0,
+    exclusiveSpells: [],
+    enemyApproachBias: 1.0,
+  },
+  {
+    id: 'mago',
+    label: 'Mago',
+    description: '+4 INT, +2 SAB. Poder mágico elevado.',
+    frame: 31,
+    statBonus: { intel: 4, wis: 2 },
+    statGrowthPerLevel: { intel: 1, wis: 1 },
+    attackType: 'magic',
+    attackRange: 1,
+    physicalDamageReceived: 1.60,
+    moveCooldownMs: 150,
+    canMelee: false,
+    forbiddenSlots: ['sword', 'shield'],
+    luckMultiplier: 1.0,
+    extraDropChance: 0.0,
+    usesArrows: false,
+    startingArrows: 0,
+    manaCostMultiplier: 0.65,
+    manaRegenPerTurn: 3,
+    exclusiveSpells: [],
+    enemyApproachBias: 0.8,
+  },
+];

--- a/src/config/shop.catalog.ts
+++ b/src/config/shop.catalog.ts
@@ -1,71 +1,48 @@
 import { Item } from '../entities/Item';
-import type { ConsumableItemType } from '../entities/Item';
 import type { EquipmentSlotId, StatBonuses, ItemRarity, EquippableItemType } from '../types/equipment';
 
 export interface ShopItemDef {
   id: string;
   name: string;
-  type: EquippableItemType | ConsumableItemType;
+  type: EquippableItemType | 'potion_heal';
   slotId: EquipmentSlotId | null;
   price: number;
   rarity: ItemRarity;
   bonuses: StatBonuses;
+  quantity?: number;
 }
 
 export const SHOP_CATALOG: ShopItemDef[] = [
-  // ── Espadas ──────────────────────────────────────────────────────────────
-  { id: 'sword_iron_1',     name: 'Espada de Ferro',      type: 'sword_iron',     slotId: 'sword',  price:  120, rarity: 'common',    bonuses: { attack: 3 } },
-  { id: 'sword_steel_1',    name: 'Espada de Aço',        type: 'sword_steel',    slotId: 'sword',  price:  280, rarity: 'uncommon',  bonuses: { attack: 6 } },
-  { id: 'sword_silver_1',   name: 'Espada de Prata',      type: 'sword_silver',   slotId: 'sword',  price:  600, rarity: 'rare',      bonuses: { attack: 12, str: 1 } },
-  { id: 'sword_obsidian_1', name: 'Espada de Obsidiana',  type: 'sword_obsidian', slotId: 'sword',  price: 1400, rarity: 'epic',      bonuses: { attack: 22, str: 3, dex: 2 } },
-  { id: 'sword_dragon_1',   name: 'Espadão do Dragão',    type: 'sword_dragon',   slotId: 'sword',  price: 3500, rarity: 'legendary', bonuses: { attack: 40, str: 6, maxHp: 30 } },
-
-  // ── Capacetes ────────────────────────────────────────────────────────────
-  { id: 'helmet_leather_1', name: 'Elmo de Couro',        type: 'helmet_leather', slotId: 'helmet', price:   80, rarity: 'common',    bonuses: { con: 1 } },
-  { id: 'helmet_bronze_1',  name: 'Elmo de Bronze',       type: 'helmet_bronze',  slotId: 'helmet', price:  190, rarity: 'uncommon',  bonuses: { con: 2 } },
-  { id: 'helmet_iron_1',    name: 'Elmo de Ferro',         type: 'helmet_iron',    slotId: 'helmet', price:  380, rarity: 'rare',      bonuses: { con: 3, maxHp: 10 } },
-  { id: 'helmet_mithril_1', name: 'Elmo de Mithril',      type: 'helmet_mithril', slotId: 'helmet', price:  950, rarity: 'epic',      bonuses: { con: 5, maxHp: 25, dex: 1 } },
-  { id: 'helmet_void_1',    name: 'Coroa do Vazio',        type: 'helmet_void',    slotId: 'helmet', price: 2800, rarity: 'legendary', bonuses: { con: 8, maxHp: 60, wis: 3, maxMana: 20 } },
-
-  // ── Escudos ───────────────────────────────────────────────────────────────
-  { id: 'shield_wood_1',    name: 'Escudo de Madeira',    type: 'shield_wood',    slotId: 'shield', price:   70, rarity: 'common',    bonuses: { con: 1 } },
-  { id: 'shield_iron_1',    name: 'Escudo de Ferro',      type: 'shield_iron',    slotId: 'shield', price:  170, rarity: 'uncommon',  bonuses: { con: 2, maxHp: 5 } },
-  { id: 'shield_steel_1',   name: 'Escudo de Aço',        type: 'shield_steel',   slotId: 'shield', price:  360, rarity: 'rare',      bonuses: { con: 3, maxHp: 15 } },
-  { id: 'shield_runic_1',   name: 'Escudo Rúnico',        type: 'shield_runic',   slotId: 'shield', price:  900, rarity: 'epic',      bonuses: { con: 5, maxHp: 35, str: 2 } },
-  { id: 'shield_aegis_1',   name: 'Égide Celestial',      type: 'shield_aegis',   slotId: 'shield', price: 2500, rarity: 'legendary', bonuses: { con: 8, maxHp: 80, attack: 5 } },
-
-  // ── Calças ────────────────────────────────────────────────────────────────
-  { id: 'pants_leather_1',  name: 'Calça de Couro',       type: 'pants_leather',  slotId: 'pants',  price:   60, rarity: 'common',    bonuses: { dex: 1 } },
-  { id: 'pants_iron_1',     name: 'Calça de Malha',       type: 'pants_iron',     slotId: 'pants',  price:  160, rarity: 'uncommon',  bonuses: { dex: 2, con: 1 } },
-  { id: 'pants_mithril_1',  name: 'Calça de Mithril',     type: 'pants_mithril',  slotId: 'pants',  price:  750, rarity: 'epic',      bonuses: { dex: 4, con: 3, maxHp: 15 } },
-  { id: 'pants_shadow_1',   name: 'Vestes da Sombra',     type: 'pants_shadow',   slotId: 'pants',  price: 2200, rarity: 'legendary', bonuses: { dex: 7, con: 4, attack: 8, maxHp: 20 } },
-
-  // ── Botas ─────────────────────────────────────────────────────────────────
-  { id: 'boots_leather_1',  name: 'Botas de Couro',       type: 'boots_leather',  slotId: 'boots',  price:   60, rarity: 'common',    bonuses: { dex: 1 } },
-  { id: 'boots_iron_1',     name: 'Botas de Ferro',       type: 'boots_iron',     slotId: 'boots',  price:  150, rarity: 'uncommon',  bonuses: { dex: 2 } },
-  { id: 'boots_swift_1',    name: 'Botas Velozes',        type: 'boots_swift',    slotId: 'boots',  price:  680, rarity: 'epic',      bonuses: { dex: 4, str: 2, maxHp: 10 } },
-  { id: 'boots_ethereal_1', name: 'Botas Etéreas',        type: 'boots_ethereal', slotId: 'boots',  price: 1900, rarity: 'legendary', bonuses: { dex: 8, attack: 6, maxHp: 15 } },
-
-  // ── Amuletos ──────────────────────────────────────────────────────────────
-  { id: 'amulet_stone_1',   name: 'Amuleto de Pedra',     type: 'amulet_stone',   slotId: 'amulet', price:  100, rarity: 'common',    bonuses: { str: 1 } },
-  { id: 'amulet_silver_1',  name: 'Amuleto de Prata',     type: 'amulet_silver',  slotId: 'amulet', price:  230, rarity: 'uncommon',  bonuses: { str: 2, attack: 2 } },
-  { id: 'amulet_gold_1',    name: 'Amuleto de Ouro',      type: 'amulet_gold',    slotId: 'amulet', price:  500, rarity: 'rare',      bonuses: { str: 3, attack: 5, maxHp: 5 } },
-  { id: 'amulet_arcane_1',  name: 'Amuleto Arcano',       type: 'amulet_arcane',  slotId: 'amulet', price: 1200, rarity: 'epic',      bonuses: { str: 4, wis: 3, int: 3, maxMana: 25 } },
-  { id: 'amulet_eternal_1', name: 'Amuleto da Eternidade',type: 'amulet_eternal', slotId: 'amulet', price: 3200, rarity: 'legendary', bonuses: { str: 6, attack: 10, maxHp: 40, maxMana: 40 } },
-
-  // ── Anéis (novo slot) ─────────────────────────────────────────────────────
-  { id: 'ring_copper_1',    name: 'Anel de Cobre',        type: 'ring_copper',    slotId: 'ring',   price:   90, rarity: 'common',    bonuses: { int: 1 } },
-  { id: 'ring_silver_1',    name: 'Anel de Prata',        type: 'ring_silver',    slotId: 'ring',   price:  210, rarity: 'uncommon',  bonuses: { wis: 2, maxMana: 10 } },
-  { id: 'ring_enchanted_1', name: 'Anel Encantado',       type: 'ring_enchanted', slotId: 'ring',   price:  850, rarity: 'epic',      bonuses: { wis: 4, int: 4, maxMana: 30, attack: 3 } },
-  { id: 'ring_void_1',      name: 'Anel do Vazio',        type: 'ring_void',      slotId: 'ring',   price: 2800, rarity: 'legendary', bonuses: { wis: 6, int: 6, maxMana: 60, str: 3, attack: 8 } },
-
-  // ── Poções ────────────────────────────────────────────────────────────────
-  { id: 'potion_heal_light_shop', name: 'Poção de Cura Fraca',  type: 'potion_heal_light', slotId: null, price:  15, rarity: 'common',   bonuses: {} },
-  { id: 'potion_heal_shop',       name: 'Poção de Cura',        type: 'potion_heal',       slotId: null, price:  40, rarity: 'uncommon', bonuses: {} },
-  { id: 'potion_heal_high_shop',  name: 'Poção de Cura Forte',  type: 'potion_heal_high',  slotId: null, price:  90, rarity: 'rare',     bonuses: {} },
-  { id: 'potion_mana_light_shop', name: 'Poção de Mana Fraca',  type: 'potion_mana_light', slotId: null, price:  20, rarity: 'common',   bonuses: {} },
-  { id: 'potion_mana_shop',       name: 'Poção de Mana',        type: 'potion_mana',       slotId: null, price:  50, rarity: 'uncommon', bonuses: {} },
-  { id: 'potion_mana_high_shop',  name: 'Poção de Mana Forte',  type: 'potion_mana_high',  slotId: null, price: 110, rarity: 'rare',     bonuses: {} },
+  // Espadas
+  { id: 'sword_iron_1',    name: 'Espada de Ferro',   type: 'sword_iron',   slotId: 'sword',  price: 120, rarity: 'common',   bonuses: { attack: 3 } },
+  { id: 'sword_steel_1',   name: 'Espada de Aço',     type: 'sword_steel',  slotId: 'sword',  price: 250, rarity: 'uncommon', bonuses: { attack: 6 } },
+  { id: 'sword_silver_1',  name: 'Espada de Prata',   type: 'sword_silver', slotId: 'sword',  price: 500, rarity: 'rare',     bonuses: { attack: 12 } },
+  // Capacetes
+  { id: 'helmet_leather_1',name: 'Elmo de Couro',     type: 'helmet_leather', slotId: 'helmet', price: 80,  rarity: 'common',   bonuses: { con: 1 } },
+  { id: 'helmet_bronze_1', name: 'Elmo de Bronze',    type: 'helmet_bronze',  slotId: 'helmet', price: 180, rarity: 'uncommon', bonuses: { con: 2 } },
+  { id: 'helmet_iron_1',   name: 'Elmo de Ferro',     type: 'helmet_iron',    slotId: 'helmet', price: 350, rarity: 'rare',     bonuses: { con: 3, maxHp: 10 } },
+  // Escudos
+  { id: 'shield_wood_1',   name: 'Escudo de Madeira', type: 'shield_wood',  slotId: 'shield', price: 70,  rarity: 'common',   bonuses: { con: 1 } },
+  { id: 'shield_iron_1',   name: 'Escudo de Ferro',   type: 'shield_iron',  slotId: 'shield', price: 160, rarity: 'uncommon', bonuses: { con: 2, maxHp: 5 } },
+  { id: 'shield_steel_1',  name: 'Escudo de Aço',     type: 'shield_steel', slotId: 'shield', price: 320, rarity: 'rare',     bonuses: { con: 3, maxHp: 15 } },
+  // Calças
+  { id: 'pants_leather_1', name: 'Calça de Couro',    type: 'pants_leather', slotId: 'pants', price: 60,  rarity: 'common',   bonuses: { dex: 1 } },
+  { id: 'pants_iron_1',    name: 'Calça de Malha',    type: 'pants_iron',    slotId: 'pants', price: 150, rarity: 'uncommon', bonuses: { dex: 2, con: 1 } },
+  // Botas
+  { id: 'boots_leather_1', name: 'Botas de Couro',    type: 'boots_leather', slotId: 'boots', price: 60,  rarity: 'common',   bonuses: { dex: 1 } },
+  { id: 'boots_iron_1',    name: 'Botas de Ferro',    type: 'boots_iron',    slotId: 'boots', price: 140, rarity: 'uncommon', bonuses: { dex: 2 } },
+  // Amuletos
+  { id: 'amulet_stone_1',  name: 'Amuleto de Pedra',  type: 'amulet_stone',  slotId: 'amulet', price: 100, rarity: 'common',   bonuses: { str: 1 } },
+  { id: 'amulet_silver_1', name: 'Amuleto de Prata',  type: 'amulet_silver', slotId: 'amulet', price: 220, rarity: 'uncommon', bonuses: { str: 2, attack: 2 } },
+  { id: 'amulet_gold_1',   name: 'Amuleto de Ouro',   type: 'amulet_gold',   slotId: 'amulet', price: 450, rarity: 'rare',     bonuses: { str: 3, attack: 5, maxHp: 5 } },
+  // Arco
+  { id: 'bow_wood', name: 'Arco de Madeira', type: 'bow', slotId: 'sword', price: 80, rarity: 'common', bonuses: { attack: 2 } },
+  // Flechas (equipáveis no slot Extra)
+  { id: 'arrows_20',  name: 'Flechas (x20)',  type: 'arrows_20',  slotId: 'extra', quantity: 20,  price: 40,  rarity: 'common',   bonuses: {} },
+  { id: 'arrows_50',  name: 'Flechas (x50)',  type: 'arrows_50',  slotId: 'extra', quantity: 50,  price: 90,  rarity: 'common',   bonuses: {} },
+  { id: 'arrows_100', name: 'Flechas (x100)', type: 'arrows_100', slotId: 'extra', quantity: 100, price: 160, rarity: 'uncommon', bonuses: {} },
+  // Poções
+  { id: 'potion_heal_shop', name: 'Poção de Cura',    type: 'potion_heal',   slotId: null,     price: 30,  rarity: 'common',   bonuses: {} },
 ];
 
 export function createItemFromCatalogEntry(entry: ShopItemDef): Item {
@@ -75,20 +52,31 @@ export function createItemFromCatalogEntry(entry: ShopItemDef): Item {
   item.bonuses = Object.keys(entry.bonuses).length > 0 ? { ...entry.bonuses } : undefined;
   item.price   = entry.price;
   item.rarity  = entry.rarity;
-  // Poções compradas chegam já identificadas
-  if (entry.type.startsWith('potion_')) item.identified = true;
+  item.identified = true;
+  if (entry.quantity !== undefined) item.quantity = entry.quantity;
   return item;
 }
 
+export const STARTING_ITEMS = {
+  spellbook_basic: {
+    id: 'spellbook_basic',
+    name: 'Livro de Magia',
+    type: 'spellbook' as const,
+    slotId: 'sword' as const,
+    price: 0,
+    rarity: 'uncommon' as const,
+    bonuses: { int: 2 } as Record<string, number>,
+  },
+  bow_wood: SHOP_CATALOG.find(e => e.id === 'bow_wood')!,
+  arrows_100: SHOP_CATALOG.find(e => e.id === 'arrows_100')!,
+};
+
 export function buildBonusText(bonuses: StatBonuses): string {
   const parts: string[] = [];
-  if (bonuses.attack)  parts.push(`+${bonuses.attack} ATK`);
-  if (bonuses.maxHp)   parts.push(`+${bonuses.maxHp} HP`);
-  if (bonuses.maxMana) parts.push(`+${bonuses.maxMana} Mana`);
-  if (bonuses.con)     parts.push(`+${bonuses.con} CON`);
-  if (bonuses.str)     parts.push(`+${bonuses.str} STR`);
-  if (bonuses.dex)     parts.push(`+${bonuses.dex} DEX`);
-  if (bonuses.wis)     parts.push(`+${bonuses.wis} WIS`);
-  if (bonuses.int)     parts.push(`+${bonuses.int} INT`);
+  if (bonuses.attack) parts.push(`+${bonuses.attack} ATK`);
+  if (bonuses.maxHp)  parts.push(`+${bonuses.maxHp} HP`);
+  if (bonuses.con)    parts.push(`+${bonuses.con} CON`);
+  if (bonuses.str)    parts.push(`+${bonuses.str} STR`);
+  if (bonuses.dex)    parts.push(`+${bonuses.dex} DEX`);
   return parts.length > 0 ? parts.join(', ') : '—';
 }

--- a/src/config/spell-progression.ts
+++ b/src/config/spell-progression.ts
@@ -1,6 +1,6 @@
 // Tabela data-driven: key = nível mínimo para desbloquear as magias listadas
 export const SPELL_PROGRESSION: Record<number, string[]> = {
-  1:  ['fire_bolt'],
+  1:  ['fire_bolt', 'minor_healing'],
   5:  ['ice_shard'],
   10: ['wind_cyclone'],
   15: ['fire_explosion'],

--- a/src/config/spells.db.ts
+++ b/src/config/spells.db.ts
@@ -1,6 +1,13 @@
 import type { SpellDef } from '../types/spells';
 
 export const SPELLS_DB: Record<string, SpellDef> = {
+  minor_healing: {
+    id: 'minor_healing', name: 'Minor Healing', element: 'arcane',
+    damage: 0, heal: 20, manaCost: 10, cooldownMs: 1500, projectileSpeed: 0,
+    animKey: 'spell_wind_fly', impactAnimKey: 'spell_wind_impact',
+    minLevel: 1,
+    description: 'Canaliza energia arcana para recuperar 20 de vida.',
+  },
   fire_bolt: {
     id: 'fire_bolt', name: 'Fire Bolt', element: 'fire',
     damage: 15, manaCost: 8, cooldownMs: 800, projectileSpeed: 3,

--- a/src/entities/Item.ts
+++ b/src/entities/Item.ts
@@ -43,15 +43,15 @@ export class Item {
   /** Descrição gerada por IA (opcional, apenas para itens raros/especiais) */
   aiDescription: string | null = null;
 
-  /** Quantidade de ouro (apenas para type === 'gold') */
-  goldAmount?: number;
-
   // Campos opcionais para equipamentos
   name?: string;
   slotId?: EquipmentSlotId;
   bonuses?: StatBonuses;
   price?: number;
   rarity?: ItemRarity;
+  noSell?: boolean;
+  noUnequip?: boolean;
+  quantity?: number;
 
   constructor(id: string, type: ItemType, gridX: number | null = null, gridY: number | null = null) {
     this.id         = id;

--- a/src/entities/Item.ts
+++ b/src/entities/Item.ts
@@ -52,6 +52,7 @@ export class Item {
   noSell?: boolean;
   noUnequip?: boolean;
   quantity?: number;
+  goldAmount?: number;
 
   constructor(id: string, type: ItemType, gridX: number | null = null, gridY: number | null = null) {
     this.id         = id;

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -5,6 +5,7 @@ import { InventorySystem } from '../systems/InventorySystem';
 import type { DungeonGenerator } from '../generators/DungeonGenerator';
 import type { StatBonuses } from '../types/equipment';
 import type { Direction } from '../types/spells';
+import { PLAYER_CLASSES, type PlayerClassDef } from '../config/player-classes.config';
 
 export class Player extends Phaser.GameObjects.Sprite {
   // Posição no grid (tile-based)
@@ -43,6 +44,13 @@ export class Player extends Phaser.GameObjects.Sprite {
   unlockedSpells: string[];
   equippedSpells: [string | null, string | null];
   facingDir:      Direction;
+
+  /** Definição da classe do personagem — fonte de verdade para regras */
+  classDef: PlayerClassDef;
+  /** Flechas disponíveis (apenas Arqueiro) */
+  arrows: number;
+  /** Cooldown de movimento em ms (configurado pela classe) */
+  moveCooldown: number;
 
   private _lastMoveTime: number;
   private _emitter: Phaser.Events.EventEmitter;
@@ -87,6 +95,11 @@ export class Player extends Phaser.GameObjects.Sprite {
     this.identifiedItems = {};
 
     this.gold = 500;
+
+    // Classe e recursos de classe
+    this.classDef    = PLAYER_CLASSES[0];
+    this.arrows      = 0;
+    this.moveCooldown = PLAYER.MOVE_COOLDOWN;
 
     // Magias e pontos livres
     this.freePoints     = 0;

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -27,6 +27,9 @@ export class Player extends Phaser.GameObjects.Sprite {
   xp: number;
   level: number;
   attack: number;
+  critChance = 0;   // DEX: chance de crítico (0–0.30)
+  cdReduction = 0;  // WIS: redução de cooldown de magias (0–0.40)
+  spellBonus = 0;   // INT: bônus de dano mágico flat
 
   // Inventário e identificação de itens
   inventory: InventorySystem;
@@ -69,11 +72,11 @@ export class Player extends Phaser.GameObjects.Sprite {
     this.xp     = 0;
     this.attack = PLAYER.ATTACK;
 
-    // Derivados via fórmulas da spec
-    this.maxHp   = this.con * 5 + this.level * 3;
-    this.hp      = this.maxHp;
-    this.maxMana = this.wis * 4 + this.intel * 2;
-    this.mana    = this.maxMana;
+    // Inicialização temporária antes do recalcStats
+    this.maxHp = 0; this.maxMana = 0;
+    this.recalcStats();
+    this.hp   = this.maxHp;
+    this.mana = this.maxMana;
 
     this._lastMoveTime    = 0;
     this._emitter         = scene.events;
@@ -92,12 +95,27 @@ export class Player extends Phaser.GameObjects.Sprite {
     this.facingDir      = 'down';
   }
 
-  /** Recalcula maxHp, maxMana e attack a partir dos atributos base, nível e bônus de equipamento. */
+  /** Recalcula todos os atributos derivados a partir dos stats base, nível e bônus de equipamento. */
   recalcStats(): void {
-    this.maxHp   = this.con * 5 + this.level * 3 + (this._equipmentBonuses.maxHp ?? 0);
-    this.maxMana = this.wis * 4 + this.intel * 2;
-    this.attack  = PLAYER.ATTACK + (this._equipmentBonuses.attack ?? 0);
-    // hp e mana nunca ultrapassam o máximo
+    // VIT (CON): cada ponto = 5 HP + bônus de nível
+    this.maxHp = this.con * 5 + this.level * 3 + (this._equipmentBonuses.maxHp ?? 0);
+
+    // WIS: peso maior para diferenciar de INT; INT contribui menos
+    this.maxMana = this.wis * 5 + this.intel * 2;
+
+    // STR: dano físico base + 0.8 por ponto acima de 10
+    const strBonus = Math.floor((this.str - 10) * 0.8);
+    this.attack = PLAYER.ATTACK + strBonus + (this._equipmentBonuses.attack ?? 0);
+
+    // DEX: +1.5% de crítico por ponto acima de 10, cap 30%
+    this.critChance = Math.min(Math.max((this.dex - 10) * 0.015, 0), 0.30);
+
+    // WIS: +2% de redução de cooldown por ponto acima de 10, cap 40%
+    this.cdReduction = Math.min(Math.max((this.wis - 10) * 0.02, 0), 0.40);
+
+    // INT: +1.2 de dano mágico flat por ponto acima de 10
+    this.spellBonus = Math.floor(Math.max((this.intel - 10) * 1.2, 0));
+
     this.hp   = Math.min(this.hp,   this.maxHp);
     this.mana = Math.min(this.mana, this.maxMana);
   }

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -72,15 +72,15 @@ export class Player extends Phaser.GameObjects.Sprite {
     this.xp     = 0;
     this.attack = PLAYER.ATTACK;
 
+    this._lastMoveTime     = 0;
+    this._emitter          = scene.events;
+    this._equipmentBonuses = {};
+
     // Inicialização temporária antes do recalcStats
     this.maxHp = 0; this.maxMana = 0;
     this.recalcStats();
     this.hp   = this.maxHp;
     this.mana = this.maxMana;
-
-    this._lastMoveTime    = 0;
-    this._emitter         = scene.events;
-    this._equipmentBonuses = {};
 
     // Inventário e identificação
     this.inventory       = new InventorySystem();

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -216,6 +216,18 @@ export class Player extends Phaser.GameObjects.Sprite {
     }
   }
 
+  applyClassBonus(classDef: PlayerClassDef): void {
+    const b = classDef.statBonus;
+    if (b.str)   this.str   = BASE_STATS.STR + b.str;
+    if (b.intel) this.intel = BASE_STATS.INT + b.intel;
+    if (b.dex)   this.dex   = BASE_STATS.DEX + b.dex;
+    if (b.con)   this.con   = BASE_STATS.CON + b.con;
+    if (b.wis)   this.wis   = BASE_STATS.WIS + b.wis;
+    this.recalcStats();
+    this.hp   = this.maxHp;
+    this.mana = this.maxMana;
+  }
+
   spendStatPoint(stat: 'str' | 'intel' | 'dex' | 'con' | 'wis'): boolean {
     if (this.freePoints <= 0) return false;
     this[stat] += 1;

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -95,6 +95,23 @@ export class Player extends Phaser.GameObjects.Sprite {
     this.facingDir      = 'down';
   }
 
+  /** Aplica o frame e a animação de idle correspondentes ao frame da classe. */
+  applySkin(frame: number): void {
+    const key = `player.idle.${frame}`;
+    if (!this.scene.anims.exists(key)) {
+      this.scene.anims.create({
+        key,
+        frames: [
+          { key: SPRITES.PLAYER, frame },
+          { key: 'player1',      frame },
+        ],
+        frameRate: 2,
+        repeat: -1,
+      });
+    }
+    this.play(key);
+  }
+
   /** Recalcula todos os atributos derivados a partir dos stats base, nível e bônus de equipamento. */
   recalcStats(): void {
     // VIT (CON): cada ponto = 5 HP + bônus de nível

--- a/src/generators/DungeonFeatureGenerator.ts
+++ b/src/generators/DungeonFeatureGenerator.ts
@@ -3,7 +3,7 @@ import type { GridPos } from './DungeonGenerator';
 import { TILE } from '../utils/constants';
 import type { StairConnection, FloorConnectionData } from '../types/dungeon';
 
-export type FeatureType = 'stairDown' | 'stairUp' | 'trap' | 'shrine' | 'portal';
+export type FeatureType = 'stairDown' | 'stairUp' | 'trap' | 'shrine' | 'portal' | 'chest';
 
 export interface DungeonFeature {
   type: FeatureType;
@@ -60,6 +60,26 @@ export class DungeonFeatureGenerator {
         targetPosition: { x: 0, y: 0 }, // preenchido depois
       };
       features.push({ type: 'stairDown', gridX: downPos.x, gridY: downPos.y, connection: downConn });
+    }
+
+    // Baús: 1-2 por andar, em rooms intermediárias (evitando a primeira e a última)
+    const chestCount = 1 + Math.floor(Math.random() * 2);
+    const midRooms = dungeon.rooms.length > 2
+      ? dungeon.rooms.slice(1, dungeon.rooms.length - 1)
+      : dungeon.rooms;
+
+    for (let i = 0; i < chestCount; i++) {
+      const roomIdx = Math.floor(Math.random() * midRooms.length);
+      const absoluteRoomIdx = dungeon.rooms.indexOf(midRooms[roomIdx]);
+      const pos = this._findPositionInRoom(dungeon, absoluteRoomIdx, excluded);
+      if (!pos) continue;
+      excluded.add(`${pos.x},${pos.y}`);
+      features.push({
+        type: 'chest',
+        gridX: pos.x,
+        gridY: pos.y,
+        metadata: { opened: false },
+      });
     }
 
     return features;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as Phaser from 'phaser';
 import { BootScene } from './scenes/BootScene';
 import { MainMenuScene } from './scenes/MainMenuScene';
+import { CharacterSelectScene } from './scenes/CharacterSelectScene';
 import { CreditsScene } from './scenes/CreditsScene';
 import { GameScene } from './scenes/GameScene';
 import { UIScene } from './scenes/UIScene';
@@ -34,7 +35,7 @@ const config: Phaser.Types.Core.GameConfig = {
     },
   },
 
-  scene: [BootScene, MainMenuScene, CreditsScene, GameScene, UIScene, GameOverScene],
+  scene: [BootScene, MainMenuScene, CharacterSelectScene, CreditsScene, GameScene, UIScene, GameOverScene],
 };
 
 const game = new Phaser.Game(config);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import * as Phaser from 'phaser';
 import { BootScene } from './scenes/BootScene';
+import { MainMenuScene } from './scenes/MainMenuScene';
+import { CreditsScene } from './scenes/CreditsScene';
 import { GameScene } from './scenes/GameScene';
 import { UIScene } from './scenes/UIScene';
 import { GameOverScene } from './scenes/GameOverScene';
@@ -32,7 +34,7 @@ const config: Phaser.Types.Core.GameConfig = {
     },
   },
 
-  scene: [BootScene, GameScene, UIScene, GameOverScene],
+  scene: [BootScene, MainMenuScene, CreditsScene, GameScene, UIScene, GameOverScene],
 };
 
 const game = new Phaser.Game(config);

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -39,6 +39,7 @@ export class BootScene extends Phaser.Scene {
     // Estes não pertencem a biomas e permanecem hardcoded aqui intencionalmente.
     this.load.spritesheet(SPRITES.WALL,    `${base}/Objects/Wall.png`,           { frameWidth: 16, frameHeight: 16 });
     this.load.spritesheet(SPRITES.PLAYER,  `${base}/Characters/Player0.png`,     { frameWidth: 16, frameHeight: 16 });
+    this.load.spritesheet('player1',       `${base}/Characters/Player1.png`,     { frameWidth: 16, frameHeight: 16 });
     this.load.spritesheet(SPRITES.ENEMY,   `${base}/Characters/Undead0.png`,     { frameWidth: 16, frameHeight: 16 });
     this.load.spritesheet(SPRITES.POTION,  `${base}/Items/Potion.png`,           { frameWidth: 16, frameHeight: 16 });
     this.load.spritesheet(SPRITES.MONEY,   `${base}/Items/Money.png`,            { frameWidth: 16, frameHeight: 16 });

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,6 +1,7 @@
 import * as Phaser from 'phaser';
-import { SPRITES } from '../utils/constants';
+import { SPRITES, DEV_CONFIG } from '../utils/constants';
 import { FLOOR_ATLAS, OBJECT_ATLAS, NPC_ATLAS } from '../config/sprites-config';
+import { ENEMY_DEFS, CATEGORY_TEXTURE_KEYS, buildAnimKey } from '../config/enemies.config';
 
 export class BootScene extends Phaser.Scene {
   constructor() {
@@ -43,6 +44,12 @@ export class BootScene extends Phaser.Scene {
     this.load.spritesheet(SPRITES.MONEY,   `${base}/Items/Money.png`,            { frameWidth: 16, frameHeight: 16 });
     this.load.spritesheet(SPRITES.PLATINO, `${base}/Characters/Reptile0.png`,    { frameWidth: 16, frameHeight: 16 });
 
+    // ── Spritesheets de inimigos (pares DawnLike *0/*1) ───────────────────────
+    // Cada categoria usa dois arquivos: o frame-0 (base) e o frame-1 (alternativo).
+    // 'humanoid0' já está carregado via NPC_ATLAS; 'undead' (Undead0) via SPRITES.ENEMY.
+    // Carregamos apenas os que ainda não existem para evitar loads duplicados.
+    this._loadEnemySpritesheets(base, loaded);
+
     // Assets necessários para o mapa TMX da cidade
     this.load.spritesheet('floor',  `${base}/Objects/Floor.png`,           { frameWidth: 16, frameHeight: 16 });
     this.load.spritesheet('pit0',   `${base}/Objects/Pit0.png`,            { frameWidth: 16, frameHeight: 16 });
@@ -55,11 +62,14 @@ export class BootScene extends Phaser.Scene {
     this.load.spritesheet('effect0', `${base}/Objects/Effect0.png`, { frameWidth: 16, frameHeight: 16 });
     this.load.spritesheet('effect1', `${base}/Objects/Effect1.png`, { frameWidth: 16, frameHeight: 16 });
 
+    this.load.image('game_bg', 'assets/game_bg.png');
+
     this._setupLoadingBar();
   }
 
   create(): void {
     this._registerSpellAnims();
+    this._registerEnemyAnims();
 
     const { width, height } = this.scale;
 
@@ -72,8 +82,95 @@ export class BootScene extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.time.delayedCall(200, () => {
-      this.scene.start('GameScene');
+      this.scene.start(DEV_CONFIG.devMode ? 'GameScene' : 'MainMenuScene');
     });
+  }
+
+  /**
+   * Carrega os spritesheets de inimigos (pares DawnLike *0/*1).
+   * Usa o set `loaded` do preload para deduplicar — mesma lógica dos atlases.
+   *
+   * Chaves já presentes antes desta chamada (NÃO são recarregadas):
+   *   'undead'     → Undead0.png   (carregado como SPRITES.ENEMY)
+   *   'humanoid0'  → Humanoid0.png (carregado via NPC_ATLAS)
+   */
+  private _loadEnemySpritesheets(base: string, loaded: Set<string>): void {
+    const frameConfig = { frameWidth: 16, frameHeight: 16 };
+    const chars = `${base}/Characters`;
+
+    // Pares a carregar: [textureKey, arquivo].
+    // 'undead' (Undead0) e 'humanoid0' já foram carregados acima; apenas adicionamos
+    // as chaves padronizadas que ainda faltam.
+    const pairs: Array<[string, string]> = [
+      ['pest0',     'Pest0.png'],
+      ['pest1',     'Pest1.png'],
+      ['misc0',     'Misc0.png'],
+      ['misc1',     'Misc1.png'],
+      ['reptile0',  'Reptile0.png'],
+      ['reptile1',  'Reptile1.png'],
+      ['undead1',   'Undead1.png'],   // Undead0 já existe como 'undead'
+      ['humanoid1', 'Humanoid1.png'], // Humanoid0 já existe como 'humanoid0'
+      ['demon0',    'Demon0.png'],
+      ['demon1',    'Demon1.png'],
+    ];
+
+    for (const [key, file] of pairs) {
+      if (loaded.has(key)) continue;
+      this.load.spritesheet(key, `${chars}/${file}`, frameConfig);
+      loaded.add(key);
+    }
+
+    if (import.meta.env.DEV) {
+      console.log(`[BootScene] Spritesheets de inimigos registrados: ${pairs.map(p => p[0]).join(', ')}`);
+    }
+  }
+
+  /**
+   * Registra globalmente as animações de inimigos no AnimationManager do Phaser.
+   * Deve ser chamado em create() — uma única vez por sessão de jogo.
+   *
+   * Estratégia ping-pong DawnLike:
+   *   Frame A → { key: '{categoria}0', frame: N }
+   *   Frame B → { key: '{categoria}1', frame: N }
+   *   O mesmo índice N representa o mesmo inimigo nos dois arquivos.
+   *
+   * Apenas cria animações para os inimigos definidos em ENEMY_DEFS (~15 entradas),
+   * evitando explosão combinatória. Idempotente por verificação prévia de existência.
+   */
+  private _registerEnemyAnims(): void {
+    // Wrapper idempotente (mesma assinatura do _registerSpellAnims)
+    const safe = (
+      key:     string,
+      frames:  Phaser.Types.Animations.AnimationFrame[],
+      rate:    number,
+      repeat:  number,
+    ): void => {
+      if (this.anims.exists(key)) return;
+      this.anims.create({ key, frames, frameRate: rate, repeat });
+    };
+
+    let registered = 0;
+
+    for (const def of ENEMY_DEFS) {
+      const [tex0, tex1] = CATEGORY_TEXTURE_KEYS[def.category];
+      const animKey = buildAnimKey(def.category, def.frameIndex);
+
+      safe(
+        animKey,
+        [
+          { key: tex0, frame: def.frameIndex },
+          { key: tex1, frame: def.frameIndex },
+        ],
+        2,   // frameRate: lento, adequado para turn-based
+        -1,  // repeat: infinito
+      );
+
+      registered++;
+    }
+
+    if (import.meta.env.DEV) {
+      console.log(`[BootScene] Animações de inimigos registradas: ${registered}`);
+    }
   }
 
   private _registerSpellAnims(): void {

--- a/src/scenes/CharacterSelectScene.ts
+++ b/src/scenes/CharacterSelectScene.ts
@@ -1,0 +1,186 @@
+import * as Phaser from 'phaser';
+import { PLAYER_CLASSES, type PlayerClassDef } from '../config/player-classes.config';
+
+const PREVIEW_SCALE = 6;
+
+export class CharacterSelectScene extends Phaser.Scene {
+  private _selectedIdx = 0;
+  private _previewSprite!: Phaser.GameObjects.Sprite;
+  private _descText!: Phaser.GameObjects.Text;
+  private _buttons: Array<{ btn: Phaser.GameObjects.Text; def: PlayerClassDef }> = [];
+  private _animTimer?: Phaser.Time.TimerEvent;
+  private _animFrame = 0;
+  private _animCurrentFrame = PLAYER_CLASSES[0].frame;
+
+  private get _selected(): PlayerClassDef { return PLAYER_CLASSES[this._selectedIdx]; }
+
+  constructor() {
+    super({ key: 'CharacterSelectScene' });
+  }
+
+  create(): void {
+    const { width, height } = this.scale;
+
+    // Fundo
+    this.add.rectangle(0, 0, width, height, 0x0d0d1e).setOrigin(0);
+
+    // Título
+    this.add.text(width / 2, height * 0.08, 'Dungeon of Echoes', {
+      fontSize: '32px',
+      color: '#ffd700',
+      fontFamily: 'monospace',
+      stroke: '#000',
+      strokeThickness: 4,
+    }).setOrigin(0.5);
+
+    this.add.text(width / 2, height * 0.18, 'Bem-vindo, herói!\nEscolha sua classe para começar a jornada.', {
+      fontSize: '16px',
+      color: '#cccccc',
+      fontFamily: 'monospace',
+      align: 'center',
+    }).setOrigin(0.5);
+
+    // Preview sprite (lado direito)
+    const previewX = width * 0.72;
+    const previewY = height * 0.45;
+
+    this.add.text(previewX, height * 0.28, 'Preview', {
+      fontSize: '13px',
+      color: '#888888',
+      fontFamily: 'monospace',
+    }).setOrigin(0.5);
+
+    this._previewSprite = this.add.sprite(previewX, previewY, 'player', this._selected.frame)
+      .setScale(PREVIEW_SCALE);
+
+    this._descText = this.add.text(previewX, previewY + 72, '', {
+      fontSize: '13px',
+      color: '#aaaaaa',
+      fontFamily: 'monospace',
+      align: 'center',
+      wordWrap: { width: 200 },
+    }).setOrigin(0.5);
+
+    // Botões de classe
+    const btnStartY = height * 0.32;
+    const btnGapY   = 60;
+    const btnX      = width * 0.28;
+
+    PLAYER_CLASSES.forEach((def, i) => {
+      const btn = this.add.text(btnX, btnStartY + i * btnGapY, def.label, {
+        fontSize: '20px',
+        color: '#ffffff',
+        fontFamily: 'monospace',
+        backgroundColor: '#2a2a4a',
+        padding: { x: 18, y: 10 },
+        stroke: '#000',
+        strokeThickness: 2,
+      }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+
+      btn.on('pointerover', () => this._hover(def, btn));
+      btn.on('pointerout',  () => this._unhover(btn));
+      btn.on('pointerdown', () => { this._selectedIdx = i; this._applySelection(); });
+
+      this._buttons.push({ btn, def });
+    });
+
+    // Separador
+    this.add.line(width / 2, height * 0.77, 0, 0, width * 0.8, 0, 0x444466).setOrigin(0.5);
+
+    // Botões de ação
+    this._makeActionBtn(width * 0.34, height * 0.88, 'Voltar', () => {
+      this._stopAnim();
+      this.scene.start('MainMenuScene');
+    });
+
+    this._makeActionBtn(width * 0.66, height * 0.88, 'Confirmar', () => this._confirm());
+
+    // Seleciona classe inicial
+    this._applySelection();
+
+    // Teclado
+    this.input.keyboard!.on('keydown-UP',     () => this._moveSelection(-1));
+    this.input.keyboard!.on('keydown-DOWN',   () => this._moveSelection(+1));
+    this.input.keyboard!.on('keydown-ENTER',  () => this._confirm());
+    this.input.keyboard!.on('keydown-SPACE',  () => this._confirm());
+    this.input.keyboard!.on('keydown-ESC',    () => { this._stopAnim(); this.scene.start('MainMenuScene'); });
+  }
+
+  private _hover(def: PlayerClassDef, btn: Phaser.GameObjects.Text): void {
+    const idx = PLAYER_CLASSES.indexOf(def);
+    if (idx !== this._selectedIdx) {
+      btn.setStyle({ color: '#ffd700' });
+    }
+    this._startAnim(def.frame);
+    this._descText.setText(def.description);
+  }
+
+  private _unhover(btn: Phaser.GameObjects.Text): void {
+    const entry = this._buttons.find(b => b.btn === btn);
+    if (entry && entry.def.id !== this._selected.id) {
+      btn.setStyle({ color: '#ffffff' });
+    }
+    this._startAnim(this._selected.frame);
+    this._descText.setText(this._selected.description);
+  }
+
+  private _moveSelection(delta: number): void {
+    this._selectedIdx = (this._selectedIdx + delta + PLAYER_CLASSES.length) % PLAYER_CLASSES.length;
+    this._applySelection();
+  }
+
+  private _applySelection(): void {
+    for (const { btn } of this._buttons) {
+      btn.setStyle({ color: '#ffffff', backgroundColor: '#2a2a4a' });
+    }
+    this._buttons[this._selectedIdx].btn.setStyle({ color: '#ffd700', backgroundColor: '#3a3a6a' });
+    this._descText.setText(this._selected.description);
+    this._startAnim(this._selected.frame);
+  }
+
+  private _confirm(): void {
+    this._stopAnim();
+    this.scene.start('GameScene', { playerClass: this._selected.id });
+  }
+
+  private _startAnim(frame: number): void {
+    if (frame === this._animCurrentFrame && this._animTimer) return;
+    this._stopAnim();
+    this._animCurrentFrame = frame;
+    this._animFrame = 0;
+    this._previewSprite.setTexture('player', frame);
+
+    this._animTimer = this.time.addEvent({
+      delay: 500,
+      loop: true,
+      callback: () => {
+        this._animFrame = 1 - this._animFrame;
+        const tex = this._animFrame === 0 ? 'player' : 'player1';
+        this._previewSprite.setTexture(tex, frame);
+      },
+    });
+  }
+
+  private _stopAnim(): void {
+    if (this._animTimer) {
+      this._animTimer.destroy();
+      this._animTimer = undefined;
+    }
+  }
+
+  private _makeActionBtn(x: number, y: number, label: string, onClick: () => void): void {
+    const btn = this.add.text(x, y, label, {
+      fontSize: '20px',
+      color: '#ffffff',
+      fontFamily: 'monospace',
+      backgroundColor: '#333355',
+      padding: { x: 20, y: 10 },
+      stroke: '#000',
+      strokeThickness: 2,
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+
+    btn.on('pointerover', () => btn.setStyle({ color: '#ffd700' }));
+    btn.on('pointerout',  () => btn.setStyle({ color: '#ffffff' }));
+    btn.on('pointerdown', onClick);
+  }
+}

--- a/src/scenes/CreditsScene.ts
+++ b/src/scenes/CreditsScene.ts
@@ -1,0 +1,62 @@
+import * as Phaser from 'phaser';
+
+const CREDITS: Array<{ role: string; names: string[] }> = [
+  { role: 'Bardo',     names: ['Vitor'] },
+  { role: 'Magos',    names: ['Gianmarco', 'Paolo'] },
+  { role: 'Paladinos', names: ['Andrea', 'Rafael'] },
+];
+
+export class CreditsScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'CreditsScene' });
+  }
+
+  create(): void {
+    const { width, height } = this.scale;
+
+    const bg = this.add.image(width / 2, height / 2, 'game_bg');
+    bg.setDisplaySize(width, height).setAlpha(0.5);
+
+    this.add.rectangle(width / 2, height / 2, width, height, 0x000000, 0.55);
+
+    this.add.text(width / 2, 60, 'Créditos', {
+      fontSize: '32px',
+      color: '#ffd700',
+      fontFamily: 'monospace',
+      stroke: '#000000',
+      strokeThickness: 3,
+    }).setOrigin(0.5);
+
+    let y = 160;
+    for (const entry of CREDITS) {
+      this.add.text(width / 2, y, entry.role, {
+        fontSize: '16px',
+        color: '#aaaaff',
+        fontFamily: 'monospace',
+      }).setOrigin(0.5);
+      y += 28;
+
+      for (const name of entry.names) {
+        this.add.text(width / 2, y, name, {
+          fontSize: '20px',
+          color: '#ffffff',
+          fontFamily: 'monospace',
+        }).setOrigin(0.5);
+        y += 30;
+      }
+      y += 10;
+    }
+
+    const btn = this.add.text(width / 2, height - 60, '← Voltar', {
+      fontSize: '20px',
+      color: '#ffffff',
+      fontFamily: 'monospace',
+      backgroundColor: '#333355',
+      padding: { x: 16, y: 8 },
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+
+    btn.on('pointerover', () => btn.setStyle({ color: '#ffd700' }));
+    btn.on('pointerout', () => btn.setStyle({ color: '#ffffff' }));
+    btn.on('pointerdown', () => this.scene.start('MainMenuScene'));
+  }
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -201,6 +201,19 @@ export class GameScene extends Phaser.Scene {
     this._emitInitialUIState();
     this._applyClassStartingItems();
 
+    // Aplicar sprite e animação da classe (após UIScene estar ativa)
+    this.time.delayedCall(50, () => {
+      const cd = this.player.classDef;
+      if (cd) {
+        this.player.applySkin(cd.frame);
+        EventBus.emit(EVENTS.CLASS_INFO, {
+          label:      cd.label,
+          usesArrows: cd.usesArrows,
+          arrows:     this.player.arrows,
+        });
+      }
+    });
+
     this._loadArea('town');
   }
 

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -102,6 +102,7 @@ export class GameScene extends Phaser.Scene {
   // ─── GameObjects rastreados por área (destruídos no cleanup) ─────────────
   private _tileObjects: Phaser.GameObjects.Image[] = [];
   private _decorObjects: Phaser.GameObjects.GameObject[] = [];
+  private _chestSprites = new Map<string, Phaser.GameObjects.Sprite>();
 
   // ─── Sistemas de cidade (recriados em cada _loadTown) ────────────────────
   private _npcController: NPCController | null = null;
@@ -189,7 +190,10 @@ export class GameScene extends Phaser.Scene {
     const initData = this.scene.settings.data as { playerClass?: string } | undefined;
     if (initData?.playerClass) {
       const classDef = PLAYER_CLASSES.find(c => c.id === initData.playerClass) ?? null;
-      if (classDef) this.player.classDef = classDef;
+      if (classDef) {
+        this.player.classDef = classDef;
+        this.player.applyClassBonus(classDef);
+      }
     }
 
     // Desbloquear magias do nível 1 para novo jogo
@@ -305,6 +309,9 @@ export class GameScene extends Phaser.Scene {
 
     this._decorObjects.forEach(o => o.destroy());
     this._decorObjects = [];
+
+    this._chestSprites.forEach(s => s.destroy());
+    this._chestSprites.clear();
 
     this._npcController?.destroy();
     this._npcController = null;
@@ -463,7 +470,7 @@ export class GameScene extends Phaser.Scene {
       item.sprite?.destroy();
       const px = item.gridX * TILE_SIZE + TILE_SIZE / 2;
       const py = item.gridY * TILE_SIZE + TILE_SIZE / 2;
-      const { texture, frame } = this._getItemVisual(item.type);
+      const { texture, frame } = this._getItemVisual(item.type, item.goldAmount);
       item.sprite = this.add.sprite(px, py, texture, frame).setDepth(3);
     }
 
@@ -540,7 +547,7 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
-  private _getItemVisual(type: ItemType): { texture: string; frame: number } {
+  private _getItemVisual(type: ItemType, goldAmount?: number): { texture: string; frame: number } {
     switch (type) {
       case 'potion_heal_light':
       case 'potion_heal':
@@ -548,7 +555,14 @@ export class GameScene extends Phaser.Scene {
       case 'potion_mana_light':
       case 'potion_mana':
       case 'potion_mana_high':  return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_MANA };
-      case 'gold':              return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
+      case 'gold': {
+        const amt = goldAmount ?? 0;
+        const frame = amt >= 50 ? DAWNLIKE_FRAMES.GOLD_LARGE
+          : amt >= 20 ? DAWNLIKE_FRAMES.GOLD_MEDIUM
+          : DAWNLIKE_FRAMES.GOLD_SMALL;
+        return { texture: SPRITES.MONEY, frame };
+      }
+      default:                  return { texture: SPRITES.POTION, frame: 0 };
     }
   }
 
@@ -556,9 +570,12 @@ export class GameScene extends Phaser.Scene {
     if (item.gridX === null || item.gridY === null) return;
     const px = item.gridX * TILE_SIZE + TILE_SIZE / 2;
     const py = item.gridY * TILE_SIZE + TILE_SIZE / 2;
-    const { texture, frame } = this._getItemVisual(item.type);
+    const { texture, frame } = this._getItemVisual(item.type, item.goldAmount);
+    item.sprite?.destroy();
     item.sprite = this.add.sprite(px, py, texture, frame).setDepth(3);
-    this._items.push(item);
+    if (!this._items.includes(item)) {
+      this._items.push(item);
+    }
   }
 
   private _renderDungeonFeatures(floor: number): void {
@@ -580,6 +597,9 @@ export class GameScene extends Phaser.Scene {
             fontSize: '5px', color: '#44aaff', fontFamily: 'monospace',
           }).setOrigin(0.5, 1).setDepth(3),
         );
+      } else if (feature.type === 'chest' && !feature.metadata?.['opened']) {
+        const sprite = this.add.sprite(px, py, SPRITES.MONEY, DAWNLIKE_FRAMES.CHEST).setDepth(3);
+        this._chestSprites.set(`${feature.gridX},${feature.gridY}`, sprite);
       }
     }
   }
@@ -755,6 +775,57 @@ export class GameScene extends Phaser.Scene {
     if (cached) cached.items = this._items;
   }
 
+  private _checkChestInteraction(): void {
+    if (this._currentArea !== 'dungeon') return;
+    const px = this.player.gridX;
+    const py = this.player.gridY;
+    const floor = this.floorManager.currentFloor;
+
+    const chest = this._dungeonFeatures.find(
+      f => f.type === 'chest' && f.gridX === px && f.gridY === py && !f.metadata?.['opened'],
+    );
+    if (!chest) return;
+
+    // Marcar baú como aberto e remover sprite
+    chest.metadata!['opened'] = true;
+    const key = `${px},${py}`;
+    this._chestSprites.get(key)?.destroy();
+    this._chestSprites.delete(key);
+
+    const result = this.lootSystem.rollChestLoot(floor);
+
+    if (result.type === 'mimic') {
+      const dmg = result.mimicDamage ?? 20;
+      this.player.hp = Math.max(0, this.player.hp - dmg);
+      EventBus.emit(EVENTS.UI_LOG, `Era uma mímica! Você tomou ${dmg} de dano!`);
+      EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
+      this._recordGameEvent('TRAP_TRIGGERED', { damage: dmg });
+      return;
+    }
+
+    const item = result.item;
+    if (!item) return;
+
+    if (result.type === 'equipment') {
+      if (this.player.inventory.isFull()) {
+        EventBus.emit(EVENTS.UI_LOG, 'Inventário cheio! Você não conseguiu pegar o item do baú.');
+        return;
+      }
+      this.player.inventory.addItem(item);
+      const slotIndex = this.player.inventory.items.findIndex(i => i === item);
+      EventBus.emit(EVENTS.UI_LOG, `Você encontrou no baú: ${item.name}!`);
+      EventBus.emit(EVENTS.ITEM_PICKED_UP, { item, slotIndex });
+      this._recordGameEvent('ITEM_FOUND', { itemName: item.name });
+      return;
+    }
+
+    // Ouro ou poção: colocar no tile do player e coletar imediatamente
+    item.gridX = px;
+    item.gridY = py;
+    this._spawnDroppedItem(item);
+    this._checkItemPickup();
+  }
+
   // ─── Input ───────────────────────────────────────────────────────────────
 
   private _setupInput(): void {
@@ -908,6 +979,7 @@ export class GameScene extends Phaser.Scene {
 
     if (result.playerMoved) {
       this._checkItemPickup();
+      this._checkChestInteraction();
       this._checkAreaTransition();
     }
 

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -865,7 +865,7 @@ export class GameScene extends Phaser.Scene {
     result.enemiesDied.forEach(e => {
       EventBus.emit(EVENTS.UI_LOG, `+${e.xpReward} XP`);
       this._removeEnemySprite(e);
-      const dropped = this.lootSystem.roll(e.gridX, e.gridY, this.floorManager.currentFloor);
+      const dropped = this.lootSystem.roll(e.gridX, e.gridY, this.floorManager.currentFloor, e.isElite);
       if (dropped && e.gridX === this.player.gridX && e.gridY === this.player.gridY) {
         anyDroppedOnPlayerTile = true;
       }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -32,6 +32,7 @@ import type { GameEventType } from '../systems/EventMemory';
 import { EquipmentSystem } from '../systems/EquipmentSystem';
 import { ShopSystem } from '../systems/ShopSystem';
 import { SHOP_CATALOG } from '../config/shop.catalog';
+import { CATEGORY_TEXTURE_KEYS } from '../config/enemies.config';
 import { SpellSystem } from '../systems/SpellSystem';
 import { SpellCastingSystem } from '../systems/SpellCastingSystem';
 import { SPELLS_DB } from '../config/spells.db';
@@ -629,12 +630,36 @@ export class GameScene extends Phaser.Scene {
   // ─── Sprites de Inimigos ─────────────────────────────────────────────────
 
   private _createEnemySprites(): void {
-    this._enemies.forEach((enemy) => {
-      const pos = enemy.getPixelPos();
-      enemy.sprite  = this.add.sprite(pos.x, pos.y, SPRITES.ENEMY, DAWNLIKE_FRAMES.ENEMY).setDepth(5);
-      enemy.hpBarBg = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0x330000).setDepth(6);
-      enemy.hpBar   = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0xff2222).setDepth(6);
-    });
+    this._enemies.forEach((enemy) => this._buildEnemySprite(enemy));
+  }
+
+  /**
+   * Cria o sprite e as barras de HP de um único inimigo.
+   * Isolado em método próprio para facilitar futura object pooling.
+   *
+   * Lógica de textura:
+   *   1. Usa CATEGORY_TEXTURE_KEYS para obter a chave padronizada do par DawnLike.
+   *   2. Verifica se a textura está carregada no TextureManager antes de usá-la.
+   *   3. Fallback em cascata: chave canônica → SPRITES.ENEMY (undead), evitando tela magenta.
+   * Animação:
+   *   Toca a animKey pré-calculada em createEnemies() se ela estiver registrada.
+   *   O AnimationManager é global — sem criação duplicada em runtime.
+   */
+  private _buildEnemySprite(enemy: EnemySystem): void {
+    const pos = enemy.getPixelPos();
+
+    // Chave da textura base (*0): ex. 'pest0', 'undead' (alias legado), 'humanoid0'
+    const [tex0] = CATEGORY_TEXTURE_KEYS[enemy.category];
+    const texKey = this.textures.exists(tex0) ? tex0 : SPRITES.ENEMY;
+
+    enemy.sprite  = this.add.sprite(pos.x, pos.y, texKey, enemy.frameIndex).setDepth(5);
+    enemy.hpBarBg = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0x330000).setDepth(6);
+    enemy.hpBar   = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0xff2222).setDepth(6);
+
+    // Toca animação ping-pong se registrada pela BootScene
+    if (enemy.animKey && this.anims.exists(enemy.animKey)) {
+      enemy.sprite.play(enemy.animKey);
+    }
   }
 
   // ─── Easter Egg: Platino (DragonDePlatino, CC-BY 4.0) ───────────────────
@@ -870,7 +895,7 @@ export class GameScene extends Phaser.Scene {
         anyDroppedOnPlayerTile = true;
       }
       // Registrar morte de inimigo na memória narrativa
-      this._recordGameEvent('ENEMY_KILLED', { enemyName: e.aiName ?? 'Inimigo' });
+      this._recordGameEvent('ENEMY_KILLED', { enemyName: e.aiName ?? e.enemyName });
     });
     // Coletar drops que caíram no mesmo tile que o player (o pickup anterior rodou antes dos drops)
     if (anyDroppedOnPlayerTile) this._checkItemPickup();

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -12,6 +12,8 @@ import { TownMap } from '../systems/WorldSystem';
 import { NPCController } from '../systems/NPCController';
 import { InteractiveObjectSystem } from '../systems/InteractiveObjectSystem';
 import { TownTMXRenderer } from '../systems/TownTMXRenderer';
+import { themeForFloor } from '../config/dungeon-themes';
+import { DungeonRenderer } from '../systems/DungeonRenderer';
 import { BonusAreaRenderer } from '../systems/BonusAreaRenderer';
 import { LAYER_GROUND } from '../config/sprites-config';
 import { InputModeManager } from '../systems/InputModeManager';
@@ -21,11 +23,19 @@ import { DifficultyScalingSystem } from '../systems/DifficultyScalingSystem';
 import { PlayerMetrics } from '../systems/PlayerMetrics';
 import { DifficultyManager } from '../systems/DifficultyManager';
 import { DungeonFeatureGenerator, type DungeonFeature } from '../generators/DungeonFeatureGenerator';
+import { AIService } from '../ai/AIService';
+import { AIIntegration } from '../ai/AIIntegration';
+import { NarrativeService } from '../ai/NarrativeService';
+import { AI_CONFIG } from '../ai/config';
+import { EventMemory } from '../systems/EventMemory';
+import type { GameEventType } from '../systems/EventMemory';
 import { EquipmentSystem } from '../systems/EquipmentSystem';
 import { ShopSystem } from '../systems/ShopSystem';
 import { SHOP_CATALOG, STARTING_ITEMS } from '../config/shop.catalog';
-import { ClassRulesEngine } from '../systems/ClassRulesEngine';
-import { PLAYER_CLASSES } from '../config/player-classes.config';
+import { CATEGORY_TEXTURE_KEYS } from '../config/enemies.config';
+import { SpellSystem } from '../systems/SpellSystem';
+import { SpellCastingSystem } from '../systems/SpellCastingSystem';
+import { SPELLS_DB } from '../config/spells.db';
 import type { TransitionResolution } from '../types/transitions';
 import type { GridPos } from '../generators/DungeonGenerator';
 import {
@@ -45,8 +55,8 @@ import { MANUAL_MAP_OVERRIDES } from '../config/TileProperties';
 import { TMX_PAD_X, TMX_PAD_Y, TMX_TILESETS } from '../config/TownTMXData';
 import { BONUS_W, BONUS_H, BONUS_PLAYER_START_X, BONUS_PLAYER_START_Y } from '../config/BonusAreaData';
 import type { DialogMenuOption } from '../types/town';
-import type { EquipmentSlotId, StatBonuses } from '../types/equipment';
-import type { ItemRarity } from '../types/equipment';
+import type { EquipmentSlotId, StatBonuses, ItemRarity } from '../types/equipment';
+import { PLAYER_CLASSES } from '../config/player-classes.config';
 
 export class GameScene extends Phaser.Scene {
   // ─── Sistemas persistentes (vivem durante toda a sessão) ─────────────────
@@ -65,7 +75,13 @@ export class GameScene extends Phaser.Scene {
   private _dungeonFeatures: DungeonFeature[] = [];
   private equipmentSystem!: EquipmentSystem;
   private _shopSystem!: ShopSystem;
+  private _spellSystem!: SpellSystem;
+  private _spellCastingSystem!: SpellCastingSystem;
   private gameState!: string;
+
+  // ─── Narrativa emergente (Fase 6) ─────────────────────────────────────────
+  private _eventMemory!: EventMemory;
+  private _narrativeService!: NarrativeService;
 
   // Cache de andares visitados (runtime — não serializado ainda)
   private _dungeonCache = new Map<number, {
@@ -105,12 +121,18 @@ export class GameScene extends Phaser.Scene {
   private vKey!: Phaser.Input.Keyboard.Key;
   private enterKey!: Phaser.Input.Keyboard.Key;
   private numKeys!: Phaser.Input.Keyboard.Key[];
+  private jKey!: Phaser.Input.Keyboard.Key;
+  private kKey!: Phaser.Input.Keyboard.Key;
+  private lKey!: Phaser.Input.Keyboard.Key;
 
   // ─── Keyboard focus reset handler ────────────────────────────────────────
   private _onWindowFocusReset!: () => void;
 
   // ─── Estado de seleção de inventário / loja ───────────────────────────────
   private _inventorySelectedIndex = 0;
+  private _inventoryTab: 'inventory' | 'status' | 'spells' = 'status';
+  private _spellsSelectedIndex = 0;
+  private _spellsFocus: 'tabs' | 'list' = 'tabs';
   private _shopSelectedIndex = 0;
   private _shopTab: 'buy' | 'sell' = 'buy';
   private _shopBuyTotal = 0;
@@ -149,33 +171,35 @@ export class GameScene extends Phaser.Scene {
     this.difficultyManager  = new DifficultyManager();
     this.featureGenerator   = new DungeonFeatureGenerator();
     this.floorManager.reset();
-    this.equipmentSystem = new EquipmentSystem();
-    this._shopSystem     = new ShopSystem(SHOP_CATALOG);
+    this.equipmentSystem      = new EquipmentSystem();
+    this._shopSystem          = new ShopSystem(SHOP_CATALOG);
+    this._spellSystem         = new SpellSystem();
+    this._spellCastingSystem  = new SpellCastingSystem();
     this._registerTransitions();
+
+    // ─── Narrativa emergente (Fase 6) ──────────────────────────────────────
+    this._eventMemory     = new EventMemory();
+    const aiService       = new AIService(AI_CONFIG.API_KEY);
+    this._narrativeService = new NarrativeService(aiService);
 
     // Player criado uma vez — moves between areas
     this.player = new Player(this, TOWN.START_X, TOWN.START_Y);
 
-    // Aplicar classe do personagem (passada pela CharacterSelectScene)
+    // Aplicar classe selecionada na CharacterSelectScene
     const initData = this.scene.settings.data as { playerClass?: string } | undefined;
     if (initData?.playerClass) {
       const classDef = PLAYER_CLASSES.find(c => c.id === initData.playerClass) ?? null;
-      if (classDef) {
-        this.player.classDef = classDef;
-        this._setupInput();
-        this._registerEvents();
-        this.scene.launch('UIScene');
-        this._emitInitialUIState();
-        this._applyClassStartingItems();
-        this._loadArea('town');
-        return;
-      }
+      if (classDef) this.player.classDef = classDef;
     }
+
+    // Desbloquear magias do nível 1 para novo jogo
+    this._spellSystem.unlockSpellsForLevel(this.player, 1);
 
     this._setupInput();
     this._registerEvents();
     this.scene.launch('UIScene');
     this._emitInitialUIState();
+    this._applyClassStartingItems();
 
     this._loadArea('town');
   }
@@ -183,8 +207,12 @@ export class GameScene extends Phaser.Scene {
   shutdown(): void {
     EventBus.off(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
     EventBus.off(EVENTS.INVENTORY_STATE_REQUESTED, undefined, this);
-    EventBus.off(EVENTS.SHOP_OPENED, undefined, this);
-    EventBus.off(EVENTS.DIALOG_OPENED, undefined, this);
+    EventBus.off(EVENTS.STATUS_STATE_REQUESTED,    undefined, this);
+    EventBus.off(EVENTS.SPELLS_STATE_REQUESTED,    undefined, this);
+    EventBus.off(EVENTS.STAT_POINT_SPENT_REQUEST,  undefined, this);
+    EventBus.off(EVENTS.SPELL_EQUIP_REQUEST,       undefined, this);
+    EventBus.off(EVENTS.SHOP_OPENED,               undefined, this);
+    EventBus.off(EVENTS.DIALOG_OPENED,             undefined, this);
     this.game.events.off(Phaser.Core.Events.BLUR,  this._onWindowFocusReset, this);
     this.game.events.off(Phaser.Core.Events.FOCUS, this._onWindowFocusReset, this);
   }
@@ -192,6 +220,8 @@ export class GameScene extends Phaser.Scene {
   update(_time: number, delta: number): void {
     if (this.gameState !== GAME_STATE.PLAYING) return;
     this._handleInput(_time);
+
+
 
     // Atualizar NPCs com wandering (cidade e área bônus)
     if ((this._currentArea === 'town' || this._currentArea === 'bonus') && this._npcController) {
@@ -390,8 +420,7 @@ export class GameScene extends Phaser.Scene {
     } else {
       this._dungeon = new DungeonGenerator();
       this._dungeon.generate();
-      const variants   = DAWNLIKE_FRAMES.FLOOR_VARIANTS;
-      this._floorFrame = variants[Math.floor(Math.random() * variants.length)];
+      this._floorFrame = 0; // mantido para compatibilidade com DungeonState (cache)
       this._items      = [];
       this._generateInitialItems();
       // Gerar features e salvar conexões apenas uma vez (Math.random implica não-determinismo)
@@ -403,23 +432,22 @@ export class GameScene extends Phaser.Scene {
     this._currentMap  = this._dungeon;
     this._currentArea = 'dungeon';
 
-    // Renderizar tiles
+    // Renderizar tiles via DungeonRenderer (shell-not-volume: VOID = preto, WALL_EDGE = bitmask)
+    this.cameras.main.setBackgroundColor(0x000000);
+    const theme = themeForFloor(floor);
     const { width: W, height: H, grid } = this._dungeon;
-    for (let y = 0; y < H; y++) {
-      for (let x = 0; x < W; x++) {
-        const isFloor = grid[y][x] === TILE.FLOOR;
-        const px = x * TILE_SIZE + TILE_SIZE / 2;
-        const py = y * TILE_SIZE + TILE_SIZE / 2;
-        this._tileObjects.push(
-          this.add.image(px, py, isFloor ? SPRITES.FLOOR : SPRITES.WALL,
-            isFloor ? this._floorFrame : DAWNLIKE_FRAMES.WALL).setDepth(0),
-        );
-      }
+    const renderer = new DungeonRenderer();
+    const commands = renderer.buildCommands(grid, theme, floor);
+    for (const cmd of commands) {
+      this._tileObjects.push(
+        this.add.image(cmd.x, cmd.y, cmd.texture, cmd.frame).setDepth(cmd.depth),
+      );
     }
 
     // Recriar sprites dos itens no chão
     for (const item of this._items) {
       if (item.gridX === null || item.gridY === null) continue;
+      item.sprite?.destroy();
       const px = item.gridX * TILE_SIZE + TILE_SIZE / 2;
       const py = item.gridY * TILE_SIZE + TILE_SIZE / 2;
       const { texture, frame } = this._getItemVisual(item.type);
@@ -429,7 +457,7 @@ export class GameScene extends Phaser.Scene {
     this._renderDungeonFeatures(floor);
 
     // Gerar inimigos com scaling adaptativo (andar + performance do jogador)
-    const difficulty = this.difficultyManager.getAdaptiveDifficulty(floor);
+    const difficulty = { ...this.difficultyManager.getAdaptiveDifficulty(floor), floor };
     this._enemies = createEnemies(this._dungeon, this._dungeon.startPos, difficulty);
     this._createEnemySprites();
 
@@ -444,8 +472,9 @@ export class GameScene extends Phaser.Scene {
       features:   this._dungeonFeatures,
     });
 
-    // Posicionar player
-    const finalSpawn = spawnPos ?? this._dungeon.startPos;
+    // Posicionar player: se não há spawnPos explícita, nascer ao lado do stairUp (entrada/saída)
+    const stairUpPos = this._dungeonFeatures.find(f => f.type === 'stairUp');
+    const finalSpawn = spawnPos ?? (stairUpPos ? { x: stairUpPos.gridX, y: stairUpPos.gridY + 1 } : this._dungeon.startPos);
     this.player.gridX = finalSpawn.x;
     this.player.gridY = finalSpawn.y;
     this.player.setPosition(finalSpawn.x * TILE_SIZE + TILE_SIZE / 2, finalSpawn.y * TILE_SIZE + TILE_SIZE / 2);
@@ -456,10 +485,29 @@ export class GameScene extends Phaser.Scene {
 
     EventBus.emit(EVENTS.AREA_CHANGED, { area: 'dungeon', floor, timestamp: Date.now() });
     EventBus.emit(EVENTS.UI_LOG, cached ? `Você está no andar ${floor}.` : `Você desce para o andar ${floor}. Cuidado!`);
+
+    // Registrar mudança de andar na memória narrativa
+    if (!cached) {
+      this._recordGameEvent('FLOOR_CHANGED', { floor });
+
+      // Gerar narrativa ao descer de andar (não-bloqueante)
+      const recentEvents = this._eventMemory.getImportantEvents(8);
+      this._narrativeService.generateNarrative(recentEvents)
+        .then((narrative) => {
+          EventBus.emit(EVENTS.UI_LOG, narrative);
+          EventBus.emit(EVENTS.NARRATIVE_GENERATED, { narrative, floor });
+        });
+    }
   }
 
   private _generateInitialItems(): void {
-    const types: Array<'potion_heal' | 'potion_poison'> = ['potion_heal', 'potion_poison'];
+    const floor = this.floorManager.currentFloor;
+    const types: Array<'potion_heal_light' | 'potion_heal' | 'potion_heal_high' | 'potion_mana_light' | 'potion_mana' | 'potion_mana_high'> =
+      floor <= 2
+        ? ['potion_heal_light', 'potion_heal', 'potion_mana_light', 'potion_mana']
+        : floor <= 4
+          ? ['potion_heal', 'potion_heal_high', 'potion_mana', 'potion_mana_high']
+          : ['potion_heal', 'potion_heal_high', 'potion_heal_high', 'potion_mana', 'potion_mana_high'];
     const count = INVENTORY.ITEM_SPAWN_MIN +
       Math.floor(Math.random() * (INVENTORY.ITEM_SPAWN_MAX - INVENTORY.ITEM_SPAWN_MIN + 1));
     const occupied = new Set<string>();
@@ -481,9 +529,13 @@ export class GameScene extends Phaser.Scene {
 
   private _getItemVisual(type: ItemType): { texture: string; frame: number } {
     switch (type) {
-      case 'potion_heal':   return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_HEAL };
-      case 'potion_poison': return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_POISON };
-      case 'gold':          return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
+      case 'potion_heal_light':
+      case 'potion_heal':
+      case 'potion_heal_high':  return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_HEAL };
+      case 'potion_mana_light':
+      case 'potion_mana':
+      case 'potion_mana_high':  return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_MANA };
+      case 'gold':              return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
     }
   }
 
@@ -588,75 +640,40 @@ export class GameScene extends Phaser.Scene {
   // ─── Sprites de Inimigos ─────────────────────────────────────────────────
 
   private _createEnemySprites(): void {
-    this._enemies.forEach((enemy) => {
-      const pos = enemy.getPixelPos();
-      enemy.sprite  = this.add.sprite(pos.x, pos.y, SPRITES.ENEMY, DAWNLIKE_FRAMES.ENEMY).setDepth(5);
-      enemy.hpBarBg = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0x330000).setDepth(6);
-      enemy.hpBar   = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0xff2222).setDepth(6);
-      // Permite clique para ataque à distância (Arqueiro)
-      enemy.sprite.setInteractive();
-      enemy.sprite.on('pointerdown', () => this._tryRangedAttack(enemy));
-    });
+    this._enemies.forEach((enemy) => this._buildEnemySprite(enemy));
   }
 
   /**
-   * Verifica linha de visão entre dois pontos do grid (algoritmo de Bresenham).
-   * @returns true se não há parede bloqueando a linha.
+   * Cria o sprite e as barras de HP de um único inimigo.
+   * Isolado em método próprio para facilitar futura object pooling.
+   *
+   * Lógica de textura:
+   *   1. Usa CATEGORY_TEXTURE_KEYS para obter a chave padronizada do par DawnLike.
+   *   2. Verifica se a textura está carregada no TextureManager antes de usá-la.
+   *   3. Fallback em cascata: chave canônica → SPRITES.ENEMY (undead), evitando tela magenta.
+   * Animação:
+   *   Toca a animKey pré-calculada em createEnemies() se ela estiver registrada.
+   *   O AnimationManager é global — sem criação duplicada em runtime.
    */
-  private _hasLineOfSight(x0: number, y0: number, x1: number, y1: number): boolean {
-    let dx = Math.abs(x1 - x0);
-    let dy = Math.abs(y1 - y0);
-    const sx = x0 < x1 ? 1 : -1;
-    const sy = y0 < y1 ? 1 : -1;
-    let err = dx - dy;
-    let x = x0;
-    let y = y0;
-    while (x !== x1 || y !== y1) {
-      const e2 = 2 * err;
-      if (e2 > -dy) { err -= dy; x += sx; }
-      if (e2 <  dx) { err += dx; y += sy; }
-      if (x === x1 && y === y1) break;
-      if (!this._currentMap.isWalkable(x, y)) return false;
-    }
-    return true;
-  }
+  private _buildEnemySprite(enemy: EnemySystem): void {
+    const pos = enemy.getPixelPos();
 
-  /**
-   * Tenta executar um ataque à distância do Arqueiro no inimigo clicado.
-   */
-  private _tryRangedAttack(enemy: EnemySystem): void {
-    if (!this.inputMode.is('GAMEPLAY')) return;
-    if (!this.player.classDef?.usesArrows) return;
-    if (!enemy.alive) return;
+    // Chave da textura base (*0): ex. 'pest0', 'undead' (alias legado), 'humanoid0'
+    const [tex0] = CATEGORY_TEXTURE_KEYS[enemy.category];
+    const texKey = this.textures.exists(tex0) ? tex0 : SPRITES.ENEMY;
 
-    const dx   = Math.abs(enemy.gridX - this.player.gridX);
-    const dy   = Math.abs(enemy.gridY - this.player.gridY);
-    const dist = Math.max(dx, dy);
-    if (dist > 4) {
-      EventBus.emit(EVENTS.UI_LOG, 'Inimigo fora de alcance (máx. 4 tiles).');
-      return;
-    }
-    if (!this._hasLineOfSight(this.player.gridX, this.player.gridY, enemy.gridX, enemy.gridY)) {
-      EventBus.emit(EVENTS.UI_LOG, 'Sem linha de visão para o inimigo.');
-      return;
+    enemy.sprite  = this.add.sprite(pos.x, pos.y, texKey, enemy.frameIndex).setDepth(5);
+    enemy.hpBarBg = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0x330000).setDepth(6);
+    enemy.hpBar   = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0xff2222).setDepth(6);
+
+    // Toca animação ping-pong se registrada pela BootScene
+    if (enemy.animKey && this.anims.exists(enemy.animKey)) {
+      enemy.sprite.play(enemy.animKey);
     }
 
-    const result = this.turnManager.processPlayerAction(
-      { type: 'ATTACK', target: enemy },
-      this.player,
-      this._enemies,
-      this._currentMap,
-      this.combatSystem,
-      this.playerMetrics,
-    );
-
-    result.messages.forEach(msg => EventBus.emit(EVENTS.UI_LOG, msg));
-    this._enemies.forEach(e => this._syncEnemySprite(e));
-    result.enemiesDied.forEach(e => {
-      EventBus.emit(EVENTS.UI_LOG, `+${e.xpReward} XP`);
-      this._removeEnemySprite(e);
-      this.lootSystem.roll(e.gridX, e.gridY);
-    });
+    // Clique para ataque à distância (Arqueiro)
+    enemy.sprite.setInteractive();
+    enemy.sprite.on('pointerdown', () => this._tryRangedAttack(enemy));
   }
 
   // ─── Easter Egg: Platino (DragonDePlatino, CC-BY 4.0) ───────────────────
@@ -683,6 +700,21 @@ export class GameScene extends Phaser.Scene {
     for (const item of this._items) {
       if (item.gridX !== px || item.gridY !== py) continue;
 
+      // Ouro vai direto para o contador — não ocupa slot
+      if (item.type === 'gold') {
+        const amount = item.goldAmount ?? 1;
+        this.player.gold += amount;
+        item.gridX = null;
+        item.gridY = null;
+        if (item.sprite) {
+          item.sprite.destroy();
+          item.sprite = null;
+        }
+        EventBus.emit(EVENTS.UI_LOG, `Você pegou ${amount} moeda(s) de ouro`);
+        EventBus.emit(EVENTS.PLAYER_GOLD_CHANGED, { gold: this.player.gold });
+        continue;
+      }
+
       if (this.player.inventory.isFull()) {
         EventBus.emit(EVENTS.UI_LOG, 'Inventário cheio! Não foi possível coletar.');
         continue;
@@ -692,16 +724,22 @@ export class GameScene extends Phaser.Scene {
       this.player.inventory.addItem(item);
       const slotIndex = this.player.inventory.items.findIndex(i => i === item);
 
-      const s = item.sprite;
-      item.sprite = null;
-      s?.setVisible(false);
-      this.time.delayedCall(0, () => s?.destroy());
+      if (item.sprite) {
+        item.sprite.destroy();
+        item.sprite = null;
+      }
 
       EventBus.emit(EVENTS.UI_LOG, `Você pegou ${displayName}`);
       EventBus.emit(EVENTS.ITEM_PICKED_UP, { item, slotIndex });
+      // Registrar na memória narrativa
+      this._recordGameEvent('ITEM_FOUND', { itemName: displayName });
     }
 
     this._items = this._items.filter(i => i.gridX !== null);
+
+    // Keep dungeon cache in sync so floor re-entry shows correct items
+    const cached = this._dungeonCache.get(this.floorManager.currentFloor);
+    if (cached) cached.items = this._items;
   }
 
   // ─── Input ───────────────────────────────────────────────────────────────
@@ -722,6 +760,9 @@ export class GameScene extends Phaser.Scene {
     this.dKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.D);
     this.vKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.V);
     this.enterKey  = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+    this.jKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.J);
+    this.kKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.K);
+    this.lKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.L);
 
     this._onWindowFocusReset = () => { this.input.keyboard?.resetKeys(); };
     this.game.events.on(Phaser.Core.Events.BLUR,  this._onWindowFocusReset, this);
@@ -749,6 +790,8 @@ export class GameScene extends Phaser.Scene {
         EventBus.emit(EVENTS.DIALOG_CLOSED, {});
       } else if (this.inputMode.is('INVENTORY')) {
         this.inputMode.pop();
+        this._inventoryTab = 'status';
+        this._spellsFocus = 'tabs';
         EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
       } else if (this.inputMode.is('SHOP')) {
         this.inputMode.pop();
@@ -767,6 +810,8 @@ export class GameScene extends Phaser.Scene {
     if (JD(this.iKey)) {
       if (this.inputMode.is('INVENTORY')) {
         this.inputMode.pop();
+        this._inventoryTab = 'status';
+        this._spellsFocus = 'tabs';
         EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
       } else if (this.inputMode.is('GAMEPLAY')) {
         this.inputMode.push('INVENTORY');
@@ -792,6 +837,11 @@ export class GameScene extends Phaser.Scene {
     // 5. GAMEPLAY
     if (!this.inputMode.is('GAMEPLAY')) return;
     if (!this.turnManager.isPlayerTurn()) return;
+
+    // J/K: disparar magia ativa (real-time, não consome turno de movimento)
+    if (JD(this.jKey)) { this._castSpell(0); }
+    if (JD(this.kKey)) { this._castSpell(1); }
+    // lKey reservado para ultimate futuro
 
     // Teclas 1–9: usar item do slot
     for (let i = 0; i < this.numKeys.length; i++) {
@@ -850,11 +900,19 @@ export class GameScene extends Phaser.Scene {
 
     this._enemies.forEach(e => this._syncEnemySprite(e));
 
+    let anyDroppedOnPlayerTile = false;
     result.enemiesDied.forEach(e => {
       EventBus.emit(EVENTS.UI_LOG, `+${e.xpReward} XP`);
       this._removeEnemySprite(e);
-      this.lootSystem.roll(e.gridX, e.gridY);
+      const dropped = this.lootSystem.roll(e.gridX, e.gridY, this.floorManager.currentFloor, e.isElite);
+      if (dropped && e.gridX === this.player.gridX && e.gridY === this.player.gridY) {
+        anyDroppedOnPlayerTile = true;
+      }
+      // Registrar morte de inimigo na memória narrativa
+      this._recordGameEvent('ENEMY_KILLED', { enemyName: e.aiName ?? e.enemyName });
     });
+    // Coletar drops que caíram no mesmo tile que o player (o pickup anterior rodou antes dos drops)
+    if (anyDroppedOnPlayerTile) this._checkItemPickup();
 
     // Atualizar dificuldade adaptativa e emitir hint narrativo se mudou
     const levelChanged = this.difficultyManager.update(this.playerMetrics);
@@ -870,15 +928,82 @@ export class GameScene extends Phaser.Scene {
 
   private _handleInventoryInput(): void {
     const JD = Phaser.Input.Keyboard.JustDown;
+    const up   = JD(this.cursors.up)   || JD(this.wasd.up);
+    const down = JD(this.cursors.down) || JD(this.wasd.down);
+    const left = JD(this.cursors.left) || JD(this.wasd.left);
+    const right= JD(this.cursors.right)|| JD(this.wasd.right);
+
+    const TAB_ORDER: Array<'status' | 'inventory' | 'spells'> = ['status', 'inventory', 'spells'];
+
+    // ── Aba MAGIAS com foco na lista ──────────────────────────────────────
+    if (this._inventoryTab === 'spells' && this._spellsFocus === 'list') {
+      const spellCount = this.player.unlockedSpells.length;
+
+      if (up) {
+        if (this._spellsSelectedIndex === 0) {
+          // Volta o foco para as abas
+          this._spellsFocus = 'tabs';
+          EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: -1 });
+        } else {
+          this._spellsSelectedIndex--;
+          EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: this._spellsSelectedIndex });
+        }
+        return;
+      }
+      if (down) {
+        this._spellsSelectedIndex = Math.min(spellCount - 1, this._spellsSelectedIndex + 1);
+        EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: this._spellsSelectedIndex });
+        return;
+      }
+      // J — equipa no slot 0; K — equipa no slot 1; Enter/E — slot 0 por padrão
+      if (JD(this.jKey) || JD(this.enterKey) || JD(this.eKey)) {
+        const spellId = this.player.unlockedSpells[this._spellsSelectedIndex] ?? null;
+        if (spellId) EventBus.emit(EVENTS.SPELL_EQUIP_REQUEST, { slotIndex: 0, spellId });
+        return;
+      }
+      if (JD(this.kKey)) {
+        const spellId = this.player.unlockedSpells[this._spellsSelectedIndex] ?? null;
+        if (spellId) EventBus.emit(EVENTS.SPELL_EQUIP_REQUEST, { slotIndex: 1, spellId });
+        return;
+      }
+      return;
+    }
+
+    // ── Navegação de abas (←/→ ou ↓ entra na lista da aba magias) ─────────
+    if (left) {
+      const idx = TAB_ORDER.indexOf(this._inventoryTab);
+      this._inventoryTab = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length];
+      this._spellsFocus = 'tabs';
+      EventBus.emit(EVENTS.INVENTORY_TAB_CHANGED, { tab: this._inventoryTab, _fromKeyboard: true });
+      return;
+    }
+    if (right) {
+      const idx = TAB_ORDER.indexOf(this._inventoryTab);
+      this._inventoryTab = TAB_ORDER[(idx + 1) % TAB_ORDER.length];
+      this._spellsFocus = 'tabs';
+      EventBus.emit(EVENTS.INVENTORY_TAB_CHANGED, { tab: this._inventoryTab, _fromKeyboard: true });
+      return;
+    }
+    if (down && this._inventoryTab === 'spells') {
+      // Entra na lista de magias
+      this._spellsFocus = 'list';
+      this._spellsSelectedIndex = 0;
+      EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: 0 });
+      return;
+    }
+
+    // ── Aba INVENTÁRIO ────────────────────────────────────────────────────
+    if (this._inventoryTab !== 'inventory') return;
+
     const inv = this.player.inventory;
     const total = inv.items.filter(i => i !== null).length;
 
-    if (JD(this.cursors.up) || JD(this.wasd.up)) {
+    if (up) {
       this._inventorySelectedIndex = Math.max(0, this._inventorySelectedIndex - 1);
       this._emitInventorySelectionChanged();
       return;
     }
-    if (JD(this.cursors.down) || JD(this.wasd.down)) {
+    if (down) {
       this._inventorySelectedIndex = Math.min(total - 1, this._inventorySelectedIndex + 1);
       this._emitInventorySelectionChanged();
       return;
@@ -886,14 +1011,10 @@ export class GameScene extends Phaser.Scene {
 
     const item = inv.getItem(this._inventorySelectedIndex);
 
-    if (JD(this.eKey)) {
+    // E / Enter — ação primária (equipa se equippable, usa se consumível)
+    if (JD(this.eKey) || JD(this.enterKey)) {
       if (!item) { EventBus.emit(EVENTS.UI_LOG, 'Nenhum item selecionado.'); return; }
-      if (!item.slotId) { EventBus.emit(EVENTS.UI_LOG, 'Este item não pode ser equipado.'); return; }
-      if (this.equipmentSystem.getEquippedId(item.slotId as EquipmentSlotId) === item.id) {
-        this._unequipSelectedItem();
-      } else {
-        this._equipSelectedItem();
-      }
+      this._inventoryPrimaryAction();
       return;
     }
 
@@ -910,42 +1031,19 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
-  // ─── Itens iniciais por classe ────────────────────────────────────────────
+  /** Ação primária contextual: equipa se equippable, usa se consumível. */
+  private _inventoryPrimaryAction(): void {
+    const item = this.player.inventory.getItem(this._inventorySelectedIndex);
+    if (!item) { EventBus.emit(EVENTS.UI_LOG, 'Nenhum item selecionado.'); return; }
 
-  private _equipStartingItem(
-    itemDef: { id: string; name: string; type: string; slotId: EquipmentSlotId; price: number; rarity: string; bonuses: StatBonuses | Record<string, number>; quantity?: number },
-    opts?: { noSell?: boolean; noUnequip?: boolean },
-  ): void {
-    const item = new Item(`${itemDef.id}_start`, itemDef.type as ItemType, null, null);
-    item.name       = itemDef.name;
-    item.slotId     = itemDef.slotId;
-    item.price      = itemDef.price;
-    item.rarity     = itemDef.rarity as ItemRarity;
-    item.bonuses    = Object.keys(itemDef.bonuses).length > 0 ? (itemDef.bonuses as StatBonuses) : undefined;
-    item.identified = true;
-    if (opts?.noSell)    item.noSell    = true;
-    if (opts?.noUnequip) item.noUnequip = true;
-    if (itemDef.quantity !== undefined) item.quantity = itemDef.quantity;
-
-    this.player.inventory.addItem(item);
-    this.equipmentSystem.equip(item.id, itemDef.slotId, this.player.classDef ?? undefined, item);
-    if (item.bonuses) this.player.applyEquipmentBonuses(item.bonuses);
-
-    if (itemDef.type.startsWith('arrows') && itemDef.quantity) {
-      this.player.arrows = itemDef.quantity;
-      EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: this.player.arrows });
-    }
-  }
-
-  private _applyClassStartingItems(): void {
-    if (!this.player.classDef) return;
-    if (this.player.classDef.id === 'mago') {
-      this._equipStartingItem(STARTING_ITEMS.spellbook_basic, { noSell: true, noUnequip: true });
-    } else if (this.player.classDef.id === 'arqueiro') {
-      const bow     = STARTING_ITEMS.bow_wood;
-      const arrows  = STARTING_ITEMS.arrows_100;
-      if (bow.slotId)    this._equipStartingItem({ ...bow,    slotId: bow.slotId });
-      if (arrows.slotId) this._equipStartingItem({ ...arrows, slotId: arrows.slotId });
+    if (item.slotId) {
+      if (this.equipmentSystem.getEquippedId(item.slotId as EquipmentSlotId) === item.id) {
+        this._unequipSelectedItem();
+      } else {
+        this._equipSelectedItem();
+      }
+    } else {
+      this._useSelectedItem();
     }
   }
 
@@ -1032,11 +1130,7 @@ export class GameScene extends Phaser.Scene {
       if (prevItem?.bonuses) this.player.removeEquipmentBonuses(prevItem.bonuses);
     }
 
-    const equipResult = this.equipmentSystem.equip(item.id, item.slotId, this.player.classDef ?? undefined, item);
-    if (!equipResult.success) {
-      EventBus.emit(EVENTS.UI_LOG, equipResult.message);
-      return;
-    }
+    this.equipmentSystem.equip(item.id, item.slotId);
     if (item.bonuses) this.player.applyEquipmentBonuses(item.bonuses);
 
     EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
@@ -1047,12 +1141,7 @@ export class GameScene extends Phaser.Scene {
   private _unequipSelectedItem(): void {
     const item = this.player.inventory.getItem(this._inventorySelectedIndex);
     if (!item?.slotId) return;
-    const unequippedId = this.equipmentSystem.unequip(item.slotId as EquipmentSlotId);
-    if (unequippedId === null && item.noUnequip) {
-      EventBus.emit(EVENTS.UI_LOG, 'Este item não pode ser retirado.');
-      return;
-    }
-    if (unequippedId === null) return;
+    this.equipmentSystem.unequip(item.slotId as EquipmentSlotId);
     if (item.bonuses) this.player.removeEquipmentBonuses(item.bonuses);
     EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
     EventBus.emit(EVENTS.UI_LOG, `Desequipou ${item.name ?? item.type}.`);
@@ -1065,15 +1154,34 @@ export class GameScene extends Phaser.Scene {
       this.player.identifiedItems,
       this.player.hp,
       this.player.maxHp,
+      this.player.mana,
+      this.player.maxMana,
     );
     result.messages.forEach(msg => EventBus.emit(EVENTS.UI_LOG, msg));
 
-    if (result.success && result.hpDelta !== 0) {
-      this.player.hp = Math.min(this.player.maxHp, this.player.hp + result.hpDelta);
-      EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
+    if (result.success) {
+      if (result.hpDelta !== 0) {
+        this.player.hp = Math.min(this.player.maxHp, this.player.hp + result.hpDelta);
+        EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
+      }
+      if (result.manaDelta !== 0) {
+        this.player.mana = Math.min(this.player.maxMana, this.player.mana + result.manaDelta);
+        EventBus.emit(EVENTS.PLAYER_MANA_CHANGED, { mana: this.player.mana, maxMana: this.player.maxMana });
+      }
     }
 
     EventBus.emit(EVENTS.ITEM_USED, { itemIndex: this._inventorySelectedIndex });
+    // Registrar uso de item na memória narrativa
+    if (result.success) {
+      const usedItem = this.player.inventory.getItem(this._inventorySelectedIndex);
+      const itemName = usedItem
+        ? usedItem.getDisplayName(this.player.identifiedItems)
+        : result.messages[0] ?? 'item';
+      this._recordGameEvent('ITEM_USED', { itemName });
+      if (result.hpDelta > 0) {
+        this._recordGameEvent('PLAYER_HEALED', { amount: result.hpDelta });
+      }
+    }
     this._clampInventorySelection();
     this._emitInventoryState();
   }
@@ -1152,8 +1260,84 @@ export class GameScene extends Phaser.Scene {
       this.player.inventory,
       equippedIds,
     );
-    this._shopBuyTotal = vm.buyItemsCount ?? vm.buyItems?.length ?? vm.items?.length ?? 0;
+    this._shopBuyTotal = vm.buyItemsCount ?? vm.buyItems?.length ?? 0;
     EventBus.emit(EVENTS.SHOP_UPDATED, vm);
+  }
+
+  private _castSpell(slotIndex: 0 | 1): void {
+    if (this._currentArea !== 'dungeon') return;
+    const result = this._spellCastingSystem.cast(
+      slotIndex, this.player, this._spellSystem, this._enemies, Date.now(),
+    );
+    if (!result) return;
+
+    if (result.hitEnemies.length === 0) {
+      EventBus.emit(EVENTS.UI_LOG, `${result.spellName} — nenhum alvo adjacente.`);
+      return;
+    }
+
+    for (const enemy of result.hitEnemies) {
+      enemy.takeDamage(result.damage, this.events);
+      EventBus.emit(EVENTS.UI_LOG, `${result.spellName} causou ${result.damage} de dano!`);
+
+      if (!enemy.alive) {
+        const pos = enemy.getPixelPos();
+        this._showDamageText(pos, result.damage, COLORS.XP_TEXT);
+        this._removeEnemySprite(enemy);
+        const xpGain = enemy.xpReward ?? 0;
+        if (xpGain > 0) this.xpSystem.addXP(this.player, xpGain);
+      } else {
+        this._syncEnemySprite(enemy);
+        this._showDamageText(enemy.getPixelPos(), result.damage, COLORS.XP_TEXT);
+        if (enemy.sprite) this._flashSprite(enemy.sprite);
+      }
+    }
+  }
+
+
+  private _emitStatusState(): void {
+    const p = this.player;
+    const xpNext = this.xpSystem.getXPToNextLevel(p.level);
+    EventBus.emit(EVENTS.STATUS_STATE_RESPONSE, {
+      level: p.level, xp: p.xp, xpNext,
+      hp: p.hp, maxHp: p.maxHp, mana: p.mana, maxMana: p.maxMana,
+      str: p.str, intel: p.intel, dex: p.dex, con: p.con, wis: p.wis, cha: p.cha,
+      attack: p.attack, freePoints: p.freePoints,
+    });
+  }
+
+  private _emitSpellsState(): void {
+    const nowMs = Date.now();
+    const slots = this._spellSystem.getSlots();
+    const activeSlots = slots.map((slot, i) => ({
+      slotIndex: i as 0 | 1,
+      key: (i === 0 ? 'J' : 'K') as 'J' | 'K',
+      spellId: slot.spellId,
+      spellName: slot.spellId ? (SPELLS_DB[slot.spellId]?.name ?? '?') : '—',
+      cooldownRatio: this._spellSystem.getCooldownRatio(i as 0 | 1, nowMs),
+    }));
+
+    const unlockedSpells = this.player.unlockedSpells.map(id => {
+      const def = SPELLS_DB[id];
+      const isEquipped = slots.some(s => s.spellId === id);
+      return {
+        id,
+        name: def?.name ?? id,
+        element: def?.element ?? 'arcane',
+        damage: def?.damage ?? 0,
+        manaCost: def?.manaCost ?? 0,
+        cooldownMs: def?.cooldownMs ?? 0,
+        isEquipped,
+        isSelected: false,
+      };
+    });
+
+    EventBus.emit(EVENTS.SPELLS_STATE_RESPONSE, {
+      activeSlots,
+      unlockedSpells,
+      selectedSpellId: null,
+      playerMana: this.player.mana,
+    });
   }
 
   private _removeEnemySprite(enemy: EnemySystem): void {
@@ -1221,16 +1405,50 @@ export class GameScene extends Phaser.Scene {
     this.events.on(EVENTS.PLAYER_DIED, () => {
       this.gameState = GAME_STATE.GAME_OVER;
       EventBus.emit(EVENTS.UI_LOG, 'Você morreu.');
+
+      // Registrar evento de morte na memória
+      this._recordGameEvent('PLAYER_DEATH', {
+        floor: this.floorManager?.currentFloor ?? 1,
+        level: this.player.level,
+      });
+
+      // Gerar história da run de forma assíncrona (não bloqueia)
+      const importantEvents = this._eventMemory.getImportantEvents(10);
+      this._narrativeService.generateDeathStory(importantEvents)
+        .then((story) => {
+          EventBus.emit(EVENTS.DEATH_STORY_GENERATED, { story });
+        });
+
       this.cameras.main.flash(500, 255, 0, 0);
       this.time.delayedCall(600, () => {
         this.scene.stop('UIScene');
-        this.scene.start('GameOverScene', { level: this.player.level, xp: this.player.xp });
+        this.scene.start('GameOverScene', {
+          level:         this.player.level,
+          xp:            this.player.xp,
+          events:        this._eventMemory.getImportantEvents(10),
+          // Métricas da partida
+          turnsSurvived: this.playerMetrics.turnsSurvived,
+          damageDealt:   this.playerMetrics.damageDealt,
+          damageTaken:   this.playerMetrics.damageTaken,
+          enemiesKilled: this.playerMetrics.enemiesKilled,
+          itemsUsed:     this.playerMetrics.itemsUsed,
+          floorsReached: this.floorManager?.currentFloor ?? 1,
+        });
       });
     });
 
     this.events.on(EVENTS.PLAYER_LEVELED_UP, (data: { level: number; maxHp: number; attack: number }) => {
       this._showDamageText(this.player.getPixelPos(), `NÍVEL ${data.level}!`, COLORS.LEVEL_UP_TEXT);
       EventBus.emit(EVENTS.UI_LOG, `Subiu para o Nível ${data.level}!`);
+      // Desbloquear magias para o novo nível
+      const newSpells = this._spellSystem.unlockSpellsForLevel(this.player, data.level);
+      for (const id of newSpells) {
+        const spell = SPELLS_DB[id];
+        if (spell) {
+          EventBus.emit(EVENTS.UI_LOG, `Magia desbloqueada: ${spell.name}!`);
+          EventBus.emit(EVENTS.SPELL_UNLOCKED, { id, name: spell.name });
+        }
+      }
     });
 
     // Feedback visual: dano no inimigo (número amarelo + flash)
@@ -1248,6 +1466,12 @@ export class GameScene extends Phaser.Scene {
     this.events.on(EVENTS.DAMAGE_PLAYER, (data: { pos: { x: number; y: number }; damage: number }) => {
       this._showDamageText(data.pos, data.damage, COLORS.DAMAGE_TEXT);
       this._flashSprite(this.player);
+      // Registrar dano na memória narrativa
+      this._recordGameEvent('PLAYER_DAMAGED', { damage: data.damage });
+      // Verificar quase-morte (HP <= 20% do máximo)
+      if (this.player.hp > 0 && this.player.hp <= Math.floor(this.player.maxHp * 0.2)) {
+        this._recordGameEvent('PLAYER_NEAR_DEATH', { hp: this.player.hp });
+      }
     });
 
     EventBus.on(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
@@ -1255,6 +1479,43 @@ export class GameScene extends Phaser.Scene {
     // Responde com estado do inventário quando UIScene solicitar
     EventBus.on(EVENTS.INVENTORY_STATE_REQUESTED, () => {
       this._emitInventoryState();
+    }, this);
+
+    // Sincroniza aba local quando UIScene muda via clique
+    EventBus.on(EVENTS.INVENTORY_TAB_CHANGED, (data: { tab: 'inventory' | 'status' | 'spells'; _fromKeyboard?: boolean }) => {
+      if (!data._fromKeyboard) {
+        this._inventoryTab = data.tab;
+        this._spellsFocus = 'tabs';
+      }
+    }, this);
+
+    // Responde com estado de status quando solicitado
+    EventBus.on(EVENTS.STATUS_STATE_REQUESTED, () => {
+      this._emitStatusState();
+    }, this);
+
+    // Responde com estado das magias quando solicitado
+    EventBus.on(EVENTS.SPELLS_STATE_REQUESTED, () => {
+      this._emitSpellsState();
+    }, this);
+
+    // Gasta ponto de atributo
+    EventBus.on(EVENTS.STAT_POINT_SPENT_REQUEST, (data: { stat: string }) => {
+      const valid = ['str', 'intel', 'dex', 'con', 'wis'] as const;
+      if (valid.includes(data.stat as typeof valid[number])) {
+        const spent = this.player.spendStatPoint(data.stat as typeof valid[number]);
+        if (spent) this._emitStatusState();
+      }
+    }, this);
+
+    // Equipar magia em slot
+    EventBus.on(EVENTS.SPELL_EQUIP_REQUEST, (data: { slotIndex: 0 | 1; spellId: string | null }) => {
+      if (data.spellId) {
+        this._spellSystem.equipSpell(this.player, data.spellId, data.slotIndex);
+      } else {
+        this._spellSystem.unequipSpell(this.player, data.slotIndex);
+      }
+      this._emitSpellsState();
     }, this);
 
     // Abre a loja quando o mercador é interagido
@@ -1286,7 +1547,7 @@ export class GameScene extends Phaser.Scene {
       this._emitShopState();
     }, this);
 
-    // Troca de aba na loja via clique
+    // Mouse: trocar aba na loja (Comprar / Vender)
     EventBus.on(EVENTS.SHOP_TAB_SWITCHED, (data: { tab: 'buy' | 'sell' }) => {
       if (!this.inputMode.is('SHOP')) return;
       this._shopTab = data.tab;
@@ -1294,16 +1555,38 @@ export class GameScene extends Phaser.Scene {
       this._emitShopState();
     }, this);
 
-    // Equipar flechas no slot extra sincroniza player.arrows
+    // Equipar flechas no slot Extra sincroniza player.arrows
     EventBus.on(EVENTS.ITEM_EQUIPPED, (data: { itemId: string; slotId: EquipmentSlotId }) => {
-      if (data.slotId === 'extra') {
-        const equippedItem = this.player.inventory.items.find(i => i?.id === data.itemId);
-        if (equippedItem?.type.startsWith('arrows')) {
-          this.player.arrows = equippedItem.quantity ?? 0;
-          EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: this.player.arrows });
-        }
+      if (data.slotId !== 'extra') return;
+      const equippedItem = this.player.inventory.items.find(i => i?.id === data.itemId);
+      if (equippedItem?.type.startsWith('arrows')) {
+        this.player.arrows = equippedItem.quantity ?? 0;
+        EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: this.player.arrows });
       }
     }, this);
+
+    // Mouse: clique em item do inventário — seleciona e executa ação primária
+    EventBus.on(EVENTS.INVENTORY_ITEM_CLICKED, (data: { index: number }) => {
+      if (!this.inputMode.is('INVENTORY')) return;
+      const inv = this.player.inventory;
+      const item = inv.getItem(data.index);
+      if (!item) return;
+
+      if (this._inventorySelectedIndex === data.index) {
+        // Segundo clique no mesmo item → executa ação primária
+        this._inventoryPrimaryAction();
+      } else {
+        // Primeiro clique → apenas seleciona
+        this._inventorySelectedIndex = data.index;
+        this._emitInventorySelectionChanged();
+      }
+    }, this);
+  }
+
+  // ─── Narrativa: registro de eventos ─────────────────────────────────────
+
+  private _recordGameEvent(type: GameEventType, data: Record<string, unknown> = {}): void {
+    this._eventMemory.addEvent({ type, timestamp: Date.now(), data });
   }
 
   private _handleDialogInput(): void {
@@ -1353,5 +1636,98 @@ export class GameScene extends Phaser.Scene {
       }
       return;
     }
+  }
+
+  // ─── Itens iniciais por classe ────────────────────────────────────────────
+
+  private _equipStartingItem(
+    itemDef: { id: string; name: string; type: string; slotId: EquipmentSlotId; price: number; rarity: string; bonuses?: StatBonuses | Record<string, number>; quantity?: number },
+    opts?: { noSell?: boolean; noUnequip?: boolean },
+  ): void {
+    const item = new Item(`${itemDef.id}_start`, itemDef.type as ItemType, null, null);
+    item.name       = itemDef.name;
+    item.slotId     = itemDef.slotId;
+    item.price      = itemDef.price;
+    item.rarity     = itemDef.rarity as ItemRarity;
+    item.bonuses    = itemDef.bonuses && Object.keys(itemDef.bonuses).length > 0
+      ? (itemDef.bonuses as StatBonuses) : undefined;
+    item.identified = true;
+    if (opts?.noSell)    item.noSell    = true;
+    if (opts?.noUnequip) item.noUnequip = true;
+    if (itemDef.quantity !== undefined) item.quantity = itemDef.quantity;
+
+    this.player.inventory.addItem(item);
+    this.equipmentSystem.equip(item.id, itemDef.slotId, this.player.classDef ?? undefined, item);
+    if (item.bonuses) this.player.applyEquipmentBonuses(item.bonuses);
+    if (itemDef.type.startsWith('arrows') && itemDef.quantity) {
+      this.player.arrows = itemDef.quantity;
+      EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: this.player.arrows });
+    }
+  }
+
+  private _applyClassStartingItems(): void {
+    if (!this.player.classDef) return;
+    if (this.player.classDef.id === 'mago') {
+      this._equipStartingItem(STARTING_ITEMS.spellbook_basic, { noSell: true, noUnequip: true });
+    } else if (this.player.classDef.id === 'arqueiro') {
+      const bow    = STARTING_ITEMS.bow_wood;
+      const arrows = STARTING_ITEMS.arrows_100;
+      if (bow.slotId)    this._equipStartingItem({ ...bow,    slotId: bow.slotId });
+      if (arrows.slotId) this._equipStartingItem({ ...arrows, slotId: arrows.slotId });
+    }
+  }
+
+  // ─── Ataque à distância (Arqueiro) ────────────────────────────────────────
+
+  private _hasLineOfSight(x0: number, y0: number, x1: number, y1: number): boolean {
+    let dx = Math.abs(x1 - x0);
+    let dy = Math.abs(y1 - y0);
+    const sx = x0 < x1 ? 1 : -1;
+    const sy = y0 < y1 ? 1 : -1;
+    let err = dx - dy;
+    let x = x0, y = y0;
+    while (x !== x1 || y !== y1) {
+      const e2 = 2 * err;
+      if (e2 > -dy) { err -= dy; x += sx; }
+      if (e2 <  dx) { err += dx; y += sy; }
+      if (x === x1 && y === y1) break;
+      if (!this._currentMap.isWalkable(x, y)) return false;
+    }
+    return true;
+  }
+
+  private _tryRangedAttack(enemy: EnemySystem): void {
+    if (!this.inputMode.is('GAMEPLAY')) return;
+    if (!this.player.classDef?.usesArrows) return;
+    if (!enemy.alive) return;
+
+    const dx   = Math.abs(enemy.gridX - this.player.gridX);
+    const dy   = Math.abs(enemy.gridY - this.player.gridY);
+    const dist = Math.max(dx, dy);
+    if (dist > 4) {
+      EventBus.emit(EVENTS.UI_LOG, 'Inimigo fora de alcance (máx. 4 tiles).');
+      return;
+    }
+    if (!this._hasLineOfSight(this.player.gridX, this.player.gridY, enemy.gridX, enemy.gridY)) {
+      EventBus.emit(EVENTS.UI_LOG, 'Sem linha de visão para o inimigo.');
+      return;
+    }
+
+    const result = this.turnManager.processPlayerAction(
+      { type: 'ATTACK', target: enemy },
+      this.player,
+      this._enemies,
+      this._currentMap,
+      this.combatSystem,
+      this.playerMetrics,
+    );
+
+    result.messages.forEach(msg => EventBus.emit(EVENTS.UI_LOG, msg));
+    this._enemies.forEach(e => this._syncEnemySprite(e));
+    result.enemiesDied.forEach(e => {
+      EventBus.emit(EVENTS.UI_LOG, `+${e.xpReward} XP`);
+      this._removeEnemySprite(e);
+      this.lootSystem.roll(e.gridX, e.gridY, this.floorManager.currentFloor, e.isElite, this.player.classDef);
+    });
   }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -916,8 +916,8 @@ export class GameScene extends Phaser.Scene {
         EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: this._spellsSelectedIndex });
         return;
       }
-      // E/Enter — equipa no slot J (0) por padrão; K com tecla K
-      if (JD(this.enterKey) || JD(this.eKey)) {
+      // J — equipa no slot 0; K — equipa no slot 1; Enter/E — slot 0 por padrão
+      if (JD(this.jKey) || JD(this.enterKey) || JD(this.eKey)) {
         const spellId = this.player.unlockedSpells[this._spellsSelectedIndex] ?? null;
         if (spellId) EventBus.emit(EVENTS.SPELL_EQUIP_REQUEST, { slotIndex: 0, spellId });
         return;

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -12,8 +12,6 @@ import { TownMap } from '../systems/WorldSystem';
 import { NPCController } from '../systems/NPCController';
 import { InteractiveObjectSystem } from '../systems/InteractiveObjectSystem';
 import { TownTMXRenderer } from '../systems/TownTMXRenderer';
-import { themeForFloor } from '../config/dungeon-themes';
-import { DungeonRenderer } from '../systems/DungeonRenderer';
 import { BonusAreaRenderer } from '../systems/BonusAreaRenderer';
 import { LAYER_GROUND } from '../config/sprites-config';
 import { InputModeManager } from '../systems/InputModeManager';
@@ -23,19 +21,11 @@ import { DifficultyScalingSystem } from '../systems/DifficultyScalingSystem';
 import { PlayerMetrics } from '../systems/PlayerMetrics';
 import { DifficultyManager } from '../systems/DifficultyManager';
 import { DungeonFeatureGenerator, type DungeonFeature } from '../generators/DungeonFeatureGenerator';
-import { AIService } from '../ai/AIService';
-import { AIIntegration } from '../ai/AIIntegration';
-import { NarrativeService } from '../ai/NarrativeService';
-import { AI_CONFIG } from '../ai/config';
-import { EventMemory } from '../systems/EventMemory';
-import type { GameEventType } from '../systems/EventMemory';
 import { EquipmentSystem } from '../systems/EquipmentSystem';
 import { ShopSystem } from '../systems/ShopSystem';
-import { SHOP_CATALOG } from '../config/shop.catalog';
-import { CATEGORY_TEXTURE_KEYS } from '../config/enemies.config';
-import { SpellSystem } from '../systems/SpellSystem';
-import { SpellCastingSystem } from '../systems/SpellCastingSystem';
-import { SPELLS_DB } from '../config/spells.db';
+import { SHOP_CATALOG, STARTING_ITEMS } from '../config/shop.catalog';
+import { ClassRulesEngine } from '../systems/ClassRulesEngine';
+import { PLAYER_CLASSES } from '../config/player-classes.config';
 import type { TransitionResolution } from '../types/transitions';
 import type { GridPos } from '../generators/DungeonGenerator';
 import {
@@ -55,7 +45,8 @@ import { MANUAL_MAP_OVERRIDES } from '../config/TileProperties';
 import { TMX_PAD_X, TMX_PAD_Y, TMX_TILESETS } from '../config/TownTMXData';
 import { BONUS_W, BONUS_H, BONUS_PLAYER_START_X, BONUS_PLAYER_START_Y } from '../config/BonusAreaData';
 import type { DialogMenuOption } from '../types/town';
-import type { EquipmentSlotId } from '../types/equipment';
+import type { EquipmentSlotId, StatBonuses } from '../types/equipment';
+import type { ItemRarity } from '../types/equipment';
 
 export class GameScene extends Phaser.Scene {
   // ─── Sistemas persistentes (vivem durante toda a sessão) ─────────────────
@@ -74,13 +65,7 @@ export class GameScene extends Phaser.Scene {
   private _dungeonFeatures: DungeonFeature[] = [];
   private equipmentSystem!: EquipmentSystem;
   private _shopSystem!: ShopSystem;
-  private _spellSystem!: SpellSystem;
-  private _spellCastingSystem!: SpellCastingSystem;
   private gameState!: string;
-
-  // ─── Narrativa emergente (Fase 6) ─────────────────────────────────────────
-  private _eventMemory!: EventMemory;
-  private _narrativeService!: NarrativeService;
 
   // Cache de andares visitados (runtime — não serializado ainda)
   private _dungeonCache = new Map<number, {
@@ -120,20 +105,15 @@ export class GameScene extends Phaser.Scene {
   private vKey!: Phaser.Input.Keyboard.Key;
   private enterKey!: Phaser.Input.Keyboard.Key;
   private numKeys!: Phaser.Input.Keyboard.Key[];
-  private jKey!: Phaser.Input.Keyboard.Key;
-  private kKey!: Phaser.Input.Keyboard.Key;
-  private lKey!: Phaser.Input.Keyboard.Key;
 
   // ─── Keyboard focus reset handler ────────────────────────────────────────
   private _onWindowFocusReset!: () => void;
 
   // ─── Estado de seleção de inventário / loja ───────────────────────────────
   private _inventorySelectedIndex = 0;
-  private _inventoryTab: 'inventory' | 'status' | 'spells' = 'status';
-  private _spellsSelectedIndex = 0;
-  private _spellsFocus: 'tabs' | 'list' = 'tabs';
   private _shopSelectedIndex = 0;
   private _shopTab: 'buy' | 'sell' = 'buy';
+  private _shopBuyTotal = 0;
 
   // ─── Estado de diálogo ────────────────────────────────────────────────────
   private _dialogOptions: DialogMenuOption[] = [];
@@ -169,22 +149,28 @@ export class GameScene extends Phaser.Scene {
     this.difficultyManager  = new DifficultyManager();
     this.featureGenerator   = new DungeonFeatureGenerator();
     this.floorManager.reset();
-    this.equipmentSystem      = new EquipmentSystem();
-    this._shopSystem          = new ShopSystem(SHOP_CATALOG);
-    this._spellSystem         = new SpellSystem();
-    this._spellCastingSystem  = new SpellCastingSystem();
+    this.equipmentSystem = new EquipmentSystem();
+    this._shopSystem     = new ShopSystem(SHOP_CATALOG);
     this._registerTransitions();
-
-    // ─── Narrativa emergente (Fase 6) ──────────────────────────────────────
-    this._eventMemory     = new EventMemory();
-    const aiService       = new AIService(AI_CONFIG.API_KEY);
-    this._narrativeService = new NarrativeService(aiService);
 
     // Player criado uma vez — moves between areas
     this.player = new Player(this, TOWN.START_X, TOWN.START_Y);
 
-    // Desbloquear magias do nível 1 para novo jogo
-    this._spellSystem.unlockSpellsForLevel(this.player, 1);
+    // Aplicar classe do personagem (passada pela CharacterSelectScene)
+    const initData = this.scene.settings.data as { playerClass?: string } | undefined;
+    if (initData?.playerClass) {
+      const classDef = PLAYER_CLASSES.find(c => c.id === initData.playerClass) ?? null;
+      if (classDef) {
+        this.player.classDef = classDef;
+        this._setupInput();
+        this._registerEvents();
+        this.scene.launch('UIScene');
+        this._emitInitialUIState();
+        this._applyClassStartingItems();
+        this._loadArea('town');
+        return;
+      }
+    }
 
     this._setupInput();
     this._registerEvents();
@@ -197,12 +183,8 @@ export class GameScene extends Phaser.Scene {
   shutdown(): void {
     EventBus.off(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
     EventBus.off(EVENTS.INVENTORY_STATE_REQUESTED, undefined, this);
-    EventBus.off(EVENTS.STATUS_STATE_REQUESTED,    undefined, this);
-    EventBus.off(EVENTS.SPELLS_STATE_REQUESTED,    undefined, this);
-    EventBus.off(EVENTS.STAT_POINT_SPENT_REQUEST,  undefined, this);
-    EventBus.off(EVENTS.SPELL_EQUIP_REQUEST,       undefined, this);
-    EventBus.off(EVENTS.SHOP_OPENED,               undefined, this);
-    EventBus.off(EVENTS.DIALOG_OPENED,             undefined, this);
+    EventBus.off(EVENTS.SHOP_OPENED, undefined, this);
+    EventBus.off(EVENTS.DIALOG_OPENED, undefined, this);
     this.game.events.off(Phaser.Core.Events.BLUR,  this._onWindowFocusReset, this);
     this.game.events.off(Phaser.Core.Events.FOCUS, this._onWindowFocusReset, this);
   }
@@ -210,8 +192,6 @@ export class GameScene extends Phaser.Scene {
   update(_time: number, delta: number): void {
     if (this.gameState !== GAME_STATE.PLAYING) return;
     this._handleInput(_time);
-
-
 
     // Atualizar NPCs com wandering (cidade e área bônus)
     if ((this._currentArea === 'town' || this._currentArea === 'bonus') && this._npcController) {
@@ -410,7 +390,8 @@ export class GameScene extends Phaser.Scene {
     } else {
       this._dungeon = new DungeonGenerator();
       this._dungeon.generate();
-      this._floorFrame = 0; // mantido para compatibilidade com DungeonState (cache)
+      const variants   = DAWNLIKE_FRAMES.FLOOR_VARIANTS;
+      this._floorFrame = variants[Math.floor(Math.random() * variants.length)];
       this._items      = [];
       this._generateInitialItems();
       // Gerar features e salvar conexões apenas uma vez (Math.random implica não-determinismo)
@@ -422,22 +403,23 @@ export class GameScene extends Phaser.Scene {
     this._currentMap  = this._dungeon;
     this._currentArea = 'dungeon';
 
-    // Renderizar tiles via DungeonRenderer (shell-not-volume: VOID = preto, WALL_EDGE = bitmask)
-    this.cameras.main.setBackgroundColor(0x000000);
-    const theme = themeForFloor(floor);
+    // Renderizar tiles
     const { width: W, height: H, grid } = this._dungeon;
-    const renderer = new DungeonRenderer();
-    const commands = renderer.buildCommands(grid, theme, floor);
-    for (const cmd of commands) {
-      this._tileObjects.push(
-        this.add.image(cmd.x, cmd.y, cmd.texture, cmd.frame).setDepth(cmd.depth),
-      );
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const isFloor = grid[y][x] === TILE.FLOOR;
+        const px = x * TILE_SIZE + TILE_SIZE / 2;
+        const py = y * TILE_SIZE + TILE_SIZE / 2;
+        this._tileObjects.push(
+          this.add.image(px, py, isFloor ? SPRITES.FLOOR : SPRITES.WALL,
+            isFloor ? this._floorFrame : DAWNLIKE_FRAMES.WALL).setDepth(0),
+        );
+      }
     }
 
     // Recriar sprites dos itens no chão
     for (const item of this._items) {
       if (item.gridX === null || item.gridY === null) continue;
-      item.sprite?.destroy();
       const px = item.gridX * TILE_SIZE + TILE_SIZE / 2;
       const py = item.gridY * TILE_SIZE + TILE_SIZE / 2;
       const { texture, frame } = this._getItemVisual(item.type);
@@ -447,7 +429,7 @@ export class GameScene extends Phaser.Scene {
     this._renderDungeonFeatures(floor);
 
     // Gerar inimigos com scaling adaptativo (andar + performance do jogador)
-    const difficulty = { ...this.difficultyManager.getAdaptiveDifficulty(floor), floor };
+    const difficulty = this.difficultyManager.getAdaptiveDifficulty(floor);
     this._enemies = createEnemies(this._dungeon, this._dungeon.startPos, difficulty);
     this._createEnemySprites();
 
@@ -462,9 +444,8 @@ export class GameScene extends Phaser.Scene {
       features:   this._dungeonFeatures,
     });
 
-    // Posicionar player: se não há spawnPos explícita, nascer ao lado do stairUp (entrada/saída)
-    const stairUpPos = this._dungeonFeatures.find(f => f.type === 'stairUp');
-    const finalSpawn = spawnPos ?? (stairUpPos ? { x: stairUpPos.gridX, y: stairUpPos.gridY + 1 } : this._dungeon.startPos);
+    // Posicionar player
+    const finalSpawn = spawnPos ?? this._dungeon.startPos;
     this.player.gridX = finalSpawn.x;
     this.player.gridY = finalSpawn.y;
     this.player.setPosition(finalSpawn.x * TILE_SIZE + TILE_SIZE / 2, finalSpawn.y * TILE_SIZE + TILE_SIZE / 2);
@@ -475,29 +456,10 @@ export class GameScene extends Phaser.Scene {
 
     EventBus.emit(EVENTS.AREA_CHANGED, { area: 'dungeon', floor, timestamp: Date.now() });
     EventBus.emit(EVENTS.UI_LOG, cached ? `Você está no andar ${floor}.` : `Você desce para o andar ${floor}. Cuidado!`);
-
-    // Registrar mudança de andar na memória narrativa
-    if (!cached) {
-      this._recordGameEvent('FLOOR_CHANGED', { floor });
-
-      // Gerar narrativa ao descer de andar (não-bloqueante)
-      const recentEvents = this._eventMemory.getImportantEvents(8);
-      this._narrativeService.generateNarrative(recentEvents)
-        .then((narrative) => {
-          EventBus.emit(EVENTS.UI_LOG, narrative);
-          EventBus.emit(EVENTS.NARRATIVE_GENERATED, { narrative, floor });
-        });
-    }
   }
 
   private _generateInitialItems(): void {
-    const floor = this.floorManager.currentFloor;
-    const types: Array<'potion_heal_light' | 'potion_heal' | 'potion_heal_high' | 'potion_mana_light' | 'potion_mana' | 'potion_mana_high'> =
-      floor <= 2
-        ? ['potion_heal_light', 'potion_heal', 'potion_mana_light', 'potion_mana']
-        : floor <= 4
-          ? ['potion_heal', 'potion_heal_high', 'potion_mana', 'potion_mana_high']
-          : ['potion_heal', 'potion_heal_high', 'potion_heal_high', 'potion_mana', 'potion_mana_high'];
+    const types: Array<'potion_heal' | 'potion_poison'> = ['potion_heal', 'potion_poison'];
     const count = INVENTORY.ITEM_SPAWN_MIN +
       Math.floor(Math.random() * (INVENTORY.ITEM_SPAWN_MAX - INVENTORY.ITEM_SPAWN_MIN + 1));
     const occupied = new Set<string>();
@@ -519,13 +481,9 @@ export class GameScene extends Phaser.Scene {
 
   private _getItemVisual(type: ItemType): { texture: string; frame: number } {
     switch (type) {
-      case 'potion_heal_light':
-      case 'potion_heal':
-      case 'potion_heal_high':  return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_HEAL };
-      case 'potion_mana_light':
-      case 'potion_mana':
-      case 'potion_mana_high':  return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_MANA };
-      case 'gold':              return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
+      case 'potion_heal':   return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_HEAL };
+      case 'potion_poison': return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_POISON };
+      case 'gold':          return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
     }
   }
 
@@ -630,36 +588,75 @@ export class GameScene extends Phaser.Scene {
   // ─── Sprites de Inimigos ─────────────────────────────────────────────────
 
   private _createEnemySprites(): void {
-    this._enemies.forEach((enemy) => this._buildEnemySprite(enemy));
+    this._enemies.forEach((enemy) => {
+      const pos = enemy.getPixelPos();
+      enemy.sprite  = this.add.sprite(pos.x, pos.y, SPRITES.ENEMY, DAWNLIKE_FRAMES.ENEMY).setDepth(5);
+      enemy.hpBarBg = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0x330000).setDepth(6);
+      enemy.hpBar   = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0xff2222).setDepth(6);
+      // Permite clique para ataque à distância (Arqueiro)
+      enemy.sprite.setInteractive();
+      enemy.sprite.on('pointerdown', () => this._tryRangedAttack(enemy));
+    });
   }
 
   /**
-   * Cria o sprite e as barras de HP de um único inimigo.
-   * Isolado em método próprio para facilitar futura object pooling.
-   *
-   * Lógica de textura:
-   *   1. Usa CATEGORY_TEXTURE_KEYS para obter a chave padronizada do par DawnLike.
-   *   2. Verifica se a textura está carregada no TextureManager antes de usá-la.
-   *   3. Fallback em cascata: chave canônica → SPRITES.ENEMY (undead), evitando tela magenta.
-   * Animação:
-   *   Toca a animKey pré-calculada em createEnemies() se ela estiver registrada.
-   *   O AnimationManager é global — sem criação duplicada em runtime.
+   * Verifica linha de visão entre dois pontos do grid (algoritmo de Bresenham).
+   * @returns true se não há parede bloqueando a linha.
    */
-  private _buildEnemySprite(enemy: EnemySystem): void {
-    const pos = enemy.getPixelPos();
-
-    // Chave da textura base (*0): ex. 'pest0', 'undead' (alias legado), 'humanoid0'
-    const [tex0] = CATEGORY_TEXTURE_KEYS[enemy.category];
-    const texKey = this.textures.exists(tex0) ? tex0 : SPRITES.ENEMY;
-
-    enemy.sprite  = this.add.sprite(pos.x, pos.y, texKey, enemy.frameIndex).setDepth(5);
-    enemy.hpBarBg = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0x330000).setDepth(6);
-    enemy.hpBar   = this.add.rectangle(pos.x, pos.y - TILE_SIZE / 2 - 2, TILE_SIZE, 3, 0xff2222).setDepth(6);
-
-    // Toca animação ping-pong se registrada pela BootScene
-    if (enemy.animKey && this.anims.exists(enemy.animKey)) {
-      enemy.sprite.play(enemy.animKey);
+  private _hasLineOfSight(x0: number, y0: number, x1: number, y1: number): boolean {
+    let dx = Math.abs(x1 - x0);
+    let dy = Math.abs(y1 - y0);
+    const sx = x0 < x1 ? 1 : -1;
+    const sy = y0 < y1 ? 1 : -1;
+    let err = dx - dy;
+    let x = x0;
+    let y = y0;
+    while (x !== x1 || y !== y1) {
+      const e2 = 2 * err;
+      if (e2 > -dy) { err -= dy; x += sx; }
+      if (e2 <  dx) { err += dx; y += sy; }
+      if (x === x1 && y === y1) break;
+      if (!this._currentMap.isWalkable(x, y)) return false;
     }
+    return true;
+  }
+
+  /**
+   * Tenta executar um ataque à distância do Arqueiro no inimigo clicado.
+   */
+  private _tryRangedAttack(enemy: EnemySystem): void {
+    if (!this.inputMode.is('GAMEPLAY')) return;
+    if (!this.player.classDef?.usesArrows) return;
+    if (!enemy.alive) return;
+
+    const dx   = Math.abs(enemy.gridX - this.player.gridX);
+    const dy   = Math.abs(enemy.gridY - this.player.gridY);
+    const dist = Math.max(dx, dy);
+    if (dist > 4) {
+      EventBus.emit(EVENTS.UI_LOG, 'Inimigo fora de alcance (máx. 4 tiles).');
+      return;
+    }
+    if (!this._hasLineOfSight(this.player.gridX, this.player.gridY, enemy.gridX, enemy.gridY)) {
+      EventBus.emit(EVENTS.UI_LOG, 'Sem linha de visão para o inimigo.');
+      return;
+    }
+
+    const result = this.turnManager.processPlayerAction(
+      { type: 'ATTACK', target: enemy },
+      this.player,
+      this._enemies,
+      this._currentMap,
+      this.combatSystem,
+      this.playerMetrics,
+    );
+
+    result.messages.forEach(msg => EventBus.emit(EVENTS.UI_LOG, msg));
+    this._enemies.forEach(e => this._syncEnemySprite(e));
+    result.enemiesDied.forEach(e => {
+      EventBus.emit(EVENTS.UI_LOG, `+${e.xpReward} XP`);
+      this._removeEnemySprite(e);
+      this.lootSystem.roll(e.gridX, e.gridY);
+    });
   }
 
   // ─── Easter Egg: Platino (DragonDePlatino, CC-BY 4.0) ───────────────────
@@ -686,21 +683,6 @@ export class GameScene extends Phaser.Scene {
     for (const item of this._items) {
       if (item.gridX !== px || item.gridY !== py) continue;
 
-      // Ouro vai direto para o contador — não ocupa slot
-      if (item.type === 'gold') {
-        const amount = item.goldAmount ?? 1;
-        this.player.gold += amount;
-        item.gridX = null;
-        item.gridY = null;
-        if (item.sprite) {
-          item.sprite.destroy();
-          item.sprite = null;
-        }
-        EventBus.emit(EVENTS.UI_LOG, `Você pegou ${amount} moeda(s) de ouro`);
-        EventBus.emit(EVENTS.PLAYER_GOLD_CHANGED, { gold: this.player.gold });
-        continue;
-      }
-
       if (this.player.inventory.isFull()) {
         EventBus.emit(EVENTS.UI_LOG, 'Inventário cheio! Não foi possível coletar.');
         continue;
@@ -710,22 +692,16 @@ export class GameScene extends Phaser.Scene {
       this.player.inventory.addItem(item);
       const slotIndex = this.player.inventory.items.findIndex(i => i === item);
 
-      if (item.sprite) {
-        item.sprite.destroy();
-        item.sprite = null;
-      }
+      const s = item.sprite;
+      item.sprite = null;
+      s?.setVisible(false);
+      this.time.delayedCall(0, () => s?.destroy());
 
       EventBus.emit(EVENTS.UI_LOG, `Você pegou ${displayName}`);
       EventBus.emit(EVENTS.ITEM_PICKED_UP, { item, slotIndex });
-      // Registrar na memória narrativa
-      this._recordGameEvent('ITEM_FOUND', { itemName: displayName });
     }
 
     this._items = this._items.filter(i => i.gridX !== null);
-
-    // Keep dungeon cache in sync so floor re-entry shows correct items
-    const cached = this._dungeonCache.get(this.floorManager.currentFloor);
-    if (cached) cached.items = this._items;
   }
 
   // ─── Input ───────────────────────────────────────────────────────────────
@@ -746,9 +722,6 @@ export class GameScene extends Phaser.Scene {
     this.dKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.D);
     this.vKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.V);
     this.enterKey  = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
-    this.jKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.J);
-    this.kKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.K);
-    this.lKey      = this.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.L);
 
     this._onWindowFocusReset = () => { this.input.keyboard?.resetKeys(); };
     this.game.events.on(Phaser.Core.Events.BLUR,  this._onWindowFocusReset, this);
@@ -776,8 +749,6 @@ export class GameScene extends Phaser.Scene {
         EventBus.emit(EVENTS.DIALOG_CLOSED, {});
       } else if (this.inputMode.is('INVENTORY')) {
         this.inputMode.pop();
-        this._inventoryTab = 'status';
-        this._spellsFocus = 'tabs';
         EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
       } else if (this.inputMode.is('SHOP')) {
         this.inputMode.pop();
@@ -796,8 +767,6 @@ export class GameScene extends Phaser.Scene {
     if (JD(this.iKey)) {
       if (this.inputMode.is('INVENTORY')) {
         this.inputMode.pop();
-        this._inventoryTab = 'status';
-        this._spellsFocus = 'tabs';
         EventBus.emit(EVENTS.INVENTORY_CLOSED, { timestamp: Date.now() });
       } else if (this.inputMode.is('GAMEPLAY')) {
         this.inputMode.push('INVENTORY');
@@ -823,11 +792,6 @@ export class GameScene extends Phaser.Scene {
     // 5. GAMEPLAY
     if (!this.inputMode.is('GAMEPLAY')) return;
     if (!this.turnManager.isPlayerTurn()) return;
-
-    // J/K: disparar magia ativa (real-time, não consome turno de movimento)
-    if (JD(this.jKey)) { this._castSpell(0); }
-    if (JD(this.kKey)) { this._castSpell(1); }
-    // lKey reservado para ultimate futuro
 
     // Teclas 1–9: usar item do slot
     for (let i = 0; i < this.numKeys.length; i++) {
@@ -886,19 +850,11 @@ export class GameScene extends Phaser.Scene {
 
     this._enemies.forEach(e => this._syncEnemySprite(e));
 
-    let anyDroppedOnPlayerTile = false;
     result.enemiesDied.forEach(e => {
       EventBus.emit(EVENTS.UI_LOG, `+${e.xpReward} XP`);
       this._removeEnemySprite(e);
-      const dropped = this.lootSystem.roll(e.gridX, e.gridY, this.floorManager.currentFloor, e.isElite);
-      if (dropped && e.gridX === this.player.gridX && e.gridY === this.player.gridY) {
-        anyDroppedOnPlayerTile = true;
-      }
-      // Registrar morte de inimigo na memória narrativa
-      this._recordGameEvent('ENEMY_KILLED', { enemyName: e.aiName ?? e.enemyName });
+      this.lootSystem.roll(e.gridX, e.gridY);
     });
-    // Coletar drops que caíram no mesmo tile que o player (o pickup anterior rodou antes dos drops)
-    if (anyDroppedOnPlayerTile) this._checkItemPickup();
 
     // Atualizar dificuldade adaptativa e emitir hint narrativo se mudou
     const levelChanged = this.difficultyManager.update(this.playerMetrics);
@@ -914,82 +870,15 @@ export class GameScene extends Phaser.Scene {
 
   private _handleInventoryInput(): void {
     const JD = Phaser.Input.Keyboard.JustDown;
-    const up   = JD(this.cursors.up)   || JD(this.wasd.up);
-    const down = JD(this.cursors.down) || JD(this.wasd.down);
-    const left = JD(this.cursors.left) || JD(this.wasd.left);
-    const right= JD(this.cursors.right)|| JD(this.wasd.right);
-
-    const TAB_ORDER: Array<'status' | 'inventory' | 'spells'> = ['status', 'inventory', 'spells'];
-
-    // ── Aba MAGIAS com foco na lista ──────────────────────────────────────
-    if (this._inventoryTab === 'spells' && this._spellsFocus === 'list') {
-      const spellCount = this.player.unlockedSpells.length;
-
-      if (up) {
-        if (this._spellsSelectedIndex === 0) {
-          // Volta o foco para as abas
-          this._spellsFocus = 'tabs';
-          EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: -1 });
-        } else {
-          this._spellsSelectedIndex--;
-          EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: this._spellsSelectedIndex });
-        }
-        return;
-      }
-      if (down) {
-        this._spellsSelectedIndex = Math.min(spellCount - 1, this._spellsSelectedIndex + 1);
-        EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: this._spellsSelectedIndex });
-        return;
-      }
-      // J — equipa no slot 0; K — equipa no slot 1; Enter/E — slot 0 por padrão
-      if (JD(this.jKey) || JD(this.enterKey) || JD(this.eKey)) {
-        const spellId = this.player.unlockedSpells[this._spellsSelectedIndex] ?? null;
-        if (spellId) EventBus.emit(EVENTS.SPELL_EQUIP_REQUEST, { slotIndex: 0, spellId });
-        return;
-      }
-      if (JD(this.kKey)) {
-        const spellId = this.player.unlockedSpells[this._spellsSelectedIndex] ?? null;
-        if (spellId) EventBus.emit(EVENTS.SPELL_EQUIP_REQUEST, { slotIndex: 1, spellId });
-        return;
-      }
-      return;
-    }
-
-    // ── Navegação de abas (←/→ ou ↓ entra na lista da aba magias) ─────────
-    if (left) {
-      const idx = TAB_ORDER.indexOf(this._inventoryTab);
-      this._inventoryTab = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length];
-      this._spellsFocus = 'tabs';
-      EventBus.emit(EVENTS.INVENTORY_TAB_CHANGED, { tab: this._inventoryTab, _fromKeyboard: true });
-      return;
-    }
-    if (right) {
-      const idx = TAB_ORDER.indexOf(this._inventoryTab);
-      this._inventoryTab = TAB_ORDER[(idx + 1) % TAB_ORDER.length];
-      this._spellsFocus = 'tabs';
-      EventBus.emit(EVENTS.INVENTORY_TAB_CHANGED, { tab: this._inventoryTab, _fromKeyboard: true });
-      return;
-    }
-    if (down && this._inventoryTab === 'spells') {
-      // Entra na lista de magias
-      this._spellsFocus = 'list';
-      this._spellsSelectedIndex = 0;
-      EventBus.emit(EVENTS.SPELLS_SELECTION_CHANGED, { index: 0 });
-      return;
-    }
-
-    // ── Aba INVENTÁRIO ────────────────────────────────────────────────────
-    if (this._inventoryTab !== 'inventory') return;
-
     const inv = this.player.inventory;
     const total = inv.items.filter(i => i !== null).length;
 
-    if (up) {
+    if (JD(this.cursors.up) || JD(this.wasd.up)) {
       this._inventorySelectedIndex = Math.max(0, this._inventorySelectedIndex - 1);
       this._emitInventorySelectionChanged();
       return;
     }
-    if (down) {
+    if (JD(this.cursors.down) || JD(this.wasd.down)) {
       this._inventorySelectedIndex = Math.min(total - 1, this._inventorySelectedIndex + 1);
       this._emitInventorySelectionChanged();
       return;
@@ -997,10 +886,14 @@ export class GameScene extends Phaser.Scene {
 
     const item = inv.getItem(this._inventorySelectedIndex);
 
-    // E / Enter — ação primária (equipa se equippable, usa se consumível)
-    if (JD(this.eKey) || JD(this.enterKey)) {
+    if (JD(this.eKey)) {
       if (!item) { EventBus.emit(EVENTS.UI_LOG, 'Nenhum item selecionado.'); return; }
-      this._inventoryPrimaryAction();
+      if (!item.slotId) { EventBus.emit(EVENTS.UI_LOG, 'Este item não pode ser equipado.'); return; }
+      if (this.equipmentSystem.getEquippedId(item.slotId as EquipmentSlotId) === item.id) {
+        this._unequipSelectedItem();
+      } else {
+        this._equipSelectedItem();
+      }
       return;
     }
 
@@ -1017,19 +910,42 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
-  /** Ação primária contextual: equipa se equippable, usa se consumível. */
-  private _inventoryPrimaryAction(): void {
-    const item = this.player.inventory.getItem(this._inventorySelectedIndex);
-    if (!item) { EventBus.emit(EVENTS.UI_LOG, 'Nenhum item selecionado.'); return; }
+  // ─── Itens iniciais por classe ────────────────────────────────────────────
 
-    if (item.slotId) {
-      if (this.equipmentSystem.getEquippedId(item.slotId as EquipmentSlotId) === item.id) {
-        this._unequipSelectedItem();
-      } else {
-        this._equipSelectedItem();
-      }
-    } else {
-      this._useSelectedItem();
+  private _equipStartingItem(
+    itemDef: { id: string; name: string; type: string; slotId: EquipmentSlotId; price: number; rarity: string; bonuses: StatBonuses | Record<string, number>; quantity?: number },
+    opts?: { noSell?: boolean; noUnequip?: boolean },
+  ): void {
+    const item = new Item(`${itemDef.id}_start`, itemDef.type as ItemType, null, null);
+    item.name       = itemDef.name;
+    item.slotId     = itemDef.slotId;
+    item.price      = itemDef.price;
+    item.rarity     = itemDef.rarity as ItemRarity;
+    item.bonuses    = Object.keys(itemDef.bonuses).length > 0 ? (itemDef.bonuses as StatBonuses) : undefined;
+    item.identified = true;
+    if (opts?.noSell)    item.noSell    = true;
+    if (opts?.noUnequip) item.noUnequip = true;
+    if (itemDef.quantity !== undefined) item.quantity = itemDef.quantity;
+
+    this.player.inventory.addItem(item);
+    this.equipmentSystem.equip(item.id, itemDef.slotId, this.player.classDef ?? undefined, item);
+    if (item.bonuses) this.player.applyEquipmentBonuses(item.bonuses);
+
+    if (itemDef.type.startsWith('arrows') && itemDef.quantity) {
+      this.player.arrows = itemDef.quantity;
+      EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: this.player.arrows });
+    }
+  }
+
+  private _applyClassStartingItems(): void {
+    if (!this.player.classDef) return;
+    if (this.player.classDef.id === 'mago') {
+      this._equipStartingItem(STARTING_ITEMS.spellbook_basic, { noSell: true, noUnequip: true });
+    } else if (this.player.classDef.id === 'arqueiro') {
+      const bow     = STARTING_ITEMS.bow_wood;
+      const arrows  = STARTING_ITEMS.arrows_100;
+      if (bow.slotId)    this._equipStartingItem({ ...bow,    slotId: bow.slotId });
+      if (arrows.slotId) this._equipStartingItem({ ...arrows, slotId: arrows.slotId });
     }
   }
 
@@ -1052,7 +968,7 @@ export class GameScene extends Phaser.Scene {
     }
 
     if (this._shopTab === 'buy') {
-      const total = this._shopSystem.catalog.length;
+      const total = this._shopBuyTotal || this._shopSystem.catalog.length;
 
       if (JD(this.cursors.up) || JD(this.wasd.up)) {
         this._shopSelectedIndex = Math.max(0, this._shopSelectedIndex - 1);
@@ -1116,7 +1032,11 @@ export class GameScene extends Phaser.Scene {
       if (prevItem?.bonuses) this.player.removeEquipmentBonuses(prevItem.bonuses);
     }
 
-    this.equipmentSystem.equip(item.id, item.slotId);
+    const equipResult = this.equipmentSystem.equip(item.id, item.slotId, this.player.classDef ?? undefined, item);
+    if (!equipResult.success) {
+      EventBus.emit(EVENTS.UI_LOG, equipResult.message);
+      return;
+    }
     if (item.bonuses) this.player.applyEquipmentBonuses(item.bonuses);
 
     EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
@@ -1127,7 +1047,12 @@ export class GameScene extends Phaser.Scene {
   private _unequipSelectedItem(): void {
     const item = this.player.inventory.getItem(this._inventorySelectedIndex);
     if (!item?.slotId) return;
-    this.equipmentSystem.unequip(item.slotId as EquipmentSlotId);
+    const unequippedId = this.equipmentSystem.unequip(item.slotId as EquipmentSlotId);
+    if (unequippedId === null && item.noUnequip) {
+      EventBus.emit(EVENTS.UI_LOG, 'Este item não pode ser retirado.');
+      return;
+    }
+    if (unequippedId === null) return;
     if (item.bonuses) this.player.removeEquipmentBonuses(item.bonuses);
     EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
     EventBus.emit(EVENTS.UI_LOG, `Desequipou ${item.name ?? item.type}.`);
@@ -1140,34 +1065,15 @@ export class GameScene extends Phaser.Scene {
       this.player.identifiedItems,
       this.player.hp,
       this.player.maxHp,
-      this.player.mana,
-      this.player.maxMana,
     );
     result.messages.forEach(msg => EventBus.emit(EVENTS.UI_LOG, msg));
 
-    if (result.success) {
-      if (result.hpDelta !== 0) {
-        this.player.hp = Math.min(this.player.maxHp, this.player.hp + result.hpDelta);
-        EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
-      }
-      if (result.manaDelta !== 0) {
-        this.player.mana = Math.min(this.player.maxMana, this.player.mana + result.manaDelta);
-        EventBus.emit(EVENTS.PLAYER_MANA_CHANGED, { mana: this.player.mana, maxMana: this.player.maxMana });
-      }
+    if (result.success && result.hpDelta !== 0) {
+      this.player.hp = Math.min(this.player.maxHp, this.player.hp + result.hpDelta);
+      EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: this.player.hp, maxHp: this.player.maxHp });
     }
 
     EventBus.emit(EVENTS.ITEM_USED, { itemIndex: this._inventorySelectedIndex });
-    // Registrar uso de item na memória narrativa
-    if (result.success) {
-      const usedItem = this.player.inventory.getItem(this._inventorySelectedIndex);
-      const itemName = usedItem
-        ? usedItem.getDisplayName(this.player.identifiedItems)
-        : result.messages[0] ?? 'item';
-      this._recordGameEvent('ITEM_USED', { itemName });
-      if (result.hpDelta > 0) {
-        this._recordGameEvent('PLAYER_HEALED', { amount: result.hpDelta });
-      }
-    }
     this._clampInventorySelection();
     this._emitInventoryState();
   }
@@ -1246,83 +1152,8 @@ export class GameScene extends Phaser.Scene {
       this.player.inventory,
       equippedIds,
     );
+    this._shopBuyTotal = vm.buyItemsCount ?? vm.buyItems?.length ?? vm.items?.length ?? 0;
     EventBus.emit(EVENTS.SHOP_UPDATED, vm);
-  }
-
-  private _castSpell(slotIndex: 0 | 1): void {
-    if (this._currentArea !== 'dungeon') return;
-    const result = this._spellCastingSystem.cast(
-      slotIndex, this.player, this._spellSystem, this._enemies, Date.now(),
-    );
-    if (!result) return;
-
-    if (result.hitEnemies.length === 0) {
-      EventBus.emit(EVENTS.UI_LOG, `${result.spellName} — nenhum alvo adjacente.`);
-      return;
-    }
-
-    for (const enemy of result.hitEnemies) {
-      enemy.takeDamage(result.damage, this.events);
-      EventBus.emit(EVENTS.UI_LOG, `${result.spellName} causou ${result.damage} de dano!`);
-
-      if (!enemy.alive) {
-        const pos = enemy.getPixelPos();
-        this._showDamageText(pos, result.damage, COLORS.XP_TEXT);
-        this._removeEnemySprite(enemy);
-        const xpGain = enemy.xpReward ?? 0;
-        if (xpGain > 0) this.xpSystem.addXP(this.player, xpGain);
-      } else {
-        this._syncEnemySprite(enemy);
-        this._showDamageText(enemy.getPixelPos(), result.damage, COLORS.XP_TEXT);
-        if (enemy.sprite) this._flashSprite(enemy.sprite);
-      }
-    }
-  }
-
-
-  private _emitStatusState(): void {
-    const p = this.player;
-    const xpNext = this.xpSystem.getXPToNextLevel(p.level);
-    EventBus.emit(EVENTS.STATUS_STATE_RESPONSE, {
-      level: p.level, xp: p.xp, xpNext,
-      hp: p.hp, maxHp: p.maxHp, mana: p.mana, maxMana: p.maxMana,
-      str: p.str, intel: p.intel, dex: p.dex, con: p.con, wis: p.wis, cha: p.cha,
-      attack: p.attack, freePoints: p.freePoints,
-    });
-  }
-
-  private _emitSpellsState(): void {
-    const nowMs = Date.now();
-    const slots = this._spellSystem.getSlots();
-    const activeSlots = slots.map((slot, i) => ({
-      slotIndex: i as 0 | 1,
-      key: (i === 0 ? 'J' : 'K') as 'J' | 'K',
-      spellId: slot.spellId,
-      spellName: slot.spellId ? (SPELLS_DB[slot.spellId]?.name ?? '?') : '—',
-      cooldownRatio: this._spellSystem.getCooldownRatio(i as 0 | 1, nowMs),
-    }));
-
-    const unlockedSpells = this.player.unlockedSpells.map(id => {
-      const def = SPELLS_DB[id];
-      const isEquipped = slots.some(s => s.spellId === id);
-      return {
-        id,
-        name: def?.name ?? id,
-        element: def?.element ?? 'arcane',
-        damage: def?.damage ?? 0,
-        manaCost: def?.manaCost ?? 0,
-        cooldownMs: def?.cooldownMs ?? 0,
-        isEquipped,
-        isSelected: false,
-      };
-    });
-
-    EventBus.emit(EVENTS.SPELLS_STATE_RESPONSE, {
-      activeSlots,
-      unlockedSpells,
-      selectedSpellId: null,
-      playerMana: this.player.mana,
-    });
   }
 
   private _removeEnemySprite(enemy: EnemySystem): void {
@@ -1390,50 +1221,16 @@ export class GameScene extends Phaser.Scene {
     this.events.on(EVENTS.PLAYER_DIED, () => {
       this.gameState = GAME_STATE.GAME_OVER;
       EventBus.emit(EVENTS.UI_LOG, 'Você morreu.');
-
-      // Registrar evento de morte na memória
-      this._recordGameEvent('PLAYER_DEATH', {
-        floor: this.floorManager?.currentFloor ?? 1,
-        level: this.player.level,
-      });
-
-      // Gerar história da run de forma assíncrona (não bloqueia)
-      const importantEvents = this._eventMemory.getImportantEvents(10);
-      this._narrativeService.generateDeathStory(importantEvents)
-        .then((story) => {
-          EventBus.emit(EVENTS.DEATH_STORY_GENERATED, { story });
-        });
-
       this.cameras.main.flash(500, 255, 0, 0);
       this.time.delayedCall(600, () => {
         this.scene.stop('UIScene');
-        this.scene.start('GameOverScene', {
-          level:         this.player.level,
-          xp:            this.player.xp,
-          events:        this._eventMemory.getImportantEvents(10),
-          // Métricas da partida
-          turnsSurvived: this.playerMetrics.turnsSurvived,
-          damageDealt:   this.playerMetrics.damageDealt,
-          damageTaken:   this.playerMetrics.damageTaken,
-          enemiesKilled: this.playerMetrics.enemiesKilled,
-          itemsUsed:     this.playerMetrics.itemsUsed,
-          floorsReached: this.floorManager?.currentFloor ?? 1,
-        });
+        this.scene.start('GameOverScene', { level: this.player.level, xp: this.player.xp });
       });
     });
 
     this.events.on(EVENTS.PLAYER_LEVELED_UP, (data: { level: number; maxHp: number; attack: number }) => {
       this._showDamageText(this.player.getPixelPos(), `NÍVEL ${data.level}!`, COLORS.LEVEL_UP_TEXT);
       EventBus.emit(EVENTS.UI_LOG, `Subiu para o Nível ${data.level}!`);
-      // Desbloquear magias para o novo nível
-      const newSpells = this._spellSystem.unlockSpellsForLevel(this.player, data.level);
-      for (const id of newSpells) {
-        const spell = SPELLS_DB[id];
-        if (spell) {
-          EventBus.emit(EVENTS.UI_LOG, `Magia desbloqueada: ${spell.name}!`);
-          EventBus.emit(EVENTS.SPELL_UNLOCKED, { id, name: spell.name });
-        }
-      }
     });
 
     // Feedback visual: dano no inimigo (número amarelo + flash)
@@ -1451,12 +1248,6 @@ export class GameScene extends Phaser.Scene {
     this.events.on(EVENTS.DAMAGE_PLAYER, (data: { pos: { x: number; y: number }; damage: number }) => {
       this._showDamageText(data.pos, data.damage, COLORS.DAMAGE_TEXT);
       this._flashSprite(this.player);
-      // Registrar dano na memória narrativa
-      this._recordGameEvent('PLAYER_DAMAGED', { damage: data.damage });
-      // Verificar quase-morte (HP <= 20% do máximo)
-      if (this.player.hp > 0 && this.player.hp <= Math.floor(this.player.maxHp * 0.2)) {
-        this._recordGameEvent('PLAYER_NEAR_DEATH', { hp: this.player.hp });
-      }
     });
 
     EventBus.on(EVENTS.ITEM_DROPPED, this._handleItemDropped, this);
@@ -1464,43 +1255,6 @@ export class GameScene extends Phaser.Scene {
     // Responde com estado do inventário quando UIScene solicitar
     EventBus.on(EVENTS.INVENTORY_STATE_REQUESTED, () => {
       this._emitInventoryState();
-    }, this);
-
-    // Sincroniza aba local quando UIScene muda via clique
-    EventBus.on(EVENTS.INVENTORY_TAB_CHANGED, (data: { tab: 'inventory' | 'status' | 'spells'; _fromKeyboard?: boolean }) => {
-      if (!data._fromKeyboard) {
-        this._inventoryTab = data.tab;
-        this._spellsFocus = 'tabs';
-      }
-    }, this);
-
-    // Responde com estado de status quando solicitado
-    EventBus.on(EVENTS.STATUS_STATE_REQUESTED, () => {
-      this._emitStatusState();
-    }, this);
-
-    // Responde com estado das magias quando solicitado
-    EventBus.on(EVENTS.SPELLS_STATE_REQUESTED, () => {
-      this._emitSpellsState();
-    }, this);
-
-    // Gasta ponto de atributo
-    EventBus.on(EVENTS.STAT_POINT_SPENT_REQUEST, (data: { stat: string }) => {
-      const valid = ['str', 'intel', 'dex', 'con', 'wis'] as const;
-      if (valid.includes(data.stat as typeof valid[number])) {
-        const spent = this.player.spendStatPoint(data.stat as typeof valid[number]);
-        if (spent) this._emitStatusState();
-      }
-    }, this);
-
-    // Equipar magia em slot
-    EventBus.on(EVENTS.SPELL_EQUIP_REQUEST, (data: { slotIndex: 0 | 1; spellId: string | null }) => {
-      if (data.spellId) {
-        this._spellSystem.equipSpell(this.player, data.spellId, data.slotIndex);
-      } else {
-        this._spellSystem.unequipSpell(this.player, data.slotIndex);
-      }
-      this._emitSpellsState();
     }, this);
 
     // Abre a loja quando o mercador é interagido
@@ -1532,28 +1286,24 @@ export class GameScene extends Phaser.Scene {
       this._emitShopState();
     }, this);
 
-    // Mouse: clique em item do inventário — seleciona e executa ação primária
-    EventBus.on(EVENTS.INVENTORY_ITEM_CLICKED, (data: { index: number }) => {
-      if (!this.inputMode.is('INVENTORY')) return;
-      const inv = this.player.inventory;
-      const item = inv.getItem(data.index);
-      if (!item) return;
+    // Troca de aba na loja via clique
+    EventBus.on(EVENTS.SHOP_TAB_SWITCHED, (data: { tab: 'buy' | 'sell' }) => {
+      if (!this.inputMode.is('SHOP')) return;
+      this._shopTab = data.tab;
+      this._shopSelectedIndex = 0;
+      this._emitShopState();
+    }, this);
 
-      if (this._inventorySelectedIndex === data.index) {
-        // Segundo clique no mesmo item → executa ação primária
-        this._inventoryPrimaryAction();
-      } else {
-        // Primeiro clique → apenas seleciona
-        this._inventorySelectedIndex = data.index;
-        this._emitInventorySelectionChanged();
+    // Equipar flechas no slot extra sincroniza player.arrows
+    EventBus.on(EVENTS.ITEM_EQUIPPED, (data: { itemId: string; slotId: EquipmentSlotId }) => {
+      if (data.slotId === 'extra') {
+        const equippedItem = this.player.inventory.items.find(i => i?.id === data.itemId);
+        if (equippedItem?.type.startsWith('arrows')) {
+          this.player.arrows = equippedItem.quantity ?? 0;
+          EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: this.player.arrows });
+        }
       }
     }, this);
-  }
-
-  // ─── Narrativa: registro de eventos ─────────────────────────────────────
-
-  private _recordGameEvent(type: GameEventType, data: Record<string, unknown> = {}): void {
-    this._eventMemory.addEvent({ type, timestamp: Date.now(), data });
   }
 
   private _handleDialogInput(): void {

--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -1,0 +1,53 @@
+import * as Phaser from 'phaser';
+
+export class MainMenuScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'MainMenuScene' });
+  }
+
+  create(): void {
+    const { width, height } = this.scale;
+
+    const bg = this.add.image(width / 2, height / 2, 'game_bg');
+    bg.setDisplaySize(width, height);
+
+    this.add.text(width / 2, height * 0.25, 'Dungeon of Echoes', {
+      fontSize: '36px',
+      color: '#ffd700',
+      fontFamily: 'monospace',
+      stroke: '#000000',
+      strokeThickness: 4,
+    }).setOrigin(0.5);
+
+    this._makeButton(width / 2, height * 0.50, 'Novo Jogo', () => {
+      this.scene.start('GameScene');
+    });
+
+    this._makeButton(width / 2, height * 0.62, 'Créditos', () => {
+      this.scene.start('CreditsScene');
+    });
+
+    this.add.text(width - 12, height - 12, `Equipe 7\nv${__APP_VERSION__}`, {
+      fontSize: '13px',
+      color: '#cccccc',
+      fontFamily: 'monospace',
+      align: 'right',
+    }).setOrigin(1, 1);
+  }
+
+  private _makeButton(x: number, y: number, label: string, onClick: () => void): void {
+    const btn = this.add.text(x, y, label, {
+      fontSize: '24px',
+      color: '#ffffff',
+      fontFamily: 'monospace',
+      backgroundColor: '#333355',
+      padding: { x: 20, y: 10 },
+      stroke: '#000000',
+      strokeThickness: 2,
+    }).setOrigin(0.5).setInteractive({ useHandCursor: true });
+
+    btn.on('pointerover', () => btn.setStyle({ color: '#ffd700' }));
+    btn.on('pointerout', () => btn.setStyle({ color: '#ffffff' }));
+    btn.on('pointerdown', onClick);
+  }
+}

--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -20,7 +20,7 @@ export class MainMenuScene extends Phaser.Scene {
     }).setOrigin(0.5);
 
     this._makeButton(width / 2, height * 0.50, 'Novo Jogo', () => {
-      this.scene.start('GameScene');
+      this.scene.start('CharacterSelectScene');
     });
 
     this._makeButton(width / 2, height * 0.62, 'Créditos', () => {

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -440,7 +440,7 @@ export class UIScene extends Phaser.Scene {
 
     const xpY = PANEL_Y + 32;
     this._levelLabel = this.add
-      .text(PANEL_X, xpY, 'Nv 1  ATK 10', TEXT_STYLE)
+      .text(PANEL_X, xpY, 'Nv 1', TEXT_STYLE)
       .setScrollFactor(0).setDepth(d + 1);
     this._xpLabel = this.add
       .text(PANEL_X, xpY + 12, 'XP: 0 / 100', TEXT_STYLE)
@@ -651,7 +651,7 @@ export class UIScene extends Phaser.Scene {
 
   private _onLevelUp(data: { level: number; maxHp: number; attack: number; freePoints?: number }): void {
     if (!this.sys.isActive()) return;
-    this._levelLabel.setText(`Nv ${data.level}  ATK ${data.attack}`);
+    this._levelLabel.setText(`Nv ${data.level}`);
     if (this._statusPanel.isVisible()) {
       EventBus.emit(EVENTS.STATUS_STATE_REQUESTED, { timestamp: Date.now() });
     }

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -43,6 +43,10 @@ export class UIScene extends Phaser.Scene {
   private _xpLabel!: Phaser.GameObjects.Text;
   private _goldLabel!: Phaser.GameObjects.Text;
 
+  // Classe e flechas
+  private _classLabel!: Phaser.GameObjects.Text;
+  private _arrowLabel!: Phaser.GameObjects.Text;
+
   // Log
   private _logSystem!: LogSystem;
   private _logPanel!: LogPanel;
@@ -445,19 +449,49 @@ export class UIScene extends Phaser.Scene {
       .text(PANEL_X, xpY + 24, 'Ouro: 500', { ...TEXT_STYLE, color: '#ffd700' })
       .setScrollFactor(0).setDepth(d + 1);
 
-    // Ajustar altura do fundo do painel de stats para acomodar nova linha
+    // Badge de classe
+    this._classLabel = this.add
+      .text(PANEL_X, xpY + 36, '', { ...TEXT_STYLE, color: '#a78bfa' })
+      .setScrollFactor(0).setDepth(d + 1);
+
+    // Contador de flechas (Arqueiro)
+    this._arrowLabel = this.add
+      .text(PANEL_X, xpY + 48, '', { ...TEXT_STYLE, color: '#fbbf24' })
+      .setScrollFactor(0).setDepth(d + 1).setVisible(false);
+
+    // Fundo do painel de stats (altura extra para acomodar classe e flechas)
     this.add
-      .rectangle(0, 0, panelW, 70, 0x000000, 0.55)
+      .rectangle(0, 0, panelW, 88, 0x000000, 0.55)
       .setOrigin(0, 0).setScrollFactor(0).setDepth(d - 1);
   }
 
   // ─── Registro de Eventos ──────────────────────────────────────────────────
+
+  setClassInfo(label: string, usesArrows: boolean, arrows: number): void {
+    if (!this.sys.isActive()) return;
+    this._classLabel.setText(`[${label}]`);
+    this._arrowLabel.setVisible(usesArrows);
+    if (usesArrows) this._updateArrowLabel(arrows);
+  }
+
+  private _updateArrowLabel(arrows: number): void {
+    this._arrowLabel.setText(`>> ${arrows} flechas`);
+    this._arrowLabel.setStyle({ color: arrows < 20 ? '#ef4444' : '#fbbf24' });
+  }
 
   private _registerEvents(): void {
     EventBus.on(EVENTS.PLAYER_HP_CHANGED,   this._onHPChanged,    this);
     EventBus.on(EVENTS.PLAYER_MANA_CHANGED, this._onManaChanged,  this);
     EventBus.on(EVENTS.PLAYER_XP_CHANGED,   this._onXPChanged,    this);
     EventBus.on(EVENTS.PLAYER_LEVELED_UP,   this._onLevelUp,      this);
+    EventBus.on(EVENTS.ARROWS_CHANGED, (data: { arrows: number }) => {
+      if (!this.sys.isActive()) return;
+      this._updateArrowLabel(data.arrows);
+    }, this);
+    EventBus.on(EVENTS.CLASS_INFO, (data: { label: string; usesArrows: boolean; arrows: number }) => {
+      if (!this.sys.isActive()) return;
+      this.setClassInfo(data.label, data.usesArrows, data.arrows);
+    }, this);
     EventBus.on(EVENTS.ITEM_PICKED_UP,      this._onItemPickedUp, this);
     EventBus.on(EVENTS.ITEM_USED,           this._onItemUsed,     this);
 

--- a/src/systems/ClassRulesEngine.ts
+++ b/src/systems/ClassRulesEngine.ts
@@ -1,0 +1,98 @@
+import type { PlayerClassDef } from '../config/player-classes.config';
+import type { EquipmentSlotId } from '../types/equipment';
+import { PLAYER_CLASSES } from '../config/player-classes.config';
+
+/**
+ * ClassRulesEngine — serviço puro sem estado.
+ * Ponto central para todas as regras dependentes de classe.
+ * Nenhum outro sistema deve checar `classDef.id` diretamente — use este engine.
+ */
+export class ClassRulesEngine {
+  /**
+   * Retorna se a classe pode equipar o slot indicado.
+   * O slot 'extra' é sempre permitido para todas as classes.
+   * Para o slot 'sword', o Arqueiro pode equipar arco e o Mago pode equipar spellbook.
+   */
+  static canEquipSlot(classDef: PlayerClassDef, slotId: EquipmentSlotId, itemType?: string): boolean {
+    // Slot extra é aberto para todas as classes
+    if (slotId === 'extra') return true;
+
+    if (!classDef.forbiddenSlots.includes(slotId)) return true;
+
+    // Slot proibido — checar exceções por tipo de item
+    if (slotId === 'sword') {
+      if (classDef.id === 'arqueiro' && itemType === 'bow') return true;
+      if (classDef.id === 'mago'     && itemType === 'spellbook') return true;
+    }
+    return false;
+  }
+
+  /** Retorna se a classe pode executar um ataque corpo a corpo */
+  static canMelee(classDef: PlayerClassDef): boolean {
+    return classDef.canMelee;
+  }
+
+  /**
+   * Retorna se a classe pode executar um ataque agora.
+   * Para o Arqueiro, bloqueia se não houver flechas equipadas no slot extra.
+   *
+   * @param equippedExtraItemType - tipo do item equipado no slot extra (ou null/undefined)
+   */
+  static canAttack(classDef: PlayerClassDef, arrows: number, equippedExtraItemType?: string | null): boolean {
+    if (classDef.usesArrows) {
+      const hasArrowsEquipped = equippedExtraItemType?.startsWith('arrows') ?? false;
+      if (!hasArrowsEquipped || arrows <= 0) return false;
+    }
+    return true;
+  }
+
+  /** Multiplicador de dano físico recebido */
+  static physicalDamageMultiplier(classDef: PlayerClassDef): number {
+    return classDef.physicalDamageReceived;
+  }
+
+  /** Multiplicador de sorte nos drops (> 1 = mais itens/raridade) */
+  static luckMultiplier(classDef: PlayerClassDef): number {
+    return classDef.luckMultiplier;
+  }
+
+  /** Chance adicional de dropar um segundo item */
+  static extraDropChance(classDef: PlayerClassDef): number {
+    return classDef.extraDropChance;
+  }
+
+  /** Multiplicador no custo de mana das magias */
+  static manaCostMultiplier(classDef: PlayerClassDef): number {
+    return classDef.manaCostMultiplier;
+  }
+
+  /** Mana regenerada por turno */
+  static manaRegenPerTurn(classDef: PlayerClassDef): number {
+    return classDef.manaRegenPerTurn;
+  }
+
+  /**
+   * Raio efetivo de detecção dos inimigos para esta classe.
+   * Arqueiro/Mago elevam o bias → inimigos os detectam de mais longe e perseguem com mais força.
+   */
+  static effectiveDetectionRadius(classDef: PlayerClassDef, baseRadius: number): number {
+    return baseRadius + classDef.enemyApproachBias * 4;
+  }
+
+  /**
+   * Retorna se esta classe pode desbloquear uma spell.
+   * Spells listadas em `exclusiveSpells` de outra classe ficam bloqueadas.
+   */
+  static canUnlockSpell(classDef: PlayerClassDef, spellId: string): boolean {
+    for (const other of PLAYER_CLASSES) {
+      if (other.id === classDef.id) continue;
+      if (other.exclusiveSpells.includes(spellId)) return false;
+    }
+    return true;
+  }
+
+  /** Custo de mana efetivo de uma spell para esta classe */
+  static effectiveManaCost(classDef: PlayerClassDef, baseManaCost: number): number {
+    return Math.max(1, Math.round(baseManaCost * classDef.manaCostMultiplier));
+  }
+}

--- a/src/systems/ClassRulesEngine.ts
+++ b/src/systems/ClassRulesEngine.ts
@@ -38,11 +38,8 @@ export class ClassRulesEngine {
    *
    * @param equippedExtraItemType - tipo do item equipado no slot extra (ou null/undefined)
    */
-  static canAttack(classDef: PlayerClassDef, arrows: number, equippedExtraItemType?: string | null): boolean {
-    if (classDef.usesArrows) {
-      const hasArrowsEquipped = equippedExtraItemType?.startsWith('arrows') ?? false;
-      if (!hasArrowsEquipped || arrows <= 0) return false;
-    }
+  static canAttack(classDef: PlayerClassDef, arrows: number): boolean {
+    if (classDef.usesArrows && arrows <= 0) return false;
     return true;
   }
 

--- a/src/systems/CombatSystem.ts
+++ b/src/systems/CombatSystem.ts
@@ -40,7 +40,7 @@ export class CombatSystem {
   }
 
   resolve(
-    player: { hp: number; maxHp: number; attack: number; xp: number; level: number; getPixelPos?: () => { x: number; y: number } },
+    player: { hp: number; maxHp: number; attack: number; xp: number; level: number; critChance?: number; getPixelPos?: () => { x: number; y: number } },
     enemy: { hp: number; maxHp: number; attack: number; xpReward: number; alive: boolean; getPixelPos?: () => { x: number; y: number } },
   ): CombatResult | null {
     if (!player || !enemy) return null;
@@ -53,12 +53,14 @@ export class CombatSystem {
       playerDied: false,
     };
 
-    // Player ataca
-    result.playerDamage = player.attack;
-    enemy.hp = Math.max(0, enemy.hp - player.attack);
-    this.emitter.emit(EVENTS.COMBAT_HIT, { attacker: player, defender: enemy, damage: player.attack });
+    // Player ataca — DEX concede chance de crítico (1.5x dano)
+    const isCrit = Math.random() < (player.critChance ?? 0);
+    const playerDmg = isCrit ? Math.floor(player.attack * 1.5) : player.attack;
+    result.playerDamage = playerDmg;
+    enemy.hp = Math.max(0, enemy.hp - playerDmg);
+    this.emitter.emit(EVENTS.COMBAT_HIT, { attacker: player, defender: enemy, damage: playerDmg, crit: isCrit });
     if (enemy.getPixelPos) {
-      this.emitter.emit(EVENTS.DAMAGE_ENEMY, { pos: enemy.getPixelPos(), damage: player.attack });
+      this.emitter.emit(EVENTS.DAMAGE_ENEMY, { pos: enemy.getPixelPos(), damage: playerDmg });
     }
 
     if (enemy.hp <= 0) {

--- a/src/systems/CombatSystem.ts
+++ b/src/systems/CombatSystem.ts
@@ -1,5 +1,5 @@
 import * as Phaser from 'phaser';
-import { EVENTS, DEV_CONFIG } from '../utils/constants';
+import { EVENTS } from '../utils/constants';
 import type { XPSystem } from './XPSystem';
 
 export interface CombatResult {
@@ -40,8 +40,9 @@ export class CombatSystem {
   }
 
   resolve(
-    player: { hp: number; maxHp: number; attack: number; xp: number; level: number; critChance?: number; getPixelPos?: () => { x: number; y: number } },
+    player: { hp: number; maxHp: number; attack: number; xp: number; level: number; getPixelPos?: () => { x: number; y: number } },
     enemy: { hp: number; maxHp: number; attack: number; xpReward: number; alive: boolean; getPixelPos?: () => { x: number; y: number } },
+    _equippedExtraItemType?: string | null,
   ): CombatResult | null {
     if (!player || !enemy) return null;
     if (!enemy.alive) return null;
@@ -53,14 +54,12 @@ export class CombatSystem {
       playerDied: false,
     };
 
-    // Player ataca — DEX concede chance de crítico (1.5x dano)
-    const isCrit = Math.random() < (player.critChance ?? 0);
-    const playerDmg = isCrit ? Math.floor(player.attack * 1.5) : player.attack;
-    result.playerDamage = playerDmg;
-    enemy.hp = Math.max(0, enemy.hp - playerDmg);
-    this.emitter.emit(EVENTS.COMBAT_HIT, { attacker: player, defender: enemy, damage: playerDmg, crit: isCrit });
+    // Player ataca
+    result.playerDamage = player.attack;
+    enemy.hp = Math.max(0, enemy.hp - player.attack);
+    this.emitter.emit(EVENTS.COMBAT_HIT, { attacker: player, defender: enemy, damage: player.attack });
     if (enemy.getPixelPos) {
-      this.emitter.emit(EVENTS.DAMAGE_ENEMY, { pos: enemy.getPixelPos(), damage: playerDmg });
+      this.emitter.emit(EVENTS.DAMAGE_ENEMY, { pos: enemy.getPixelPos(), damage: player.attack });
     }
 
     if (enemy.hp <= 0) {
@@ -73,7 +72,7 @@ export class CombatSystem {
 
     // Inimigo contra-ataca
     result.enemyDamage = enemy.attack;
-    if (!DEV_CONFIG.godMode) player.hp = Math.max(0, player.hp - enemy.attack);
+    player.hp = Math.max(0, player.hp - enemy.attack);
     this.emitter.emit(EVENTS.COMBAT_HIT, { attacker: enemy, defender: player, damage: enemy.attack });
     if (player.getPixelPos) {
       this.emitter.emit(EVENTS.DAMAGE_PLAYER, { pos: player.getPixelPos(), damage: enemy.attack });

--- a/src/systems/EnemySystem.ts
+++ b/src/systems/EnemySystem.ts
@@ -1,9 +1,11 @@
 import * as Phaser from 'phaser';
 import { ENEMY, EVENTS, TILE_SIZE } from '../utils/constants';
+import { ClassRulesEngine } from './ClassRulesEngine';
 import type { DungeonGenerator, GridPos } from '../generators/DungeonGenerator';
 import type { FloorDifficulty } from '../config/difficulty.config';
 import { pickEnemyDef, buildAnimKey } from '../config/enemies.config';
 import type { EnemyCategory } from '../config/enemies.config';
+import type { PlayerClassDef } from '../config/player-classes.config';
 
 export type EnemyState = 'IDLE' | 'CHASING' | 'ATTACKING';
 
@@ -78,6 +80,7 @@ export class EnemySystem {
     playerGridY: number,
     dungeon: DungeonGenerator,
     allEnemies: EnemySystem[],
+    playerClassDef?: PlayerClassDef,
   ): EnemyAttackResult {
     if (!this.alive) return { attacked: false, damage: 0 };
 
@@ -86,14 +89,20 @@ export class EnemySystem {
     const manhattan = Math.abs(dx) + Math.abs(dy);
     const adjacent  = manhattan === 1;
 
-    // Raio de detecção ampliado para inimigos agressivos
-    const effectiveRadius = this.aggressionLevel > 0.7
+    // Raio de detecção: ampliado por aggressionLevel e pelo bias da classe do player
+    const baseRadius = this.aggressionLevel > 0.7
       ? this.detectionRadius * 1.5
       : this.detectionRadius;
+    const effectiveRadius = playerClassDef
+      ? ClassRulesEngine.effectiveDetectionRadius(playerClassDef, baseRadius)
+      : baseRadius;
 
-    // Detecção: dentro do raio OU mesma sala (sempre para agressivos)
+    // Detecção: dentro do raio OU mesma sala (sempre para agressivos ou vs ranged)
+    const alwaysChase = this.aggressionLevel > 0.7 ||
+      (playerClassDef ? playerClassDef.enemyApproachBias >= 1.0 : false);
+
     const detected = manhattan <= effectiveRadius ||
-      (this.aggressionLevel > 0.7) ||
+      alwaysChase ||
       this._isInSameRoom(playerGridX, playerGridY, dungeon);
 
     if (detected) {
@@ -103,7 +112,9 @@ export class EnemySystem {
     if (this.state === 'IDLE') return { attacked: false, damage: 0 };
 
     // Inimigos pouco agressivos têm chance de ficar idle mesmo detectando
-    if (this.aggressionLevel < 0.3 && Math.random() > this.aggressionLevel + 0.3) {
+    // (mas não quando enfrentam classes ranged — eles sempre perseguem)
+    const approachBias = playerClassDef?.enemyApproachBias ?? 0;
+    if (this.aggressionLevel < 0.3 && approachBias < 0.5 && Math.random() > this.aggressionLevel + 0.3) {
       return { attacked: false, damage: 0 };
     }
 

--- a/src/systems/EnemySystem.ts
+++ b/src/systems/EnemySystem.ts
@@ -29,6 +29,8 @@ export class EnemySystem {
    * Definido pelo DifficultyManager no momento do spawn.
    */
   aggressionLevel: number;
+  isElite: boolean = false;
+  aiName: string | null = null;
 
   sprite: Phaser.GameObjects.Sprite | null = null;
   hpBar: Phaser.GameObjects.Rectangle | null = null;

--- a/src/systems/EnemySystem.ts
+++ b/src/systems/EnemySystem.ts
@@ -2,6 +2,8 @@ import * as Phaser from 'phaser';
 import { ENEMY, EVENTS, TILE_SIZE } from '../utils/constants';
 import type { DungeonGenerator, GridPos } from '../generators/DungeonGenerator';
 import type { FloorDifficulty } from '../config/difficulty.config';
+import { pickEnemyDef, buildAnimKey } from '../config/enemies.config';
+import type { EnemyCategory } from '../config/enemies.config';
 
 export type EnemyState = 'IDLE' | 'CHASING' | 'ATTACKING';
 
@@ -31,6 +33,21 @@ export class EnemySystem {
   aggressionLevel: number;
   isElite: boolean = false;
   aiName: string | null = null;
+
+  // ── Dados visuais e de identidade (definidos em enemies.config.ts) ──────────
+  /** Categoria DawnLike — determina o par de spritesheets e a animação. */
+  category: EnemyCategory = 'undead';
+  /** Índice do frame no spritesheet (mesmo em *0.png e *1.png). */
+  frameIndex: number = 0;
+  /** Identificador da definição de inimigo (enemies.config.ts). */
+  enemyDefId: string = 'skeleton';
+  /** Nome de exibição base (pode ser sobrescrito por aiName em elites). */
+  enemyName: string = 'Inimigo';
+  /**
+   * Chave da animação Phaser registrada em BootScene.
+   * Pré-calculada no spawn para evitar reconstrução a cada frame.
+   */
+  animKey: string = '';
 
   sprite: Phaser.GameObjects.Sprite | null = null;
   hpBar: Phaser.GameObjects.Rectangle | null = null;
@@ -186,12 +203,24 @@ export function createEnemies(
 
     if (!occupied.has(`${pos.x},${pos.y}`)) {
       occupied.add(`${pos.x},${pos.y}`);
-      const enemy = new EnemySystem(pos.x, pos.y, i);
-      enemy.hp             = Math.round(ENEMY.HP        * hpScale);
-      enemy.maxHp          = Math.round(ENEMY.HP        * hpScale);
-      enemy.attack         = Math.round(ENEMY.ATTACK    * atkScale);
-      enemy.xpReward       = Math.round(ENEMY.XP_REWARD * xpScale);
-      enemy.aggressionLevel = aggression;
+
+      // Seleção procedural: escolhe um EnemyDef válido para o andar atual.
+      // O scaling de HP/ATK/XP é aplicado em cima dos valores base do def,
+      // mantendo compatibilidade total com difficulty.config.ts e AIIntegration.
+      const def = pickEnemyDef(floor);
+
+      const enemy            = new EnemySystem(pos.x, pos.y, i);
+      enemy.hp               = Math.round(def.hpBase     * hpScale);
+      enemy.maxHp            = Math.round(def.hpBase     * hpScale);
+      enemy.attack           = Math.round(def.damageBase * atkScale);
+      enemy.xpReward         = Math.round(def.xpBase     * xpScale);
+      enemy.aggressionLevel  = aggression;
+      enemy.category         = def.category;
+      enemy.frameIndex       = def.frameIndex;
+      enemy.enemyDefId       = def.id;
+      enemy.enemyName        = def.name;
+      enemy.animKey          = buildAnimKey(def.category, def.frameIndex);
+
       enemies.push(enemy);
     }
   }

--- a/src/systems/EquipmentSystem.ts
+++ b/src/systems/EquipmentSystem.ts
@@ -1,12 +1,18 @@
 import { EventBus } from '../utils/EventBus';
 import { EVENTS } from '../utils/constants';
+import { ClassRulesEngine } from './ClassRulesEngine';
 import {
   EQUIPMENT_SLOT_ORDER,
   type EquipmentSlotId,
   type EquipResult,
 } from '../types/equipment';
+import type { PlayerClassDef } from '../config/player-classes.config';
 
 export type { EquipmentSlotId, EquipResult };
+
+interface SlotMeta {
+  noUnequip?: boolean;
+}
 
 export class EquipmentSystem {
   private _equipped: Record<EquipmentSlotId, string | null> = {
@@ -16,11 +22,38 @@ export class EquipmentSystem {
     pants:  null,
     boots:  null,
     amulet: null,
+    ring:   null,
+    extra:  null,
   };
 
-  equip(itemId: string, slotId: EquipmentSlotId): EquipResult {
+  private _equippedMeta: Record<string, SlotMeta> = {};
+
+  /**
+   * Equipa um item no slot indicado.
+   *
+   * @param itemId  - ID do item a equipar
+   * @param slotId  - Slot de destino
+   * @param classDef - Definição de classe do jogador (para validação de regras)
+   * @param item    - Metadados opcionais do item (type, noUnequip)
+   */
+  equip(
+    itemId: string,
+    slotId: EquipmentSlotId,
+    classDef?: PlayerClassDef,
+    item?: { noUnequip?: boolean; type?: string },
+  ): EquipResult {
+    // Validação de regras de classe (se classDef fornecido)
+    if (classDef && !ClassRulesEngine.canEquipSlot(classDef, slotId, item?.type)) {
+      return {
+        success: false,
+        message: `Sua classe não pode equipar este item neste slot.`,
+        previousItemId: null,
+      };
+    }
+
     const previousItemId = this._equipped[slotId];
     this._equipped[slotId] = itemId;
+    this._equippedMeta[slotId] = { noUnequip: item?.noUnequip ?? false };
 
     EventBus.emit(EVENTS.ITEM_EQUIPPED, {
       itemId,
@@ -39,11 +72,18 @@ export class EquipmentSystem {
     };
   }
 
+  /**
+   * Desequipa o item no slot indicado.
+   * Retorna null se o slot estiver vazio ou se o item tem noUnequip=true.
+   */
   unequip(slotId: EquipmentSlotId): string | null {
+    if (this._equippedMeta[slotId]?.noUnequip) return null;
+
     const itemId = this._equipped[slotId];
     if (!itemId) return null;
 
     this._equipped[slotId] = null;
+    delete this._equippedMeta[slotId];
     EventBus.emit(EVENTS.ITEM_UNEQUIPPED, { itemId, slotId, timestamp: Date.now() });
     return itemId;
   }
@@ -64,5 +104,6 @@ export class EquipmentSystem {
     for (const slotId of EQUIPMENT_SLOT_ORDER) {
       this._equipped[slotId] = null;
     }
+    this._equippedMeta = {};
   }
 }

--- a/src/systems/LootSystem.ts
+++ b/src/systems/LootSystem.ts
@@ -3,6 +3,7 @@ import { EventBus } from '../utils/EventBus';
 import { EVENTS } from '../utils/constants';
 import { ClassRulesEngine } from './ClassRulesEngine';
 import type { PlayerClassDef } from '../config/player-classes.config';
+import type { EquippableItemType, EquipmentSlotId, ItemRarity, StatBonuses } from '../types/equipment';
 
 // Tabela de loot por andar — ouro é a recompensa principal e deve ser frequente.
 const LOOT_TABLE: Array<{ nothing: number; potion: number; gold: number }> = [
@@ -63,6 +64,94 @@ function rollOne(gridX: number, gridY: number, floor: number, elite: boolean, id
   return { item, nextId: id + 1 };
 }
 
+export interface ChestLootResult {
+  type: 'gold' | 'potion' | 'equipment' | 'mimic';
+  item?: Item;
+  mimicDamage?: number;
+}
+
+// Pools de equipamentos por tier de andar
+const EQUIPMENT_POOL_MID: Array<{ type: EquippableItemType; slot: EquipmentSlotId; name: string }> = [
+  { type: 'sword_iron',      slot: 'sword',  name: 'Espada de Ferro' },
+  { type: 'helmet_leather',  slot: 'helmet', name: 'Capacete de Couro' },
+  { type: 'shield_wood',     slot: 'shield', name: 'Escudo de Madeira' },
+  { type: 'boots_leather',   slot: 'boots',  name: 'Botas de Couro' },
+  { type: 'pants_leather',   slot: 'pants',  name: 'Calça de Couro' },
+  { type: 'amulet_stone',    slot: 'amulet', name: 'Amuleto de Pedra' },
+];
+
+const EQUIPMENT_POOL_ADVANCED: Array<{ type: EquippableItemType; slot: EquipmentSlotId; name: string }> = [
+  { type: 'sword_steel',     slot: 'sword',  name: 'Espada de Aço' },
+  { type: 'sword_silver',    slot: 'sword',  name: 'Espada de Prata' },
+  { type: 'helmet_bronze',   slot: 'helmet', name: 'Capacete de Bronze' },
+  { type: 'helmet_iron',     slot: 'helmet', name: 'Capacete de Ferro' },
+  { type: 'shield_iron',     slot: 'shield', name: 'Escudo de Ferro' },
+  { type: 'shield_steel',    slot: 'shield', name: 'Escudo de Aço' },
+  { type: 'pants_iron',      slot: 'pants',  name: 'Calça de Ferro' },
+  { type: 'boots_iron',      slot: 'boots',  name: 'Botas de Ferro' },
+  { type: 'boots_swift',     slot: 'boots',  name: 'Botas Velozes' },
+  { type: 'amulet_silver',   slot: 'amulet', name: 'Amuleto de Prata' },
+  { type: 'amulet_gold',     slot: 'amulet', name: 'Amuleto de Ouro' },
+  { type: 'ring_silver',     slot: 'ring',   name: 'Anel de Prata' },
+  { type: 'ring_enchanted',  slot: 'ring',   name: 'Anel Encantado' },
+];
+
+const EQUIPMENT_POOL_ELITE: Array<{ type: EquippableItemType; slot: EquipmentSlotId; name: string }> = [
+  { type: 'sword_obsidian',  slot: 'sword',  name: 'Espada de Obsidiana' },
+  { type: 'sword_dragon',    slot: 'sword',  name: 'Espada do Dragão' },
+  { type: 'helmet_mithril',  slot: 'helmet', name: 'Capacete de Mithril' },
+  { type: 'shield_runic',    slot: 'shield', name: 'Escudo Rúnico' },
+  { type: 'shield_aegis',    slot: 'shield', name: 'Égide' },
+  { type: 'pants_mithril',   slot: 'pants',  name: 'Calça de Mithril' },
+  { type: 'boots_ethereal',  slot: 'boots',  name: 'Botas Etéreas' },
+  { type: 'amulet_arcane',   slot: 'amulet', name: 'Amuleto Arcano' },
+  { type: 'amulet_eternal',  slot: 'amulet', name: 'Amuleto Eterno' },
+  { type: 'ring_void',       slot: 'ring',   name: 'Anel do Vazio' },
+];
+
+function pickEquipmentPool(floor: number) {
+  if (floor >= 10) return EQUIPMENT_POOL_ELITE;
+  if (floor >= 6)  return EQUIPMENT_POOL_ADVANCED;
+  return EQUIPMENT_POOL_MID;
+}
+
+function equipmentRarity(floor: number): ItemRarity {
+  if (floor >= 10) return Math.random() < 0.3 ? 'epic' : 'rare';
+  if (floor >= 6)  return Math.random() < 0.4 ? 'rare' : 'uncommon';
+  return 'common';
+}
+
+function equipmentBonuses(slot: EquipmentSlotId, floor: number): StatBonuses {
+  const scale = Math.ceil(floor / 2);
+  const bonusMap: Record<EquipmentSlotId, StatBonuses> = {
+    sword:  { attack: 3 + scale, str: 1 + Math.floor(scale / 2) },
+    helmet: { con: 2 + scale,    maxHp: 5 + scale * 3 },
+    shield: { con: 1 + scale,    maxHp: 3 + scale * 2 },
+    pants:  { dex: 1 + scale,    maxHp: 2 + scale * 2 },
+    boots:  { dex: 2 + scale },
+    amulet: { wis: 1 + scale,    int: 1 + scale },
+    ring:   { str: 1 + scale,    dex: 1 + scale },
+    extra:  { maxMana: 5 + scale * 3 },
+  };
+  return bonusMap[slot];
+}
+
+function generateEquipmentForFloor(floor: number, id: number): Item {
+  const pool = pickEquipmentPool(floor);
+  const entry = pool[Math.floor(Math.random() * pool.length)];
+  const rarity = equipmentRarity(floor);
+  const bonuses = equipmentBonuses(entry.slot, floor);
+  const price = 20 + floor * 15 + Math.floor(Math.random() * 20);
+
+  const item = new Item(`chest_eq_${id}`, entry.type, null, null);
+  item.name    = entry.name;
+  item.slotId  = entry.slot;
+  item.rarity  = rarity;
+  item.bonuses = bonuses;
+  item.price   = price;
+  return item;
+}
+
 /**
  * LootSystem — decide e emite drops de inimigos.
  * Puro: sem dependência de Phaser. A Scene cria o sprite ao receber ITEM_DROPPED.
@@ -106,5 +195,51 @@ export class LootSystem {
     }
 
     return primary;
+  }
+
+  /**
+   * Rola o loot de um baú baseado no andar atual.
+   * Não emite evento — a GameScene processa o resultado diretamente.
+   */
+  rollChestLoot(floor: number): ChestLootResult {
+    const r = Math.random();
+
+    // Andar inicial (1-2): ouro ou poção
+    if (floor <= 2) {
+      if (r < 0.60) {
+        const item = new Item(`chest_gold_${this._nextId++}`, 'gold', null, null);
+        item.goldAmount = pickGoldAmount(floor + 1); // baú dá sempre mais que drop comum
+        return { type: 'gold', item };
+      }
+      const potionType = Math.random() < 0.5 ? pickHealTier(floor) : pickManaTier(floor);
+      return { type: 'potion', item: new Item(`chest_pot_${this._nextId++}`, potionType, null, null) };
+    }
+
+    // Andar intermediário (3-5): ouro, poção ou mímica
+    if (floor <= 5) {
+      if (r < 0.50) {
+        const item = new Item(`chest_gold_${this._nextId++}`, 'gold', null, null);
+        item.goldAmount = pickGoldAmount(floor + 2);
+        return { type: 'gold', item };
+      }
+      if (r < 0.80) {
+        const potionType = Math.random() < 0.5 ? pickHealTier(floor) : pickManaTier(floor);
+        return { type: 'potion', item: new Item(`chest_pot_${this._nextId++}`, potionType, null, null) };
+      }
+      const mimicDamage = 15 + Math.floor(Math.random() * 11); // 15-25
+      return { type: 'mimic', mimicDamage };
+    }
+
+    // Andar avançado (6+): equipamento, ouro grande ou poção forte
+    if (r < 0.50) {
+      return { type: 'equipment', item: generateEquipmentForFloor(floor, this._nextId++) };
+    }
+    if (r < 0.80) {
+      const item = new Item(`chest_gold_${this._nextId++}`, 'gold', null, null);
+      item.goldAmount = pickGoldAmount(floor + 3);
+      return { type: 'gold', item };
+    }
+    const potionType = Math.random() < 0.5 ? pickHealTier(floor) : pickManaTier(floor);
+    return { type: 'potion', item: new Item(`chest_pot_${this._nextId++}`, potionType, null, null) };
   }
 }

--- a/src/systems/LootSystem.ts
+++ b/src/systems/LootSystem.ts
@@ -1,6 +1,8 @@
 import { Item, ItemType } from '../entities/Item';
 import { EventBus } from '../utils/EventBus';
 import { EVENTS } from '../utils/constants';
+import { ClassRulesEngine } from './ClassRulesEngine';
+import type { PlayerClassDef } from '../config/player-classes.config';
 
 // Tabela de loot por andar — ouro é a recompensa principal e deve ser frequente.
 const LOOT_TABLE: Array<{ nothing: number; potion: number; gold: number }> = [
@@ -34,10 +36,31 @@ function pickManaTier(floor: number): ManaTier {
 
 // Ouro: base maior e escala mais agressiva com o andar (±30% de variação)
 function pickGoldAmount(floor: number, elite = false): number {
-  const base = 5 + floor * 6;          // andar 1=11, 2=17, 3=23, 4=29, 5=35...
+  const base = 5 + floor * 6;
   const variance = Math.floor(base * 0.3);
   const amount = base + Math.floor(Math.random() * (variance * 2 + 1)) - variance;
   return elite ? Math.floor(amount * 1.8) : amount;
+}
+
+function rollOne(gridX: number, gridY: number, floor: number, elite: boolean, id: number): { item: Item | null; nextId: number } {
+  const t = getTable(floor);
+  const r = elite ? 1 : Math.random();
+
+  let type: ItemType | null = null;
+  let goldAmount: number | undefined;
+
+  if (r < t.nothing) {
+    return { item: null, nextId: id };
+  } else if (r < t.nothing + t.potion) {
+    type = Math.random() < 0.5 ? pickHealTier(floor) : pickManaTier(floor);
+  } else {
+    type = 'gold';
+    goldAmount = pickGoldAmount(floor, elite);
+  }
+
+  const item = new Item(`loot_${id}`, type, gridX, gridY);
+  if (goldAmount !== undefined) item.goldAmount = goldAmount;
+  return { item, nextId: id + 1 };
 }
 
 /**
@@ -49,29 +72,39 @@ export class LootSystem {
 
   /**
    * Roda a tabela de loot para a posição dada e emite ITEM_DROPPED se sortear item.
-   * @param floor - Andar atual; influencia chances e tier das recompensas.
-   * @returns O item dropado, ou null se não dropar nada.
+   * classDef opcional aplica luckMultiplier e extraDropChance do Aventureiro.
    */
-  roll(gridX: number, gridY: number, floor = 1, elite = false): Item | null {
+  roll(gridX: number, gridY: number, floor = 1, elite = false, classDef?: PlayerClassDef): Item | null {
+    const luck   = classDef ? ClassRulesEngine.luckMultiplier(classDef) : 1.0;
+    const extra  = classDef ? ClassRulesEngine.extraDropChance(classDef) : 0.0;
+
+    // Luck modifica a chance de "nada" — reduz proporcionalmente
     const t = getTable(floor);
-    // Elites têm 100% de chance de dropar ouro
+    const adjustedNothing = elite ? 0 : Math.max(0, t.nothing / luck);
     const r = elite ? 1 : Math.random();
+    const effectiveR = r < adjustedNothing ? 0 : r; // forçar drop se sorte reduziu threshold
 
-    let type: ItemType | null = null;
-    let goldAmount: number | undefined;
+    const { item, nextId } = rollOne(gridX, gridY, floor, elite, this._nextId);
+    this._nextId = nextId;
 
-    if (r < t.nothing) {
-      return null;
-    } else if (r < t.nothing + t.potion) {
-      type = Math.random() < 0.5 ? pickHealTier(floor) : pickManaTier(floor);
+    // Re-roll com ajuste de sorte: usar effectiveR reaproveitado ou rolar de novo
+    let primary: Item | null;
+    if (r < adjustedNothing) {
+      primary = null;
     } else {
-      type = 'gold';
-      goldAmount = pickGoldAmount(floor, elite);
+      void effectiveR; // usamos o item já rolado
+      primary = item;
     }
 
-    const item = new Item(`loot_${this._nextId++}`, type, gridX, gridY);
-    if (goldAmount !== undefined) item.goldAmount = goldAmount;
-    EventBus.emit(EVENTS.ITEM_DROPPED, { item });
-    return item;
+    if (primary) EventBus.emit(EVENTS.ITEM_DROPPED, { item: primary });
+
+    // Chance de drop extra (Aventureiro)
+    if (extra > 0 && Math.random() < extra) {
+      const { item: bonus, nextId: nextId2 } = rollOne(gridX, gridY, floor, false, this._nextId);
+      this._nextId = nextId2;
+      if (bonus) EventBus.emit(EVENTS.ITEM_DROPPED, { item: bonus });
+    }
+
+    return primary;
   }
 }

--- a/src/systems/LootSystem.ts
+++ b/src/systems/LootSystem.ts
@@ -2,15 +2,13 @@ import { Item, ItemType } from '../entities/Item';
 import { EventBus } from '../utils/EventBus';
 import { EVENTS } from '../utils/constants';
 
-// Tabela de loot por andar
-// Chances acumuladas: nada | poção | ouro
-// Pocão é rara; ouro é mais comum e escala com o andar.
+// Tabela de loot por andar — ouro é a recompensa principal e deve ser frequente.
 const LOOT_TABLE: Array<{ nothing: number; potion: number; gold: number }> = [
-  { nothing: 0.72, potion: 0.08, gold: 0.20 }, // andar 1
-  { nothing: 0.70, potion: 0.08, gold: 0.22 }, // andar 2
-  { nothing: 0.68, potion: 0.07, gold: 0.25 }, // andar 3
-  { nothing: 0.66, potion: 0.07, gold: 0.27 }, // andar 4
-  { nothing: 0.64, potion: 0.06, gold: 0.30 }, // andar 5+
+  { nothing: 0.50, potion: 0.08, gold: 0.42 }, // andar 1
+  { nothing: 0.47, potion: 0.08, gold: 0.45 }, // andar 2
+  { nothing: 0.44, potion: 0.07, gold: 0.49 }, // andar 3
+  { nothing: 0.41, potion: 0.07, gold: 0.52 }, // andar 4
+  { nothing: 0.38, potion: 0.06, gold: 0.56 }, // andar 5+
 ];
 
 function getTable(floor: number) {
@@ -34,11 +32,12 @@ function pickManaTier(floor: number): ManaTier {
   return r < 0.15 ? 'potion_mana_light' : r < 0.55 ? 'potion_mana' : 'potion_mana_high';
 }
 
-// Ouro: valor base escala com o andar (±30% de variação)
-function pickGoldAmount(floor: number): number {
-  const base = 3 + floor * 4;          // andar 1=7, 2=11, 3=15, 4=19, 5=23...
+// Ouro: base maior e escala mais agressiva com o andar (±30% de variação)
+function pickGoldAmount(floor: number, elite = false): number {
+  const base = 5 + floor * 6;          // andar 1=11, 2=17, 3=23, 4=29, 5=35...
   const variance = Math.floor(base * 0.3);
-  return base + Math.floor(Math.random() * (variance * 2 + 1)) - variance;
+  const amount = base + Math.floor(Math.random() * (variance * 2 + 1)) - variance;
+  return elite ? Math.floor(amount * 1.8) : amount;
 }
 
 /**
@@ -53,9 +52,10 @@ export class LootSystem {
    * @param floor - Andar atual; influencia chances e tier das recompensas.
    * @returns O item dropado, ou null se não dropar nada.
    */
-  roll(gridX: number, gridY: number, floor = 1): Item | null {
+  roll(gridX: number, gridY: number, floor = 1, elite = false): Item | null {
     const t = getTable(floor);
-    const r = Math.random();
+    // Elites têm 100% de chance de dropar ouro
+    const r = elite ? 1 : Math.random();
 
     let type: ItemType | null = null;
     let goldAmount: number | undefined;
@@ -66,7 +66,7 @@ export class LootSystem {
       type = Math.random() < 0.5 ? pickHealTier(floor) : pickManaTier(floor);
     } else {
       type = 'gold';
-      goldAmount = pickGoldAmount(floor);
+      goldAmount = pickGoldAmount(floor, elite);
     }
 
     const item = new Item(`loot_${this._nextId++}`, type, gridX, gridY);

--- a/src/systems/ShopSystem.ts
+++ b/src/systems/ShopSystem.ts
@@ -49,6 +49,10 @@ export class ShopSystem {
       return { success: false, message: 'Este item não pode ser vendido.', goldGained: 0 };
     }
 
+    if (item.noSell) {
+      return { success: false, message: 'Este item não pode ser vendido.', goldGained: 0 };
+    }
+
     const goldGained = Math.floor(basePrice * SHOP.SELL_RATIO);
     inventory.removeItem(itemIndex);
     player.gold += goldGained;
@@ -73,7 +77,7 @@ export class ShopSystem {
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
       if (!item) continue;
-      const canSell = (item.price != null && item.price > 0) && !equippedIds.has(item.id);
+      const canSell = (item.price != null && item.price > 0) && !equippedIds.has(item.id) && !item.noSell;
       const sellPrice = Math.floor((item.price ?? 0) * SHOP.SELL_RATIO);
       result.push({
         inventoryIndex: i,
@@ -95,16 +99,20 @@ export class ShopSystem {
     inventory?: InventorySystem,
     equippedIds?: Set<string>,
   ): ShopViewModel {
-    const buyItems = this._catalog.map((entry, i) => ({
-      index:      i,
-      id:         entry.id,
-      name:       entry.name,
-      price:      entry.price,
-      rarity:     entry.rarity,
-      bonusText:  buildBonusText(entry.bonuses),
-      canAfford:  player.gold >= entry.price,
-      isSelected: tab === 'buy' && i === selectedIndex,
-    }));
+    let filteredIndex = 0;
+    const buyItems = this._catalog.map((entry) => {
+      const fi = filteredIndex++;
+      return {
+        index:      fi,
+        id:         entry.id,
+        name:       entry.name,
+        price:      entry.price,
+        rarity:     entry.rarity,
+        bonusText:  buildBonusText(entry.bonuses),
+        canAfford:  player.gold >= entry.price,
+        isSelected: tab === 'buy' && fi === selectedIndex,
+      };
+    });
 
     const sellItems: SellItemViewModel[] = (inventory && equippedIds)
       ? this.buildSellItems({ inventory }, equippedIds, tab === 'sell' ? selectedIndex : -1)
@@ -113,6 +121,7 @@ export class ShopSystem {
     return {
       items: buyItems,
       buyItems,
+      buyItemsCount: buyItems.length,
       sellItems,
       tab,
       playerGold: player.gold,

--- a/src/systems/SpellCastingSystem.ts
+++ b/src/systems/SpellCastingSystem.ts
@@ -15,6 +15,7 @@ const ADJACENT = [
 export type SpellCastResult = {
   success: boolean;
   damage: number;
+  heal?: number;
   spellName: string;
   hitEnemies: EnemySystem[];
 };
@@ -49,6 +50,14 @@ export class SpellCastingSystem {
     EventBus.emit(EVENTS.PLAYER_MANA_CHANGED, { mana: player.mana, maxMana: player.maxMana });
     spellSystem.recordCast(slotIndex, nowMs);
     EventBus.emit(EVENTS.SPELL_CAST, { slotIndex, spellId: spell.id });
+
+    // Magia de cura: aplica no player, não nos inimigos
+    if (spell.heal && spell.heal > 0) {
+      const healed = Math.min(spell.heal, player.maxHp - player.hp);
+      player.hp = Math.min(player.maxHp, player.hp + spell.heal);
+      EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: player.hp, maxHp: player.maxHp });
+      return { success: true, damage: 0, heal: healed, spellName: spell.name, hitEnemies: [] };
+    }
 
     // INT: adiciona bônus de dano mágico flat
     const effectiveDamage = spell.damage + (player.spellBonus ?? 0);

--- a/src/systems/SpellCastingSystem.ts
+++ b/src/systems/SpellCastingSystem.ts
@@ -33,7 +33,12 @@ export class SpellCastingSystem {
 
     const spell = SPELLS_DB[slot.spellId];
     if (!spell) return null;
-    if (!spellSystem.canCast(slotIndex, nowMs)) return null;
+
+    // WIS: reduz cooldown efetivo antes de checar se pode lançar
+    const effectiveCooldown = slot.cooldownMs * (1 - (player.cdReduction ?? 0));
+    const elapsed = nowMs - slot.lastCastMs;
+    if (elapsed < effectiveCooldown) return null;
+
     if (player.mana < spell.manaCost) return null;
 
     const targets = ADJACENT
@@ -45,6 +50,8 @@ export class SpellCastingSystem {
     spellSystem.recordCast(slotIndex, nowMs);
     EventBus.emit(EVENTS.SPELL_CAST, { slotIndex, spellId: spell.id });
 
-    return { success: true, damage: spell.damage, spellName: spell.name, hitEnemies: targets };
+    // INT: adiciona bônus de dano mágico flat
+    const effectiveDamage = spell.damage + (player.spellBonus ?? 0);
+    return { success: true, damage: effectiveDamage, spellName: spell.name, hitEnemies: targets };
   }
 }

--- a/src/systems/SpellSystem.ts
+++ b/src/systems/SpellSystem.ts
@@ -2,11 +2,14 @@ import { SPELLS_DB } from '../config/spells.db';
 import { SPELL_PROGRESSION } from '../config/spell-progression';
 import { EventBus } from '../utils/EventBus';
 import { EVENTS } from '../utils/constants';
+import { ClassRulesEngine } from './ClassRulesEngine';
 import type { SpellSlotState } from '../types/spells';
+import type { PlayerClassDef } from '../config/player-classes.config';
 
 type SpellPlayer = {
   unlockedSpells: string[];
   equippedSpells: [string | null, string | null];
+  classDef?: PlayerClassDef;
 };
 
 export class SpellSystem {
@@ -20,11 +23,20 @@ export class SpellSystem {
     const added: string[] = [];
     for (const id of ids) {
       if (!player.unlockedSpells.includes(id)) {
+        // Pular spells exclusivas de outras classes
+        if (player.classDef && !ClassRulesEngine.canUnlockSpell(player.classDef, id)) continue;
         player.unlockedSpells.push(id);
         added.push(id);
       }
     }
     return added;
+  }
+
+  /** Custo efetivo de mana de uma spell considerando a classe do player */
+  getManaCost(spellId: string, classDef?: PlayerClassDef): number {
+    const base = SPELLS_DB[spellId]?.manaCost ?? 0;
+    if (!classDef) return base;
+    return ClassRulesEngine.effectiveManaCost(classDef, base);
   }
 
   equipSpell(player: SpellPlayer, spellId: string, slotIndex: 0 | 1): boolean {

--- a/src/systems/TurnManager.ts
+++ b/src/systems/TurnManager.ts
@@ -1,5 +1,6 @@
 import { TILE_SIZE, EVENTS, INVENTORY, DEV_CONFIG } from '../utils/constants';
 import { EventBus } from '../utils/EventBus';
+import { ClassRulesEngine } from './ClassRulesEngine';
 import type { Player } from '../entities/Player';
 import type { EnemySystem } from './EnemySystem';
 import type { CombatSystem } from './CombatSystem';
@@ -58,11 +59,30 @@ export class TurnManager {
       }
     } else if (action.type === 'ATTACK') {
       const target = action.target;
+
+      // Verificar se a classe pode atacar (Mago não pode corpo a corpo; Arqueiro precisa de flechas)
+      if (!ClassRulesEngine.canMelee(player.classDef) && !player.classDef.usesArrows) {
+        result.messages.push(`${player.classDef.label} não pode atacar corpo a corpo. Use magias!`);
+        this.playerTurn = true;
+        return result;
+      }
+      if (!ClassRulesEngine.canAttack(player.classDef, player.arrows)) {
+        result.messages.push('Sem flechas! Compre mais na loja.');
+        this.playerTurn = true;
+        return result;
+      }
+
       const atk = combat.attack(player, target);
       if (atk.hit) {
         target.hp = Math.max(0, target.hp - atk.damage);
         metrics?.recordDamageDealt(atk.damage);
-        result.messages.push(`Você atacou e causou ${atk.damage} de dano`);
+        const verb = player.classDef.usesArrows ? 'atirou e causou' : 'atacou e causou';
+        result.messages.push(`Você ${verb} ${atk.damage} de dano`);
+        // Consumir flecha
+        if (player.classDef.usesArrows) {
+          player.arrows = Math.max(0, player.arrows - 1);
+          EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: player.arrows });
+        }
         if (target.hp <= 0) {
           target.alive = false;
           result.enemiesDied.push(target);
@@ -108,15 +128,17 @@ export class TurnManager {
     for (const enemy of enemies) {
       if (!enemy.alive) continue;
 
-      const ai = enemy.update(player.gridX, player.gridY, dungeon, enemies);
+      const ai = enemy.update(player.gridX, player.gridY, dungeon, enemies, player.classDef);
 
       if (ai.attacked) {
         const atk = combat.attack(enemy, player);
         if (atk.hit) {
-          if (!DEV_CONFIG.godMode) player.hp = Math.max(0, player.hp - atk.damage);
-          metrics?.recordDamageTaken(atk.damage);
+          const rawDmg = atk.damage;
+          const reduced = Math.max(1, Math.round(rawDmg * ClassRulesEngine.physicalDamageMultiplier(player.classDef)));
+          if (!DEV_CONFIG.godMode) player.hp = Math.max(0, player.hp - reduced);
+          metrics?.recordDamageTaken(reduced);
           EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: player.hp, maxHp: player.maxHp });
-          result.messages.push(`Inimigo atacou você por ${atk.damage}`);
+          result.messages.push(`Inimigo atacou você por ${reduced}`);
           if (player.hp <= 0) {
             result.playerDied = true;
             metrics?.recordDeath();

--- a/src/systems/XPSystem.ts
+++ b/src/systems/XPSystem.ts
@@ -7,6 +7,8 @@ type PlayerLike = {
   level: number;
   maxHp: number;
   hp: number;
+  maxMana?: number;
+  mana?: number;
   attack: number;
   freePoints?: number;
   recalcStats?: () => void;
@@ -64,6 +66,7 @@ export class XPSystem {
     }
 
     player.hp = player.maxHp;
+    if (player.maxMana !== undefined) player.mana = player.maxMana;
 
     this.emitter.emit(EVENTS.PLAYER_LEVELED_UP, {
       level: player.level,
@@ -73,5 +76,8 @@ export class XPSystem {
     });
 
     EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: player.hp, maxHp: player.maxHp });
+    if (player.mana !== undefined && player.maxMana !== undefined) {
+      EventBus.emit(EVENTS.PLAYER_MANA_CHANGED, { mana: player.mana, maxMana: player.maxMana });
+    }
   }
 }

--- a/src/systems/XPSystem.ts
+++ b/src/systems/XPSystem.ts
@@ -74,6 +74,12 @@ export class XPSystem {
       attack: player.attack,
       freePoints: player.freePoints ?? 0,
     });
+    EventBus.emit(EVENTS.PLAYER_LEVELED_UP, {
+      level: player.level,
+      maxHp: player.maxHp,
+      attack: player.attack,
+      freePoints: player.freePoints ?? 0,
+    });
 
     EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: player.hp, maxHp: player.maxHp });
     if (player.mana !== undefined && player.maxMana !== undefined) {

--- a/src/types/equipment.ts
+++ b/src/types/equipment.ts
@@ -1,4 +1,4 @@
-export type EquipmentSlotId = 'helmet' | 'shield' | 'sword' | 'pants' | 'boots' | 'amulet' | 'ring';
+export type EquipmentSlotId = 'helmet' | 'shield' | 'sword' | 'pants' | 'boots' | 'amulet' | 'ring' | 'extra';
 
 export interface StatBonuses {
   str?: number;
@@ -19,10 +19,11 @@ export const EQUIPMENT_SLOT_LABELS: Record<EquipmentSlotId, string> = {
   boots:  'Bota',
   amulet: 'Amuleto',
   ring:   'Anel',
+  extra:  'Extra',
 };
 
 export const EQUIPMENT_SLOT_ORDER: EquipmentSlotId[] = [
-  'helmet', 'shield', 'sword', 'pants', 'boots', 'amulet', 'ring',
+  'helmet', 'shield', 'sword', 'pants', 'boots', 'amulet', 'ring', 'extra',
 ];
 
 export type EquippableItemType =
@@ -32,7 +33,9 @@ export type EquippableItemType =
   | 'pants_leather' | 'pants_iron' | 'pants_mithril' | 'pants_shadow'
   | 'boots_leather' | 'boots_iron' | 'boots_swift' | 'boots_ethereal'
   | 'amulet_stone' | 'amulet_silver' | 'amulet_gold' | 'amulet_arcane' | 'amulet_eternal'
-  | 'ring_copper' | 'ring_silver' | 'ring_enchanted' | 'ring_void';
+  | 'ring_copper' | 'ring_silver' | 'ring_enchanted' | 'ring_void'
+  | 'bow' | 'spellbook'
+  | 'arrows_20' | 'arrows_50' | 'arrows_100';
 
 export type ItemRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
 

--- a/src/types/spells.ts
+++ b/src/types/spells.ts
@@ -6,6 +6,7 @@ export interface SpellDef {
   name: string;
   element: SpellElement;
   damage: number;
+  heal?: number;        // se > 0, cura o player em vez de atacar
   manaCost: number;
   cooldownMs: number;
   projectileSpeed: number;

--- a/src/types/viewmodels.ts
+++ b/src/types/viewmodels.ts
@@ -63,52 +63,9 @@ export interface ShopViewModel {
   /** @deprecated use buyItems */
   items: ShopItemViewModel[];
   buyItems: ShopItemViewModel[];
+  buyItemsCount?: number;
   sellItems: SellItemViewModel[];
   tab: 'buy' | 'sell';
   playerGold: number;
   selectedIndex: number;
-}
-
-export interface StatusViewModel {
-  level: number;
-  xp: number;
-  xpNext: number;
-  hp: number;
-  maxHp: number;
-  mana: number;
-  maxMana: number;
-  str: number;
-  intel: number;
-  dex: number;
-  con: number;
-  wis: number;
-  cha: number;
-  attack: number;
-  freePoints: number;
-}
-
-export interface SpellSlotViewModel {
-  slotIndex: 0 | 1;
-  key: 'J' | 'K';
-  spellId: string | null;
-  spellName: string;
-  cooldownRatio: number;
-}
-
-export interface SpellListItemViewModel {
-  id: string;
-  name: string;
-  element: string;
-  damage: number;
-  manaCost: number;
-  cooldownMs: number;
-  isEquipped: boolean;
-  isSelected: boolean;
-}
-
-export interface SpellsViewModel {
-  activeSlots: SpellSlotViewModel[];
-  unlockedSpells: SpellListItemViewModel[];
-  selectedSpellId: string | null;
-  playerMana: number;
 }

--- a/src/ui/ActionBarPanel.ts
+++ b/src/ui/ActionBarPanel.ts
@@ -86,7 +86,7 @@ export class ActionBarPanel {
       case 'potion_mana_light':
       case 'potion_mana':
       case 'potion_mana_high':  return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_MANA };
-      case 'gold':              return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD };
+      case 'gold':              return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD_SMALL };
     }
   }
 }

--- a/src/ui/ShopPanel.ts
+++ b/src/ui/ShopPanel.ts
@@ -28,11 +28,9 @@ const TEXT_GOLD: Phaser.Types.GameObjects.Text.TextStyle = {
 };
 
 const RARITY_COLORS: Record<string, string> = {
-  common:    '#aaaaaa',
-  uncommon:  '#55ff55',
-  rare:      '#aaaaff',
-  epic:      '#cc44ff',
-  legendary: '#ffaa00',
+  common:   '#aaaaaa',
+  uncommon: '#55ff55',
+  rare:     '#aaaaff',
 };
 
 export class ShopPanel {
@@ -92,6 +90,14 @@ export class ShopPanel {
     this._tabSellBg = scene.add.rectangle(ox + padding + tabW + 4, oy + 26, tabW, 14, EMPTY_COLOR).setOrigin(0, 0);
     this._tabBuyTxt  = scene.add.text(ox + padding + tabW / 2, oy + 28, 'Comprar', { ...TEXT_BASE, fontSize: '9px' }).setOrigin(0.5, 0);
     this._tabSellTxt = scene.add.text(ox + padding + tabW + 4 + tabW / 2, oy + 28, 'Vender', { ...TEXT_DIM, fontSize: '9px' }).setOrigin(0.5, 0);
+
+    // Abas clicáveis
+    this._tabBuyBg
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', () => EventBus.emit(EVENTS.SHOP_TAB_SWITCHED, { tab: 'buy' }));
+    this._tabSellBg
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', () => EventBus.emit(EVENTS.SHOP_TAB_SWITCHED, { tab: 'sell' }));
 
     const divLine = scene.add.rectangle(ox + listW, oy + 30, 1, panelH - 40, PANEL_BORDER, 0.5).setOrigin(0, 0);
     const detailLabel = scene.add.text(ox + listW + padding, oy + 30, 'DETALHES', { ...TEXT_BASE, color: '#8888cc' });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -168,6 +168,8 @@ export const EVENTS = {
   // Seleção de inventário
   INVENTORY_SELECTION_CHANGED: 'inventory-selection-changed',
   INVENTORY_ITEM_CLICKED: 'inventory-item-clicked',
+  // Classe do personagem
+  CLASS_INFO: 'class-info',
   // Moedas
   PLAYER_GOLD_CHANGED: 'player-gold-changed',
   ARROWS_CHANGED:      'arrows-changed',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -68,7 +68,7 @@ export const DAWNLIKE_FRAMES = {
   ENEMY: 0,           // Undead0.png — esqueleto (frame fixo)
   PLATINO: 0,         // Reptiles0.png — lagartixa do DragonDePlatino (easter egg)
   POTION_HEAL: 0,     // Potion.png — frasco vermelho (poção de cura)
-  POTION_POISON: 7,   // Potion.png — frasco azul (poção de veneno)
+  POTION_MANA: 7,     // Potion.png — frasco azul (poção de mana)
   GOLD: 0,            // Money.png — moeda de ouro (frame fixo)
 };
 
@@ -120,10 +120,14 @@ export const GAME_STATE = {
 // --- Inventário ---
 export const INVENTORY = {
   MAX_SLOTS: 20,
-  POTION_HEAL_AMOUNT: 10,
-  POTION_POISON_AMOUNT: 5,
-  ITEM_SPAWN_MIN: 3,
-  ITEM_SPAWN_MAX: 6,
+  POTION_HEAL_LIGHT_AMOUNT:  10,
+  POTION_HEAL_AMOUNT:        25,
+  POTION_HEAL_HIGH_AMOUNT:   50,
+  POTION_MANA_LIGHT_AMOUNT:  15,
+  POTION_MANA_AMOUNT:        30,
+  POTION_MANA_HIGH_AMOUNT:   60,
+  ITEM_SPAWN_MIN: 1,
+  ITEM_SPAWN_MAX: 3,
 };
 
 // --- Eventos ---
@@ -163,21 +167,41 @@ export const EVENTS = {
   INPUT_MODE_CHANGED: 'input-mode-changed',
   // Seleção de inventário
   INVENTORY_SELECTION_CHANGED: 'inventory-selection-changed',
+  INVENTORY_ITEM_CLICKED: 'inventory-item-clicked',
   // Moedas
   PLAYER_GOLD_CHANGED: 'player-gold-changed',
-  // Flechas
-  ARROWS_CHANGED: 'arrows-changed',
+  ARROWS_CHANGED:      'arrows-changed',
   // Loja
   SHOP_OPENED:  'shop-opened',
   SHOP_CLOSED:  'shop-closed',
   SHOP_UPDATED: 'shop-updated',
-  SHOP_TAB_SWITCHED:      'shop_tab_switched',
   SHOP_ITEM_HOVERED:      'shop-item-hovered',
   SHOP_ITEM_SELECTED:     'shop-item-selected',
+  SHOP_TAB_SWITCHED:      'shop-tab-switched',
   // Diálogo
   DIALOG_OPENED:          'dialog-opened',
   DIALOG_CLOSED:          'dialog-closed',
   DIALOG_OPTION_SELECTED: 'dialog-option-selected',
+  // Pontos de atributo
+  STAT_POINT_SPENT_REQUEST: 'stat-point-spent-request',
+  STAT_POINT_SPENT:         'stat-point-spent',
+  // Magias
+  SPELL_UNLOCKED:        'spell-unlocked',
+  SPELL_EQUIPPED:        'spell-equipped',
+  SPELL_CAST:            'spell-cast',
+  // Painel I — abas
+  INVENTORY_TAB_CHANGED: 'inventory-tab-changed',
+  // Status
+  STATUS_STATE_REQUESTED: 'status-state-requested',
+  STATUS_STATE_RESPONSE:  'status-state-response',
+  // Magias
+  SPELLS_STATE_REQUESTED:   'spells-state-requested',
+  SPELLS_STATE_RESPONSE:    'spells-state-response',
+  SPELL_EQUIP_REQUEST:      'spell-equip-request',
+  SPELLS_SELECTION_CHANGED: 'spells-selection-changed',
+  // Narrativa emergente (Fase 6)
+  NARRATIVE_GENERATED:      'narrative-generated',
+  DEATH_STORY_GENERATED:    'death-story-generated',
 } as const;
 
 // --- Loja ---
@@ -232,3 +256,9 @@ export const AI = {
   CACHE_MAX_SIZE: 100,          // Máximo de entradas no cache
   REQUEST_TIMEOUT: 5000,        // Timeout de 5s para chamadas LLM
 } as const;
+
+// ─── Configurações de desenvolvimento ────────────────────────────────────────
+export const DEV_CONFIG = {
+  godMode: false,  // true → player não toma dano
+  devMode: false,  // true → pula o menu principal e inicia direto na GameScene
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -69,7 +69,10 @@ export const DAWNLIKE_FRAMES = {
   PLATINO: 0,         // Reptiles0.png — lagartixa do DragonDePlatino (easter egg)
   POTION_HEAL: 0,     // Potion.png — frasco vermelho (poção de cura)
   POTION_MANA: 7,     // Potion.png — frasco azul (poção de mana)
-  GOLD: 0,            // Money.png — moeda de ouro (frame fixo)
+  GOLD_SMALL:  10,    // Money.png Row 2 Col 3 — moeda única (pouca quantidade)
+  GOLD_MEDIUM:  9,    // Money.png Row 2 Col 2 — poucas moedas agrupadas
+  GOLD_LARGE:   8,    // Money.png Row 2 Col 1 — pilha grande de moedas
+  CHEST:       14,    // Money.png Row 2 Col 7 — baú vermelho fechado
 };
 
 // --- Chaves dos spritesheets carregados na BootScene ---

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -258,4 +258,5 @@ export const AI = {
 // ─── Configurações de desenvolvimento ────────────────────────────────────────
 export const DEV_CONFIG = {
   godMode: false,  // true → player não toma dano
+  devMode: false,  // true → pula o menu principal e inicia direto na GameScene
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -68,7 +68,7 @@ export const DAWNLIKE_FRAMES = {
   ENEMY: 0,           // Undead0.png — esqueleto (frame fixo)
   PLATINO: 0,         // Reptiles0.png — lagartixa do DragonDePlatino (easter egg)
   POTION_HEAL: 0,     // Potion.png — frasco vermelho (poção de cura)
-  POTION_MANA: 7,     // Potion.png — frasco azul (poção de mana)
+  POTION_POISON: 7,   // Potion.png — frasco azul (poção de veneno)
   GOLD: 0,            // Money.png — moeda de ouro (frame fixo)
 };
 
@@ -120,14 +120,10 @@ export const GAME_STATE = {
 // --- Inventário ---
 export const INVENTORY = {
   MAX_SLOTS: 20,
-  POTION_HEAL_LIGHT_AMOUNT:  10,
-  POTION_HEAL_AMOUNT:        25,
-  POTION_HEAL_HIGH_AMOUNT:   50,
-  POTION_MANA_LIGHT_AMOUNT:  15,
-  POTION_MANA_AMOUNT:        30,
-  POTION_MANA_HIGH_AMOUNT:   60,
-  ITEM_SPAWN_MIN: 1,
-  ITEM_SPAWN_MAX: 3,
+  POTION_HEAL_AMOUNT: 10,
+  POTION_POISON_AMOUNT: 5,
+  ITEM_SPAWN_MIN: 3,
+  ITEM_SPAWN_MAX: 6,
 };
 
 // --- Eventos ---
@@ -167,39 +163,21 @@ export const EVENTS = {
   INPUT_MODE_CHANGED: 'input-mode-changed',
   // Seleção de inventário
   INVENTORY_SELECTION_CHANGED: 'inventory-selection-changed',
-  INVENTORY_ITEM_CLICKED: 'inventory-item-clicked',
   // Moedas
   PLAYER_GOLD_CHANGED: 'player-gold-changed',
+  // Flechas
+  ARROWS_CHANGED: 'arrows-changed',
   // Loja
   SHOP_OPENED:  'shop-opened',
   SHOP_CLOSED:  'shop-closed',
   SHOP_UPDATED: 'shop-updated',
+  SHOP_TAB_SWITCHED:      'shop_tab_switched',
   SHOP_ITEM_HOVERED:      'shop-item-hovered',
   SHOP_ITEM_SELECTED:     'shop-item-selected',
   // Diálogo
   DIALOG_OPENED:          'dialog-opened',
   DIALOG_CLOSED:          'dialog-closed',
   DIALOG_OPTION_SELECTED: 'dialog-option-selected',
-  // Pontos de atributo
-  STAT_POINT_SPENT_REQUEST: 'stat-point-spent-request',
-  STAT_POINT_SPENT:         'stat-point-spent',
-  // Magias
-  SPELL_UNLOCKED:        'spell-unlocked',
-  SPELL_EQUIPPED:        'spell-equipped',
-  SPELL_CAST:            'spell-cast',
-  // Painel I — abas
-  INVENTORY_TAB_CHANGED: 'inventory-tab-changed',
-  // Status
-  STATUS_STATE_REQUESTED: 'status-state-requested',
-  STATUS_STATE_RESPONSE:  'status-state-response',
-  // Magias
-  SPELLS_STATE_REQUESTED:   'spells-state-requested',
-  SPELLS_STATE_RESPONSE:    'spells-state-response',
-  SPELL_EQUIP_REQUEST:      'spell-equip-request',
-  SPELLS_SELECTION_CHANGED: 'spells-selection-changed',
-  // Narrativa emergente (Fase 6)
-  NARRATIVE_GENERATED:      'narrative-generated',
-  DEATH_STORY_GENERATED:    'death-story-generated',
 } as const;
 
 // --- Loja ---
@@ -254,9 +232,3 @@ export const AI = {
   CACHE_MAX_SIZE: 100,          // Máximo de entradas no cache
   REQUEST_TIMEOUT: 5000,        // Timeout de 5s para chamadas LLM
 } as const;
-
-// ─── Configurações de desenvolvimento ────────────────────────────────────────
-export const DEV_CONFIG = {
-  godMode: false,  // true → player não toma dano
-  devMode: false,  // true → pula o menu principal e inicia direto na GameScene
-};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/tests/spell-system.test.js
+++ b/tests/spell-system.test.js
@@ -52,7 +52,7 @@ describe('SpellSystem — desbloqueio por nível', () => {
   });
 
   it('não adiciona magia duplicada se já desbloqueada', () => {
-    const player = makePlayer({ unlockedSpells: ['fire_bolt'] });
+    const player = makePlayer({ unlockedSpells: ['fire_bolt', 'minor_healing'] });
     const added = spellSystem.unlockSpellsForLevel(player, 1);
     expect(added).toHaveLength(0);
     expect(player.unlockedSpells.filter(s => s === 'fire_bolt')).toHaveLength(1);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import pkg from './package.json';
 
 export default defineConfig({
   server: {
@@ -12,5 +13,8 @@ export default defineConfig({
   },
   resolve: {
     extensions: ['.ts', '.js'],
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
 });


### PR DESCRIPTION
## Descrição

Implementação das classes de heróis (Guerreiro, Arqueiro, Mago) com mecânicas distintas de combate, correção de bugs críticos na loja, equip e animações de idle, e adição de tela inicial com menu principal e créditos.

---

## Tipo de mudança

- [x] `feat` — nova funcionalidade
- [x] `fix` — correção de bug

---

## O que foi feito

- Adicionado sistema de classes de personagem (`player-classes.config.ts`): Guerreiro (melee), Arqueiro (ranged com flechas + linha de visão Bresenham) e Mago (magic + livro equipado como noUnequip)
- Implementado `ClassRulesEngine` com regras de canAttack, canEquipSlot e validação de flechas para o Arqueiro
- Adicionado slot `extra` de equipamento aberto para todas as classes (acessório adicional)
- Corrigida seleção por teclado na loja (usava índice do catálogo bruto em vez do filtrado por `byItems`)
- Abas Comprar/Vender da loja agora respondem ao clique do mouse via evento `SHOP_TAB_SWITCHED`
- `EquipmentSystem` estendido com suporte a `noUnequip` por slot via `_equippedMeta`
- Adicionadas `MainMenuScene` e `CreditsScene` com tela inicial navegável
- Sprite e animação de idle da classe selecionada agora aplicados corretamente ao iniciar o jogo
- `EnemySystem` configurado via `enemies.config.ts` com 14 tipos de inimigos data-driven
- Corrigido `classDef`/`arrows` no `Player` e simplificado `canAttack` do Arqueiro

---

## Como testar

1. `npm install`
2. `npm run dev`
3. Na tela inicial, escolher uma classe (Guerreiro, Arqueiro ou Mago) e iniciar o jogo
4. Verificar que o sprite de idle corresponde à classe selecionada
5. Com o Arqueiro: tentar atacar sem flechas equipadas (deve bloquear) e com flechas no slot Extra (deve funcionar com range 4)
6. Abrir a loja (`S` ou interagir com NPC), navegar pelas abas Comprar/Vender com mouse e teclado
7. Com o Mago: verificar que o Livro de Magia não pode ser desequipado

---

## Evidências

<!-- Prints, GIFs, logs de console ou saída de testes. Apague se não aplicável. -->

---

## Checklist

- [x] Atualizei o `CHANGELOG.md`
- [x] Atualizei `docs/prompts/Vitor.md` (se usei IA neste PR)
- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser

---

## Observações

- O Mago ainda não possui fallback de ataque corpo a corpo quando sem mana — fica bloqueado. Ponto de atenção para o próximo PR.
- `GameScene.ts` está crescendo como classe deus (~1800 linhas); considerar extração de responsabilidades em iteração futura.
- `SpellCastingSystem` limita magias a tiles adjacentes — ranged spells ainda não implementadas.
