### PR TITLE
feat: fase 7 polish - fog of war, HUD floor label, game over fix, enemy highlight

### DIFF
--- a/.kiro/specs/fase7-polish/.config.kiro
+++ b/.kiro/specs/fase7-polish/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "f5c30d65-bba3-40a4-ba4a-3d044ea91ce2", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/fase7-polish/design.md
+++ b/.kiro/specs/fase7-polish/design.md
@@ -1,0 +1,102 @@
+# Design Técnico — Fase 7
+
+## Arquitetura Existente
+
+O projeto usa Phaser.js com TypeScript. A comunicação entre cenas é feita via `EventBus` (pub/sub global). A `UIScene` roda em paralelo com a `GameScene` e escuta eventos do `EventBus`.
+
+## Mudanças por Requisito
+
+### R1 + R6 — Floor Label no HUD
+
+**Arquivo:** `src/scenes/UIScene.ts`
+
+Adicionar um `_floorLabel: Phaser.GameObjects.Text` no painel de stats (abaixo do `_goldLabel`).
+
+Escutar o evento `EVENTS.AREA_CHANGED` no `_registerEvents()`:
+```ts
+EventBus.on(EVENTS.AREA_CHANGED, (data: { area: string; floor?: number }) => {
+  if (!this.sys.isActive() || !this._floorLabel?.active) return;
+  if (data.area === 'dungeon') {
+    this._floorLabel.setText(`Andar: ${data.floor ?? 1}`);
+  } else {
+    this._floorLabel.setText('Cidade');
+  }
+}, this);
+```
+
+Também registrar o off() no `shutdown()`.
+
+### R2 — Fog of War
+
+**Arquivo novo:** `src/systems/FogOfWarSystem.ts`
+
+```ts
+export class FogOfWarSystem {
+  private _visited: Set<string> = new Set();
+  private _visible: Set<string> = new Set();
+  private _overlays: Map<string, Phaser.GameObjects.Rectangle> = new Map();
+
+  update(scene: Phaser.Scene, tiles: Phaser.GameObjects.Image[], playerGridX: number, playerGridY: number, radius = 5): void
+  reset(): void
+}
+```
+
+A lógica:
+1. Calcular tiles visíveis (círculo de raio 5 ao redor do player)
+2. Adicionar tiles visíveis ao set `_visited`
+3. Para cada tile renderizado:
+   - Se visível: alpha = 1
+   - Se visitado mas não visível: alpha = 0.4
+   - Se não visitado: alpha = 0
+
+**Integração em `GameScene`:**
+- Instanciar `FogOfWarSystem` no `create()`
+- Chamar `fogOfWar.update()` após cada movimento do player na dungeon
+- Chamar `fogOfWar.reset()` no `_cleanup()`
+
+### R3 — Destaque de Inimigos Próximos
+
+**Arquivo:** `src/scenes/GameScene.ts`
+
+No método `_syncEnemySprite()`, adicionar lógica de tint:
+```ts
+const dist = Math.max(Math.abs(enemy.gridX - this.player.gridX), Math.abs(enemy.gridY - this.player.gridY));
+if (dist <= 3 && enemy.alive) {
+  enemy.sprite?.setTint(0xff8888);
+} else {
+  enemy.sprite?.clearTint();
+}
+```
+
+Cuidado: não sobrescrever o tint do flash de dano. Usar flag `_isFlashing` no EnemySystem ou verificar se o tween está ativo.
+
+### R4 — GameOverScene volta ao MainMenuScene
+
+**Arquivo:** `src/scenes/GameOverScene.ts`
+
+Mudar o método `_restart()`:
+```ts
+private _restart(): void {
+  this.scene.start('MainMenuScene');  // era 'GameScene'
+}
+```
+
+### R5 — Fluxo completo
+
+Verificar que `GameScene._registerEvents()` para `PLAYER_DIED` faz:
+1. `this.scene.stop('UIScene')`
+2. `this.scene.start('GameOverScene', { ...dados })`
+
+Isso já existe. Apenas garantir que `GameOverScene._restart()` vai para `MainMenuScene`.
+
+## Estrutura de Arquivos Modificados
+
+```
+src/
+  scenes/
+    UIScene.ts          — adicionar _floorLabel + listener AREA_CHANGED
+    GameOverScene.ts    — _restart() → MainMenuScene
+    GameScene.ts        — integrar FogOfWarSystem + destaque inimigos próximos
+  systems/
+    FogOfWarSystem.ts   — NOVO: fog of war
+```

--- a/.kiro/specs/fase7-polish/requirements.md
+++ b/.kiro/specs/fase7-polish/requirements.md
@@ -1,0 +1,27 @@
+# Fase 7 — Polimento, UI e Preparação para Demo
+
+## Requisitos Funcionais
+
+### R1 — HUD com indicador de Andar
+O HUD deve exibir o andar atual (floor) da dungeon. Quando o jogador estiver na cidade ou área bônus, deve exibir "Cidade". Quando estiver na dungeon, deve exibir "Andar: N".
+
+### R2 — Fog of War na Dungeon
+A dungeon deve implementar fog of war:
+- Tiles não visitados: completamente escuros (alpha 0 ou tint preto)
+- Tiles visitados mas fora do campo de visão: escurecidos (alpha ~0.4)
+- Tiles no campo de visão do player (raio 5): visíveis normalmente
+
+### R3 — Destaque de Inimigos Próximos
+Inimigos dentro de raio 3 tiles do player devem ter um tint levemente avermelhado para indicar perigo iminente.
+
+### R4 — GameOverScene volta ao MainMenuScene
+O botão "Jogar Novamente" e as teclas ENTER/SPACE na GameOverScene devem iniciar a `MainMenuScene` (não a `GameScene` diretamente), para que o jogador passe pela seleção de classe novamente.
+
+### R5 — Fluxo completo validado
+O fluxo Menu → CharacterSelect → Game → GameOver → Menu deve funcionar sem erros ou estados corrompidos.
+
+### R6 — Floor label no HUD
+A UIScene deve escutar o evento `AREA_CHANGED` e atualizar um label de floor visível no painel de stats.
+
+### R7 — Evento FLOOR_CHANGED no constants
+Adicionar `FLOOR_LABEL_CHANGED` ao objeto EVENTS em constants.ts para comunicar o andar atual à UIScene.

--- a/.kiro/specs/fase7-polish/tasks.md
+++ b/.kiro/specs/fase7-polish/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — Fase 7 Polimento
+
+- [x] 1. Adicionar Floor Label no HUD da UIScene
+  - Adicionar campo `_floorLabel: Phaser.GameObjects.Text` em `src/scenes/UIScene.ts`
+  - Criar o texto no método `_createStatsPanel()` após `_arrowLabel`, com texto inicial 'Cidade' e cor '#88ddff'
+  - Registrar listener para `EVENTS.AREA_CHANGED` em `_registerEvents()` que atualiza o label com 'Andar: N' ou 'Cidade'
+  - Adicionar `EventBus.off(EVENTS.AREA_CHANGED, undefined, this)` no `shutdown()`
+  - Aumentar altura do retângulo de fundo do painel de stats de 88 para 104
+  - _Requirements: R1, R6_
+
+- [x] 2. Corrigir GameOverScene para voltar ao MainMenuScene
+  - Em `src/scenes/GameOverScene.ts`, mudar `_restart()` de `this.scene.start('GameScene')` para `this.scene.start('MainMenuScene')`
+  - _Requirements: R4, R5_
+
+- [x] 3. Implementar FogOfWarSystem
+  - Criar `src/systems/FogOfWarSystem.ts` com classe `FogOfWarSystem`
+  - Implementar método `update(tiles, playerGridX, playerGridY, radius)` que calcula tiles visíveis (círculo de raio 5) e aplica alpha: 1 para visível, 0.35 para visitado, 0 para não visitado
+  - Implementar método `reset()` que limpa os sets de visitados e visíveis
+  - Usar `TILE_SIZE` de constants para calcular posição grid a partir de pixel
+  - _Requirements: R2_
+
+- [x] 4. Integrar FogOfWarSystem na GameScene
+  - Importar e instanciar `FogOfWarSystem` em `src/scenes/GameScene.ts`
+  - Chamar `_fogOfWar.reset()` no método `_cleanup()`
+  - Chamar `_fogOfWar.update()` após movimento do player na dungeon (dentro do bloco `result.playerMoved`)
+  - Chamar `_fogOfWar.update()` ao final de `_loadDungeonFloor()` após posicionar o player
+  - _Requirements: R2_
+
+- [ ] 5. Adicionar destaque visual em inimigos próximos
+  - Em `src/scenes/GameScene.ts`, modificar `_syncEnemySprite()` para aplicar tint 0xff9999 em inimigos a raio <= 3 tiles do player
+  - Modificar `_flashSprite()` para usar flag `flashing` via `sprite.setData('flashing', true/false)` para evitar conflito com tint de proximidade
+  - Só aplicar tint de proximidade se `!enemy.sprite.getData('flashing')`
+  - _Requirements: R3_

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -145,6 +145,6 @@ export class GameOverScene extends Phaser.Scene {
   }
 
   private _restart(): void {
-    this.scene.start('GameScene');
+    this.scene.start('MainMenuScene');
   }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -35,6 +35,7 @@ import { SHOP_CATALOG, STARTING_ITEMS } from '../config/shop.catalog';
 import { CATEGORY_TEXTURE_KEYS } from '../config/enemies.config';
 import { SpellSystem } from '../systems/SpellSystem';
 import { SpellCastingSystem } from '../systems/SpellCastingSystem';
+import { FogOfWarSystem } from '../systems/FogOfWarSystem';
 import { SPELLS_DB } from '../config/spells.db';
 import type { TransitionResolution } from '../types/transitions';
 import type { GridPos } from '../generators/DungeonGenerator';
@@ -77,6 +78,7 @@ export class GameScene extends Phaser.Scene {
   private _shopSystem!: ShopSystem;
   private _spellSystem!: SpellSystem;
   private _spellCastingSystem!: SpellCastingSystem;
+  private _fogOfWar!: FogOfWarSystem;
   private gameState!: string;
 
   // ─── Narrativa emergente (Fase 6) ─────────────────────────────────────────
@@ -176,6 +178,7 @@ export class GameScene extends Phaser.Scene {
     this._shopSystem          = new ShopSystem(SHOP_CATALOG);
     this._spellSystem         = new SpellSystem();
     this._spellCastingSystem  = new SpellCastingSystem();
+    this._fogOfWar = new FogOfWarSystem();
     this._registerTransitions();
 
     // ─── Narrativa emergente (Fase 6) ──────────────────────────────────────
@@ -327,6 +330,10 @@ export class GameScene extends Phaser.Scene {
 
     this._enemies.forEach(e => this._removeEnemySprite(e));
     this._enemies = [];
+
+    if (this._currentArea === 'dungeon') {
+      this._fogOfWar?.reset();
+    }
   }
 
   private _loadTown(spawnX = TOWN.START_X, spawnY = TOWN.START_Y): void {
@@ -502,6 +509,9 @@ export class GameScene extends Phaser.Scene {
     this.cameras.main.setBounds(0, 0, W * TILE_SIZE, H * TILE_SIZE);
     this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
     this.cameras.main.setZoom(2);
+
+    // Aplicar fog of war inicial ao carregar o andar
+    this._fogOfWar.update(this._tileObjects, this.player.gridX, this.player.gridY);
 
     EventBus.emit(EVENTS.AREA_CHANGED, { area: 'dungeon', floor, timestamp: Date.now() });
     EventBus.emit(EVENTS.UI_LOG, cached ? `Você está no andar ${floor}.` : `Você desce para o andar ${floor}. Cuidado!`);
@@ -981,6 +991,9 @@ export class GameScene extends Phaser.Scene {
       this._checkItemPickup();
       this._checkChestInteraction();
       this._checkAreaTransition();
+      if (this._currentArea === 'dungeon') {
+        this._fogOfWar.update(this._tileObjects, this.player.gridX, this.player.gridY);
+      }
     }
 
     this._enemies.forEach(e => this._syncEnemySprite(e));
@@ -1445,6 +1458,21 @@ export class GameScene extends Phaser.Scene {
         .setPosition(pos.x - TILE_SIZE / 2 + barWidth / 2, pos.y - TILE_SIZE / 2 - 2);
       enemy.hpBarBg?.setPosition(pos.x, pos.y - TILE_SIZE / 2 - 2);
     }
+    // Destaque de inimigos próximos (raio 3 tiles)
+    if (enemy.sprite?.active) {
+      const dist = Math.max(
+        Math.abs(enemy.gridX - this.player.gridX),
+        Math.abs(enemy.gridY - this.player.gridY),
+      );
+      // Só aplica tint de proximidade se não estiver em flash de dano
+      if (!enemy.sprite.getData('flashing')) {
+        if (dist <= 3) {
+          enemy.sprite.setTint(0xff9999);
+        } else {
+          enemy.sprite.clearTint();
+        }
+      }
+    }
   }
 
   // ─── Feedback Visual ─────────────────────────────────────────────────────
@@ -1463,13 +1491,17 @@ export class GameScene extends Phaser.Scene {
 
   /** Flash vermelho no sprite atingido (pisca uma vez). */
   private _flashSprite(sprite: Phaser.GameObjects.Sprite): void {
+    sprite.setData('flashing', true);
     this.tweens.add({
       targets: sprite,
       alpha: 0.2,
       duration: 80,
       yoyo: true,
       repeat: 1,
-      onComplete: () => { sprite.setAlpha(1); },
+      onComplete: () => {
+        sprite.setAlpha(1);
+        sprite.setData('flashing', false);
+      },
     });
     sprite.setTint(0xff4444);
     this.time.delayedCall(160, () => { if (sprite.active) sprite.clearTint(); });

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -46,6 +46,7 @@ export class UIScene extends Phaser.Scene {
   // Classe e flechas
   private _classLabel!: Phaser.GameObjects.Text;
   private _arrowLabel!: Phaser.GameObjects.Text;
+  private _floorLabel!: Phaser.GameObjects.Text;
 
   // Log
   private _logSystem!: LogSystem;
@@ -163,6 +164,7 @@ export class UIScene extends Phaser.Scene {
     EventBus.off(EVENTS.STAT_POINT_SPENT,           undefined,            this);
     EventBus.off(EVENTS.SPELL_UNLOCKED,             undefined,            this);
     EventBus.off(EVENTS.SPELL_CAST,                 undefined,            this);
+    EventBus.off(EVENTS.AREA_CHANGED,               undefined,            this);
   }
 
   // ─── Spell Bar no footer (canto direito) ────────────────────────────────
@@ -459,9 +461,13 @@ export class UIScene extends Phaser.Scene {
       .text(PANEL_X, xpY + 48, '', { ...TEXT_STYLE, color: '#fbbf24' })
       .setScrollFactor(0).setDepth(d + 1).setVisible(false);
 
+    this._floorLabel = this.add
+      .text(PANEL_X, xpY + 60, 'Cidade', { ...TEXT_STYLE, color: '#88ddff' })
+      .setScrollFactor(0).setDepth(d + 1);
+
     // Fundo do painel de stats (altura extra para acomodar classe e flechas)
     this.add
-      .rectangle(0, 0, panelW, 88, 0x000000, 0.55)
+      .rectangle(0, 0, panelW, 104, 0x000000, 0.55)
       .setOrigin(0, 0).setScrollFactor(0).setDepth(d - 1);
   }
 
@@ -491,6 +497,14 @@ export class UIScene extends Phaser.Scene {
     EventBus.on(EVENTS.CLASS_INFO, (data: { label: string; usesArrows: boolean; arrows: number }) => {
       if (!this.sys.isActive()) return;
       this.setClassInfo(data.label, data.usesArrows, data.arrows);
+    }, this);
+    EventBus.on(EVENTS.AREA_CHANGED, (data: { area: string; floor?: number }) => {
+      if (!this.sys.isActive() || !this._floorLabel?.active) return;
+      if (data.area === 'dungeon') {
+        this._floorLabel.setText(`Andar: ${data.floor ?? 1}`);
+      } else {
+        this._floorLabel.setText('Cidade');
+      }
     }, this);
     EventBus.on(EVENTS.ITEM_PICKED_UP,      this._onItemPickedUp, this);
     EventBus.on(EVENTS.ITEM_USED,           this._onItemUsed,     this);

--- a/src/systems/FogOfWarSystem.ts
+++ b/src/systems/FogOfWarSystem.ts
@@ -1,0 +1,65 @@
+import * as Phaser from 'phaser';
+import { TILE_SIZE } from '../utils/constants';
+
+/**
+ * FogOfWarSystem — controla a visibilidade dos tiles da dungeon.
+ *
+ * - Tiles visíveis (raio do player): alpha 1
+ * - Tiles visitados mas fora do campo de visão: alpha 0.35
+ * - Tiles nunca visitados: alpha 0
+ */
+export class FogOfWarSystem {
+  private _visited = new Set<string>();
+  private _visible = new Set<string>();
+
+  /**
+   * Atualiza a visibilidade dos tiles com base na posição do player.
+   * @param tiles - array de tiles renderizados na cena
+   * @param playerGridX - posição X do player no grid
+   * @param playerGridY - posição Y do player no grid
+   * @param radius - raio de visão em tiles (padrão: 5)
+   */
+  update(
+    tiles: Phaser.GameObjects.Image[],
+    playerGridX: number,
+    playerGridY: number,
+    radius = 5,
+  ): void {
+    // Recalcular tiles visíveis neste turno (círculo)
+    this._visible.clear();
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        if (dx * dx + dy * dy <= radius * radius) {
+          const key = `${playerGridX + dx},${playerGridY + dy}`;
+          this._visible.add(key);
+          this._visited.add(key);
+        }
+      }
+    }
+
+    // Aplicar alpha em cada tile baseado no estado de visibilidade
+    for (const tile of tiles) {
+      // Calcular posição grid a partir da posição pixel do tile
+      const gx = Math.round((tile.x - TILE_SIZE / 2) / TILE_SIZE);
+      const gy = Math.round((tile.y - TILE_SIZE / 2) / TILE_SIZE);
+      const key = `${gx},${gy}`;
+
+      if (this._visible.has(key)) {
+        tile.setAlpha(1);
+      } else if (this._visited.has(key)) {
+        tile.setAlpha(0.35);
+      } else {
+        tile.setAlpha(0);
+      }
+    }
+  }
+
+  /**
+   * Reseta o estado ao trocar de andar ou área.
+   * Todos os tiles voltam a ser invisíveis.
+   */
+  reset(): void {
+    this._visited.clear();
+    this._visible.clear();
+  }
+}

--- a/src/systems/TurnManager.ts
+++ b/src/systems/TurnManager.ts
@@ -61,12 +61,12 @@ export class TurnManager {
       const target = action.target;
 
       // Verificar se a classe pode atacar (Mago não pode corpo a corpo; Arqueiro precisa de flechas)
-      if (!ClassRulesEngine.canMelee(player.classDef) && !player.classDef.usesArrows) {
+      if (player.classDef && !ClassRulesEngine.canMelee(player.classDef) && !player.classDef.usesArrows) {
         result.messages.push(`${player.classDef.label} não pode atacar corpo a corpo. Use magias!`);
         this.playerTurn = true;
         return result;
       }
-      if (!ClassRulesEngine.canAttack(player.classDef, player.arrows)) {
+      if (player.classDef && !ClassRulesEngine.canAttack(player.classDef, player.arrows ?? 0)) {
         result.messages.push('Sem flechas! Compre mais na loja.');
         this.playerTurn = true;
         return result;
@@ -76,10 +76,10 @@ export class TurnManager {
       if (atk.hit) {
         target.hp = Math.max(0, target.hp - atk.damage);
         metrics?.recordDamageDealt(atk.damage);
-        const verb = player.classDef.usesArrows ? 'atirou e causou' : 'atacou e causou';
+        const verb = player.classDef?.usesArrows ? 'atirou e causou' : 'atacou e causou';
         result.messages.push(`Você ${verb} ${atk.damage} de dano`);
         // Consumir flecha
-        if (player.classDef.usesArrows) {
+        if (player.classDef?.usesArrows) {
           player.arrows = Math.max(0, player.arrows - 1);
           EventBus.emit(EVENTS.ARROWS_CHANGED, { arrows: player.arrows });
         }
@@ -134,7 +134,10 @@ export class TurnManager {
         const atk = combat.attack(enemy, player);
         if (atk.hit) {
           const rawDmg = atk.damage;
-          const reduced = Math.max(1, Math.round(rawDmg * ClassRulesEngine.physicalDamageMultiplier(player.classDef)));
+          const dmgMultiplier = player.classDef
+            ? ClassRulesEngine.physicalDamageMultiplier(player.classDef)
+            : 1.0;
+          const reduced = Math.max(1, Math.round(rawDmg * dmgMultiplier));
           if (!DEV_CONFIG.godMode) player.hp = Math.max(0, player.hp - reduced);
           metrics?.recordDamageTaken(reduced);
           EventBus.emit(EVENTS.PLAYER_HP_CHANGED, { hp: player.hp, maxHp: player.maxHp });

--- a/tests/fog-of-war.test.js
+++ b/tests/fog-of-war.test.js
@@ -1,0 +1,241 @@
+/**
+ * fog-of-war.test.js — Testes do FogOfWarSystem
+ *
+ * O FogOfWarSystem não depende de Phaser diretamente — apenas chama
+ * tile.setAlpha(). Por isso podemos mockar tiles como objetos simples
+ * { x, y, setAlpha: vi.fn() } sem precisar de um ambiente Phaser real.
+ *
+ * TILE_SIZE = 16 (de constants.ts)
+ * Fórmula de conversão pixel → grid:
+ *   gx = Math.round((tile.x - TILE_SIZE / 2) / TILE_SIZE)
+ *   gy = Math.round((tile.y - TILE_SIZE / 2) / TILE_SIZE)
+ *
+ * Portanto, para um tile na posição grid (gx, gy):
+ *   tile.x = gx * TILE_SIZE + TILE_SIZE / 2
+ *   tile.y = gy * TILE_SIZE + TILE_SIZE / 2
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { FogOfWarSystem } from '../src/systems/FogOfWarSystem';
+import { TILE_SIZE } from '../src/utils/constants';
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+/**
+ * Cria um tile mock na posição grid (gx, gy).
+ * O setAlpha é um spy para verificar quais valores foram aplicados.
+ */
+function makeTile(gx, gy) {
+  return {
+    x: gx * TILE_SIZE + TILE_SIZE / 2,
+    y: gy * TILE_SIZE + TILE_SIZE / 2,
+    setAlpha: vi.fn(),
+  };
+}
+
+/**
+ * Retorna o último valor passado para setAlpha de um tile.
+ * Útil para verificar o estado final após múltiplas chamadas.
+ */
+function lastAlpha(tile) {
+  const calls = tile.setAlpha.mock.calls;
+  return calls.length > 0 ? calls[calls.length - 1][0] : undefined;
+}
+
+// ─── Testes ───────────────────────────────────────────────────────────────────
+
+describe('FogOfWarSystem — visibilidade inicial', () => {
+  let fog;
+
+  beforeEach(() => {
+    fog = new FogOfWarSystem();
+  });
+
+  it('tile na posição exata do player fica com alpha 1', () => {
+    const tile = makeTile(5, 5);
+    fog.update([tile], 5, 5, 3);
+    expect(lastAlpha(tile)).toBe(1);
+  });
+
+  it('tile dentro do raio fica com alpha 1', () => {
+    // player em (10, 10), raio 3 — tile em (12, 10) está a distância 2
+    const tile = makeTile(12, 10);
+    fog.update([tile], 10, 10, 3);
+    expect(lastAlpha(tile)).toBe(1);
+  });
+
+  it('tile exatamente na borda do raio fica com alpha 1', () => {
+    // player em (5, 5), raio 3 — tile em (8, 5) está a distância exata 3
+    const tile = makeTile(8, 5);
+    fog.update([tile], 5, 5, 3);
+    expect(lastAlpha(tile)).toBe(1);
+  });
+
+  it('tile fora do raio nunca visitado fica com alpha 0', () => {
+    // player em (5, 5), raio 3 — tile em (10, 5) está a distância 5
+    const tile = makeTile(10, 5);
+    fog.update([tile], 5, 5, 3);
+    expect(lastAlpha(tile)).toBe(0);
+  });
+
+  it('tile na diagonal dentro do raio circular fica com alpha 1', () => {
+    // player em (5, 5), raio 3 — tile em (7, 7): dx=2, dy=2 → dist²=8 ≤ 9
+    const tile = makeTile(7, 7);
+    fog.update([tile], 5, 5, 3);
+    expect(lastAlpha(tile)).toBe(1);
+  });
+
+  it('tile na diagonal fora do raio circular fica com alpha 0', () => {
+    // player em (5, 5), raio 3 — tile em (8, 8): dx=3, dy=3 → dist²=18 > 9
+    const tile = makeTile(8, 8);
+    fog.update([tile], 5, 5, 3);
+    expect(lastAlpha(tile)).toBe(0);
+  });
+});
+
+describe('FogOfWarSystem — tiles visitados', () => {
+  let fog;
+
+  beforeEach(() => {
+    fog = new FogOfWarSystem();
+  });
+
+  it('tile visitado mas fora do campo de visão atual fica com alpha 0.35', () => {
+    const tile = makeTile(5, 5);
+
+    // Primeira chamada: player em (5, 5) — tile fica visível (alpha 1)
+    fog.update([tile], 5, 5, 2);
+    expect(lastAlpha(tile)).toBe(1);
+
+    // Segunda chamada: player se move para (10, 10) — tile sai do raio
+    fog.update([tile], 10, 10, 2);
+    expect(lastAlpha(tile)).toBe(0.35);
+  });
+
+  it('tile visitado volta a alpha 1 quando o player retorna ao raio', () => {
+    const tile = makeTile(5, 5);
+
+    fog.update([tile], 5, 5, 2);   // visível
+    fog.update([tile], 10, 10, 2); // visitado (fora do raio)
+    fog.update([tile], 5, 5, 2);   // volta ao raio
+
+    expect(lastAlpha(tile)).toBe(1);
+  });
+
+  it('múltiplos tiles: cada um recebe o alpha correto conforme posição', () => {
+    const tileVisivel   = makeTile(5, 5);  // dentro do raio
+    const tileVisitado  = makeTile(0, 0);  // fora do raio, mas será visitado antes
+    const tileNaoVisto  = makeTile(20, 20); // nunca visitado
+
+    // Primeira passagem: player em (0, 0) — tileVisitado fica visível
+    fog.update([tileVisivel, tileVisitado, tileNaoVisto], 0, 0, 2);
+
+    // Segunda passagem: player em (5, 5) — tileVisivel fica visível, tileVisitado fica escurecido
+    fog.update([tileVisivel, tileVisitado, tileNaoVisto], 5, 5, 2);
+
+    expect(lastAlpha(tileVisivel)).toBe(1);
+    expect(lastAlpha(tileVisitado)).toBe(0.35);
+    expect(lastAlpha(tileNaoVisto)).toBe(0);
+  });
+});
+
+describe('FogOfWarSystem — reset()', () => {
+  let fog;
+
+  beforeEach(() => {
+    fog = new FogOfWarSystem();
+  });
+
+  it('após reset(), tile anteriormente visitado fica com alpha 0', () => {
+    const tile = makeTile(5, 5);
+
+    fog.update([tile], 5, 5, 2);  // visível
+    fog.reset();
+    fog.update([tile], 10, 10, 2); // player longe — tile não está no raio
+
+    expect(lastAlpha(tile)).toBe(0); // não visitado após reset
+  });
+
+  it('após reset(), tile no raio do player fica com alpha 1 normalmente', () => {
+    const tile = makeTile(5, 5);
+
+    fog.update([tile], 5, 5, 2);
+    fog.reset();
+    fog.update([tile], 5, 5, 2); // player volta ao mesmo lugar
+
+    expect(lastAlpha(tile)).toBe(1);
+  });
+
+  it('reset() pode ser chamado sem update() anterior sem erros', () => {
+    expect(() => fog.reset()).not.toThrow();
+  });
+});
+
+describe('FogOfWarSystem — raio customizado', () => {
+  let fog;
+
+  beforeEach(() => {
+    fog = new FogOfWarSystem();
+  });
+
+  it('raio 1 só ilumina tiles imediatamente adjacentes', () => {
+    const tileAdjacente = makeTile(6, 5); // distância 1
+    const tileLonge     = makeTile(7, 5); // distância 2
+
+    fog.update([tileAdjacente, tileLonge], 5, 5, 1);
+
+    expect(lastAlpha(tileAdjacente)).toBe(1);
+    expect(lastAlpha(tileLonge)).toBe(0);
+  });
+
+  it('raio 0 só ilumina o tile exato do player', () => {
+    const tilePlayer    = makeTile(5, 5);
+    const tileAdjacente = makeTile(6, 5);
+
+    fog.update([tilePlayer, tileAdjacente], 5, 5, 0);
+
+    expect(lastAlpha(tilePlayer)).toBe(1);
+    expect(lastAlpha(tileAdjacente)).toBe(0);
+  });
+
+  it('raio padrão (5) ilumina tile a distância 5 na horizontal', () => {
+    const tile = makeTile(10, 5); // distância 5 de (5, 5)
+    fog.update([tile], 5, 5); // sem passar raio — usa padrão 5
+    expect(lastAlpha(tile)).toBe(1);
+  });
+
+  it('raio padrão (5) não ilumina tile a distância 6', () => {
+    const tile = makeTile(11, 5); // distância 6 de (5, 5)
+    fog.update([tile], 5, 5); // raio padrão 5
+    expect(lastAlpha(tile)).toBe(0);
+  });
+});
+
+describe('FogOfWarSystem — casos extremos', () => {
+  let fog;
+
+  beforeEach(() => {
+    fog = new FogOfWarSystem();
+  });
+
+  it('array de tiles vazio não lança erro', () => {
+    expect(() => fog.update([], 5, 5, 3)).not.toThrow();
+  });
+
+  it('setAlpha é chamado uma vez por tile por update()', () => {
+    const tile = makeTile(5, 5);
+    fog.update([tile], 5, 5, 3);
+    expect(tile.setAlpha).toHaveBeenCalledTimes(1);
+  });
+
+  it('múltiplos updates acumulam tiles visitados corretamente', () => {
+    const tileA = makeTile(0, 0);
+    const tileB = makeTile(10, 0);
+
+    fog.update([tileA, tileB], 0, 0, 2);  // tileA visível, tileB não visto
+    fog.update([tileA, tileB], 10, 0, 2); // tileB visível, tileA visitado
+
+    expect(lastAlpha(tileA)).toBe(0.35);
+    expect(lastAlpha(tileB)).toBe(1);
+  });
+});

--- a/tests/shop.test.js
+++ b/tests/shop.test.js
@@ -118,8 +118,9 @@ describe('ShopSystem — buyItem', () => {
 
   it('emite PLAYER_GOLD_CHANGED após compra', () => {
     const idx = SHOP_CATALOG.findIndex(e => e.id === 'potion_heal_shop'); // preço 30
+    const entry = SHOP_CATALOG[idx];
     shop.buyItem(player, idx, inv);
-    expect(EventBus.emit).toHaveBeenCalledWith('player-gold-changed', { gold: 460 });
+    expect(EventBus.emit).toHaveBeenCalledWith('player-gold-changed', { gold: 500 - entry.price });
   });
 });
 


### PR DESCRIPTION
## Descrição

Implementação completa da Fase 7 (polimento, UI e preparação para demo), incluindo Fog of War, melhorias no HUD, correções de fluxo e 19 novos testes unitários.

---

## Tipo de mudança

- [x] `feat` — nova funcionalidade
- [x] `fix` — correção de bug

---

## O que foi feito

- **FogOfWarSystem** (`src/systems/FogOfWarSystem.ts`): névoa de guerra circular — visível (alpha 1), visitado (alpha 0.35), não visitado (alpha 0)
- **Integração na GameScene**: fog ativado ao carregar andar, ao mover o player e resetado no cleanup
- **Floor label no HUD** (`UIScene.ts`): label 'Andar: N' / 'Cidade' atualizado via evento `AREA_CHANGED`
- **Fix GameOverScene**: 'Jogar Novamente' agora vai para `MainMenuScene` (fluxo completo Menu → CharacterSelect → Game → GameOver → Menu)
- **Destaque de inimigos próximos**: tint rosa (0xff9999) em inimigos a ≤ 3 tiles do player
- **Fix `_flashSprite()`**: flag `flashing` via `sprite.setData()` evita conflito de tint
- **Fix `TurnManager`**: guards defensivos para `player.classDef` ausente nos testes
- **Fix `shop.test.js`**: valor esperado atualizado para preço atual da poção (30)
- **19 novos testes** em `tests/fog-of-war.test.js`

---

## Como testar

1. `npm install`
2. `npm test` — 214 testes devem passar
3. `npm run dev` → entrar na dungeon → verificar fog of war e label de andar no HUD
4. Morrer → 'Jogar Novamente' → deve ir para o Menu Principal

---

## Evidências

```
Test Files  15 passed (15)
Tests       214 passed (214)
```

---

## Checklist

- [x] Segui o padrão de commits (Conventional Commits)
- [x] Testei manualmente as alterações no browser