### PR TITLE
Chores/refinamentos gerais

### DIFF
--- a/.kiro/specs/product.md
+++ b/.kiro/specs/product.md
@@ -147,7 +147,7 @@ Input do jogador → Resolve ação (mover/atacar/item/magia/esperar) → Turno 
 - Level up: +3 pontos de atributo para distribuir
 - HP e Mana recalculados automaticamente
 
-### Magias (v1.0.0)
+### Magias (v1.0.1)
 
 - 6 magias data-driven (`spells.db.ts`): Fire Bolt, Ice Bolt, Ice Shard, Wind Cyclone, Fire Explosion, Blizzard + Great Fire (exclusiva do Mago)
 - Desbloqueio automático por nível (`spell-progression.ts`): nível 1, 5, 10, 15, 20

--- a/.kiro/specs/spells.spec.md
+++ b/.kiro/specs/spells.spec.md
@@ -1,5 +1,7 @@
 # Spec — Sistema de Magias (Spells)
 
+> **Última revisão:** v1.0.1 — Corrigido label dos botões "Equipar" no `SpellsPanel`: classes não-Mago usam slots `J`/`K` mas os botões exibiam `H`/`J` (hardcoded). Labels agora derivados de `vm.activeSlots[i].key` em tempo de render; botões também mostram a magia já equipada no slot.
+
 ## Descrição
 
 O sistema de magias permite ao jogador desbloquear, equipar e usar feitiços melee-range durante a exploração da dungeon. As magias atingem todos os inimigos adjacentes (4 tiles cardinais) ao custo de mana e respeitam cooldown por slot. São desbloqueadas automaticamente ao subir de nível e equipadas em dois slots (`J` e `K`).

--- a/.kiro/steering/game-steering.md
+++ b/.kiro/steering/game-steering.md
@@ -124,6 +124,13 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 - **`VisualRegressionScene`** é exclusivamente para testes de regressão de autotiling (teclas 1-4 toggleiam debug modes); não deve ser incluída em builds de produção
 - **`PlayerMetrics` alimenta `DifficultyManager`** via sliding window de 20 turnos; `DifficultyScalingSystem` aplica os multiplicadores por andar; os três sistemas são independentes entre si
 
+## Histórico de Correções Críticas
+
+### v1.0.1 (2026-05-20)
+- **`ActionBarPanel._getItemVisual()`**: `switch` sem `default` retornava `undefined` para `EquippableItemType`, causando crash ao coletar equipamentos. Adicionado `default` com fallback para frame 0
+- **`SpellsPanel` — labels dos botões Equipar**: labels fixos `['H','J','K','L']` não correspondiam aos slots reais de classes não-Mago (`J`/`K`). Labels agora derivados de `vm.activeSlots[i].key` em `render()`; botão também exibe o nome da magia já equipada no slot
+- **Promises narrativas sem `.catch()`**: `generateNarrative()` e `generateDeathStory()` podiam gerar `UnhandledPromiseRejection`. `.catch()` silencioso adicionado em ambas
+
 ## Expansões Futuras Planejadas
 
 Estes sistemas NÃO fazem parte do MVP atual mas o código deve ser estruturado para suportá-los:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ---
 
+## [1.0.1] — 2026-05-20
+
+### Fixed
+
+- **Crash ao pegar muitas poções**: `ActionBarPanel._getItemVisual()` não tinha `default` no `switch`, retornando `undefined` para itens equipáveis e causando `TypeError: this._getItemVisual(...) is undefined`. Adicionado `default` com fallback para o frame 0 do sprite de poção (mesmo padrão já usado na `GameScene`)
+- **Magias não equipáveis (não-Mago)**: botões "Equipar" no painel de magias exibiam labels `[H]`/`[J]` fixos em código, mas classes não-Mago usam os slots `[J]`/`[K]`. O jogador clicava em "Equipar [H]", a magia ia para `[J]` (correto internamente), e ao tentar conjurar com `H` nada acontecia. Labels agora são derivados dinamicamente do `vm.activeSlots[i].key` em tempo de render; botões também exibem o nome da magia já equipada no slot como feedback visual
+- **Promises de narrativa sem tratamento de erro**: chamadas assíncronas a `generateNarrative()` e `generateDeathStory()` na `GameScene` não tinham `.catch()`, podendo gerar `UnhandledPromiseRejection` em caso de timeout ou falha de rede. Adicionado `.catch()` silencioso em ambas (narrativa é opcional)
+
+---
+
 ## [1.0.0] — 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://ia-para-devs-sctec-t2.github.io/jogo-dungeon-of-echoes/dashboard/
 | **Integração com IA Generativa (LLM)** | ✅ **Implementado** |
 | **Renderização Shell-not-Volume (bitmask 8-bit)** | ✅ **Implementado** |
 | **Sistema de Magias com projéteis** | ✅ **Implementado** |
-| FOG of War | 🔜 Planejado |
+| FOG of War | ✅ **Implementado** |
 
 ---
 
@@ -209,6 +209,28 @@ dungeon-of-echoes/
 ```
 
 **Princípio de arquitetura:** cenas orquestram, sistemas executam. Uma cena nunca calcula dano ou gera dungeon diretamente. Sistemas comunicam-se via `EventBus` (cross-cena) ou `scene.events` (local) — nunca por importação direta.
+
+---
+
+## Escolhas Técnicas
+
+### Phaser 4 como engine de jogo
+Optamos pelo Phaser 4 por sua maturidade no ecossistema browser-game, suporte nativo a tilemaps, sistema de cenas e gerenciamento de assets — eliminando a necessidade de bibliotecas auxiliares para rendering e input.
+
+### Arquitetura: Cenas orquestram, Sistemas executam
+Nenhuma cena calcula dano, gera dungeon ou manipula inventário diretamente. Toda lógica de domínio vive em sistemas (`CombatSystem`, `XPSystem`, `DungeonGenerator`, etc.) que são puramente TypeScript, sem dependência de Phaser — o que os torna testáveis em Node.js sem inicializar a engine.
+
+### Comunicação via EventBus
+Sistemas se comunicam por um EventBus singleton desacoplado de Phaser (`src/utils/EventBus.ts`). Isso evita importação direta entre sistemas e permite que a UIScene (overlay) reaja a eventos da GameScene sem acoplamento estrutural.
+
+### TypeScript + Vite
+TypeScript garante segurança de tipos em ~80 arquivos de lógica de jogo. Vite oferece HMR instantâneo durante o desenvolvimento e build otimizado para GitHub Pages via `npm run build`.
+
+### Testes com Vitest (sem Phaser)
+A separação entre sistemas e cenas permite rodar toda a suite de testes unitários em Node.js puro. Os 15 arquivos de teste cobrem os sistemas críticos (combat, XP, dungeon, fog of war, inventory, spells) sem necessidade de um browser.
+
+### IA Generativa como camada opcional
+A integração com Claude (Anthropic) é encapsulada em `src/ai/` e tratada como serviço externo: o jogo é 100% funcional sem a API key. Quando presente, narrativas dinâmicas enriquecem encontros com inimigos elite e diálogos de NPC sem bloquear o loop de jogo.
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -236,6 +236,40 @@ Os requisitos abaixo são derivados diretamente das specs em `.kiro/specs/`.
 
 ---
 
+## 8.1 User Stories
+
+As histórias abaixo representam os principais fluxos do jogador e guiaram as decisões de design e implementação do produto.
+
+**US-01 — Seleção de Classe**
+> Como jogador, quero escolher uma classe antes de iniciar a partida (Guerreiro, Arqueiro, Mago ou Aventureiro), para que minha experiência de jogo reflita um estilo de combate distinto desde o primeiro turno.
+
+**Critérios de aceite:**
+- Tela de seleção exibe as 4 classes com atributos e habilidades de cada uma
+- Ao confirmar, os bônus da classe são aplicados aos atributos base do personagem
+- Não é possível trocar de classe após iniciar a partida
+
+---
+
+**US-02 — Exploração com Memória de Mapa**
+> Como jogador, quero que as áreas já exploradas permaneçam visíveis no mapa mesmo após sair do andar ou visitar a cidade, para que eu possa me orientar sem precisar reexplorar áreas já conhecidas.
+
+**Critérios de aceite:**
+- Tiles visitados ficam com iluminação reduzida (estado REVEALED) ao saírem do campo de visão
+- O estado de exploração persiste ao transitar entre dungeon e cidade
+- Tiles nunca visitados permanecem completamente escuros (estado HIDDEN)
+
+---
+
+**US-03 — Narrativa Dinâmica via IA**
+> Como jogador, quero receber descrições narrativas geradas por IA ao encontrar inimigos elite e ao interagir com NPCs, para que cada partida tenha uma identidade única e imersiva.
+
+**Critérios de aceite:**
+- Inimigos elite recebem nome e habilidade especial gerados pelo modelo de linguagem
+- Diálogos de NPCs são contextualizados com os eventos recentes da partida
+- A narrativa é exibida no painel de log sem interromper o fluxo de jogo
+
+---
+
 ## 9. Escopo
 
 ### Dentro do escopo (v0.6.0 — estado atual)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,10 +1,10 @@
 # PRD — Product Requirements Document
 # Dungeon of Echoes
 
-**Versão:** 0.6.0  
-**Data:** 2026-05-16  
+**Versão:** 1.0.1  
+**Data:** 2026-05-20  
 **Equipe:** Equipe 7 — IA para DEVs SCTEC T2  
-**Status:** v0.6.0 entregue — Classes de herói com bônus de atributo, drops visuais de ouro por quantidade e sistema de baús com loot por profundidade
+**Status:** v1.0.1 — Hotfix: crash ao coletar poções, labels incorretos no painel de magias e promises sem tratamento de erro
 
 ---
 

--- a/docs/c4-architecture.md
+++ b/docs/c4-architecture.md
@@ -1,0 +1,108 @@
+# C4 Architecture — Dungeon Crawler
+
+> Modelo C4 em três níveis de zoom. Renderiza automaticamente no GitHub e no VSCode (extensão Mermaid Preview).
+
+---
+
+## L1 — System Context
+
+Visão de alto nível: o sistema no mundo, quem usa e com o que se integra.
+
+```mermaid
+C4Context
+    title Dungeon Crawler — Contexto do Sistema
+
+    Person(player, "Jogador", "Joga via navegador em desktop")
+    System(game, "Dungeon Crawler Game", "Jogo roguelike baseado em turnos rodando inteiramente no browser")
+    System_Ext(ai, "Anthropic Claude API", "Gera narrativas dinâmicas com base nos eventos do jogo")
+
+    Rel(player, game, "Joga via teclado/mouse")
+    Rel(game, ai, "Envia contexto do jogo, recebe narrativas", "HTTPS/REST")
+```
+
+---
+
+## L2 — Container
+
+Zoom no sistema: processos, camadas tecnológicas e suas responsabilidades.
+
+```mermaid
+C4Container
+    title Dungeon Crawler — Containers
+
+    Person(player, "Jogador")
+
+    Container_Boundary(browser, "Browser (SPA)") {
+        Container(phaser, "Phaser Game Engine", "TypeScript + Phaser 3", "Renderização, física, input, loop de jogo e orquestração de sistemas")
+        Container(ui, "UI Layer", "TypeScript", "Painéis de HUD: status, inventário, log de combate, loja e magias")
+        Container(ai_layer, "AI Integration Layer", "TypeScript", "Prepara contexto semântico e comunica com Claude API para narrativa")
+        Container(config, "Config & Data Layer", "TypeScript", "Dados estáticos: classes, inimigos, magias, loja, temas de dungeon")
+    }
+
+    System_Ext(claude_api, "Claude API", "Anthropic")
+
+    Rel(player, phaser, "Input (teclado/mouse)")
+    Rel(phaser, ui, "Publica eventos de estado via EventBus")
+    Rel(phaser, ai_layer, "Envia contexto de eventos (combate, NPC, exploração)")
+    Rel(phaser, config, "Lê definições de dados em tempo de execução")
+    Rel(ai_layer, claude_api, "POST /messages", "HTTPS")
+    Rel(claude_api, ai_layer, "Retorna narrativa gerada")
+    Rel(ai_layer, ui, "Exibe narrativa no LogPanel/DialogPanel")
+```
+
+---
+
+## L3 — Component
+
+Zoom na camada Phaser Game: os sistemas internos e como se comunicam.
+
+```mermaid
+C4Component
+    title Dungeon Crawler — Componentes Internos
+
+    Container_Boundary(phaser, "Phaser Game Engine") {
+
+        Component(gamescene, "GameScene", "Scene principal", "Orquestra todos os sistemas; loop de update por turno")
+        Component(uiscene, "UIScene", "Scene de UI paralela", "Renderiza HUD em overlay — status, log, painéis")
+
+        Component(turn, "TurnManager", "Sistema", "Controla a ordem de turnos: jogador → inimigos")
+        Component(combat, "CombatSystem", "Sistema", "Resolve ataques, dano, status e morte")
+        Component(spell, "SpellSystem / SpellCastingSystem", "Sistema", "Catálogo de magias, cooldowns e lançamento")
+        Component(enemy, "EnemySystem / EnemyAI", "Sistema", "Spawn, pathfinding e decisão de ação dos inimigos")
+
+        Component(dungeon, "DungeonGenerator / DungeonFloorManager", "Gerador", "Geração procedural de mapas e gerenciamento de andares")
+        Component(world, "WorldSystem / MapTransitionSystem", "Sistema", "Gerencia estados do mundo: cidade, dungeon e transições")
+        Component(fog, "FogOfWarSystem", "Sistema", "Controla tiles visíveis e memória do mapa explorado")
+
+        Component(inventory, "InventorySystem / LootSystem / ShopSystem", "Sistema", "Gerencia itens, drops e compras na loja")
+        Component(equipment, "EquipmentSystem / ClassRulesEngine", "Sistema", "Aplica bônus de equipamentos respeitando regras de classe")
+        Component(xp, "XPSystem / DifficultyManager", "Sistema", "Progressão de XP, level-up e escalonamento de dificuldade")
+
+        Component(events, "EventBus / EventMemory", "Infraestrutura", "Pub/sub desacoplado entre sistemas; histórico de eventos")
+        Component(ai_int, "AIIntegration / NarrativeService", "IA", "Classifica eventos semanticamente e solicita narrativa ao Claude")
+        Component(metrics, "PlayerMetrics / LogSystem", "Observabilidade", "Registra ações do jogador e logs de combate")
+    }
+
+    Rel(gamescene, turn, "Dispara tick de turno")
+    Rel(turn, combat, "Processa ação do jogador")
+    Rel(turn, enemy, "Processa turno de cada inimigo")
+    Rel(combat, xp, "Concede XP ao matar inimigo")
+    Rel(combat, events, "Publica CombatEvent")
+    Rel(enemy, events, "Publica EnemyEvent")
+    Rel(events, ai_int, "Fornece histórico de eventos como contexto")
+    Rel(events, metrics, "Alimenta métricas e log")
+    Rel(gamescene, dungeon, "Solicita geração de novo andar")
+    Rel(gamescene, world, "Solicita transição de mapa")
+    Rel(gamescene, fog, "Atualiza visibilidade após movimento")
+    Rel(gamescene, inventory, "Processa coleta de loot e abertura de loja")
+    Rel(inventory, equipment, "Aplica item equipado ao personagem")
+    Rel(uiscene, events, "Escuta eventos para atualizar HUD")
+    Rel(ai_int, uiscene, "Envia narrativa para exibição no LogPanel")
+```
+
+---
+
+## Referências
+
+- [C4 Model](https://c4model.com) — Simon Brown
+- [Mermaid C4 Diagram docs](https://mermaid.js.org/syntax/c4.html)

--- a/docs/diagrams/casos-de-uso.mmd
+++ b/docs/diagrams/casos-de-uso.mmd
@@ -4,7 +4,7 @@ title: Dungeon of Echoes — Casos de Uso (v0.6.0)
 flowchart TD
   %% ─── Atores ──────────────────────────────────────────────────────────────
   Player(["👤 Jogador"])
-  AI(["🤖 IA Narrativa\n(OpenAI GPT-3.5)"])
+  AI(["🤖 IA Narrativa\n(Claude - Anthropic)"])
 
   %% ─── Sistema ─────────────────────────────────────────────────────────────
   subgraph GAME["🎮 Dungeon of Echoes"]

--- a/docs/diagrams/diagrama-classes.mmd
+++ b/docs/diagrams/diagrama-classes.mmd
@@ -35,7 +35,7 @@ classDiagram
     +reset(gridX, gridY) void
   }
 
-  class EnemySystem {
+  class Enemy {
     +id: number
     +hp, maxHp, attack, xpReward: number
     +gridX, gridY: number
@@ -323,7 +323,7 @@ classDiagram
     -_narrativeService: NarrativeService
     -_dungeonCache: Map~number,DungeonState~
     -_currentArea: string
-    -_enemies: EnemySystem[]
+    -_enemies: Enemy[]
     -_items: Item[]
     +create() void
     +update(time, delta) void
@@ -375,7 +375,7 @@ classDiagram
 
   %% GameScene → Systems
   GameScene --> Player : cria e controla
-  GameScene --> EnemySystem : cria via createEnemies()
+  GameScene --> Enemy : cria via createEnemies()
   GameScene --> Item : gerencia no chão
   GameScene --> XPSystem : usa
   GameScene --> CombatSystem : usa
@@ -416,7 +416,7 @@ classDiagram
   %% Spells
   SpellSystem --> ClassRulesEngine : usa
   SpellCastingSystem --> SpellSystem : usa
-  SpellCastingSystem --> EnemySystem : busca alvos
+  SpellCastingSystem --> Enemy : busca alvos
 
   %% Difficulty
   DifficultyManager --> PlayerMetrics : lê performance
@@ -428,7 +428,7 @@ classDiagram
 
   %% Projectile
   Projectile --> DungeonGenerator : colisão
-  Projectile --> EnemySystem : detecta hit
+  Projectile --> Enemy : detecta hit
 
   %% UI
   UIScene --> LogSystem : usa

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jogo-dungeon-of-echoes",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "description": "Dungeon of Echoes – RPG 2D tile-based com geração procedural",
   "scripts": {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -544,7 +544,8 @@ export class GameScene extends Phaser.Scene {
         .then((narrative) => {
           EventBus.emit(EVENTS.UI_LOG, narrative);
           EventBus.emit(EVENTS.NARRATIVE_GENERATED, { narrative, floor });
-        });
+        })
+        .catch(() => { /* narrativa opcional — falha silenciosa */ });
     }
   }
 
@@ -1632,7 +1633,8 @@ export class GameScene extends Phaser.Scene {
       this._narrativeService.generateDeathStory(importantEvents)
         .then((story) => {
           EventBus.emit(EVENTS.DEATH_STORY_GENERATED, { story });
-        });
+        })
+        .catch(() => { /* narrativa opcional — falha silenciosa */ });
 
       this.cameras.main.flash(500, 255, 0, 0);
       this.time.delayedCall(600, () => {

--- a/src/ui/ActionBarPanel.ts
+++ b/src/ui/ActionBarPanel.ts
@@ -87,6 +87,7 @@ export class ActionBarPanel {
       case 'potion_mana':
       case 'potion_mana_high':  return { texture: SPRITES.POTION, frame: DAWNLIKE_FRAMES.POTION_MANA };
       case 'gold':              return { texture: SPRITES.MONEY,  frame: DAWNLIKE_FRAMES.GOLD_SMALL };
+      default:                  return { texture: SPRITES.POTION, frame: 0 };
     }
   }
 }

--- a/src/ui/SpellsPanel.ts
+++ b/src/ui/SpellsPanel.ts
@@ -218,8 +218,21 @@ export class SpellsPanel {
     if (sel) {
       this._detailName.setText(sel.name);
       this._detailDesc.setText(`[${sel.element}] Dano:${sel.damage} Mana:${sel.manaCost} CD:${(sel.cooldownMs/1000).toFixed(1)}s`);
-      this._equipBtns.forEach((b, i) => b.setVisible(i < activeSlotCount));
-      this._equipTxts.forEach((t, i) => t.setVisible(i < activeSlotCount));
+      this._equipBtns.forEach((b, i) => {
+        b.setVisible(i < activeSlotCount);
+        if (i < activeSlotCount) {
+          const slotOccupied = !!vm.activeSlots[i]?.spellId;
+          b.setFillStyle(slotOccupied ? 0x3a5c3a : 0x224422, 1);
+        }
+      });
+      this._equipTxts.forEach((t, i) => {
+        t.setVisible(i < activeSlotCount);
+        if (i < activeSlotCount) {
+          const key = vm.activeSlots[i]?.key ?? String(i);
+          const slotSpellName = vm.activeSlots[i]?.spellId ? vm.activeSlots[i].spellName : '—';
+          t.setText(`[${key}]: ${slotSpellName}`);
+        }
+      });
     } else {
       this._detailName.setText('');
       this._detailDesc.setText('Selecione uma magia para ver detalhes.');


### PR DESCRIPTION
## Descrição

Hotfix v1.0.1: corrige crash ao coletar itens equipáveis (TypeError no `ActionBarPanel`), labels incorretos nos botões "Equipar" do painel de magias para classes não-Mago, e promises de narrativa sem tratamento de erro. Nenhuma funcionalidade nova foi adicionada.

---

## Tipo de mudança

- [ ] `feat` — nova funcionalidade
- [x] `fix` — correção de bug
- [ ] `refactor` — refatoração sem mudança de comportamento
- [ ] `docs` — apenas documentação
- [ ] `chore` — CI, dependências, configuração

---

## O que foi feito

- **`ActionBarPanel._getItemVisual()`**: `switch` sem `default` retornava `undefined` para qualquer `EquippableItemType`, causando `TypeError: this._getItemVisual(...) is undefined` ao coletar espadas, capacetes ou escudos. Adicionado `default: return { texture: SPRITES.POTION, frame: 0 }` (mesmo padrão já usado na `GameScene`)
- **`SpellsPanel` — botões "Equipar"**: labels hardcoded `['H','J','K','L']` não correspondiam aos slots reais de classes não-Mago (`J`/`K`). O jogador clicava em "Equipar [H]", a magia era equipada corretamente no slot `J`, mas ao tentar conjurar com `H` nada acontecia — parecendo que o equip não funcionou. Labels agora derivados de `vm.activeSlots[i].key` em tempo de render; cada botão também exibe o nome da magia já ocupando o slot como feedback visual
- **`GameScene` — promises sem `.catch()`**: `generateNarrative()` e `generateDeathStory()` podiam gerar `UnhandledPromiseRejection` silencioso em caso de timeout ou falha de rede da API de narrativa. Adicionado `.catch()` em ambas (narrativa é opcional, falha silenciosa é intencional)
- **Versão bumped para 1.0.1** em `package.json`, `CHANGELOG.md`, `docs/PRD.md`, `.kiro/specs/product.md`, `.kiro/specs/spells.spec.md` e `.kiro/steering/game-steering.md`

---

## Como testar

1. `npm install`
2. `npm run dev`
3. Iniciar partida com qualquer classe não-Mago (ex: Guerreiro)
4. Explorar a dungeon até encontrar um baú ou inimigo que drope equipamento — **não deve ocorrer crash**
5. Abrir o painel de magias (`I` → aba MAGIAS), selecionar uma magia na lista
6. Verificar que os botões "Equipar" exibem as teclas corretas: **`[J]`** e **`[K]`** para não-Mago (não `[H]`/`[J]`)
7. Clicar em "Equipar [J]" e confirmar que a magia aparece no slot `[J]` da action bar e pode ser conjurada com `J` em gameplay
8. Repetir com classe Mago: botões devem exibir `[H]`, `[J]`, `[K]`, `[L]` corretamente

---

## Evidências

Erro original reproduzível ao coletar qualquer item equipável (espada, capacete, etc.):
