### PR TITLE
Staging

### DIFF
--- a/.kiro/specs/product.md
+++ b/.kiro/specs/product.md
@@ -147,7 +147,7 @@ Input do jogador → Resolve ação (mover/atacar/item/magia/esperar) → Turno 
 - Level up: +3 pontos de atributo para distribuir
 - HP e Mana recalculados automaticamente
 
-### Magias (v1.0.1)
+### Magias (v1.0.2)
 
 - 6 magias data-driven (`spells.db.ts`): Fire Bolt, Ice Bolt, Ice Shard, Wind Cyclone, Fire Explosion, Blizzard + Great Fire (exclusiva do Mago)
 - Desbloqueio automático por nível (`spell-progression.ts`): nível 1, 5, 10, 15, 20

--- a/.kiro/steering/game-steering.md
+++ b/.kiro/steering/game-steering.md
@@ -126,6 +126,9 @@ Dungeon of Echoes é um RPG 2D tile-based jogado no navegador. O jogador explora
 
 ## Histórico de Correções Críticas
 
+### v1.0.2 (2026-05-21)
+- **`spell-system.test.js` — testes desatualizados**: 3 casos falhavam após rebalanceamento da implementação — `fire_bolt.manaCost` 8 → 6, `fire_bolt` com `range: 2 / areaType: 'line'`, nível 1 com 4 magias. Testes corrigidos para refletir o comportamento atual
+
 ### v1.0.1 (2026-05-20)
 - **`ActionBarPanel._getItemVisual()`**: `switch` sem `default` retornava `undefined` para `EquippableItemType`, causando crash ao coletar equipamentos. Adicionado `default` com fallback para frame 0
 - **`SpellsPanel` — labels dos botões Equipar**: labels fixos `['H','J','K','L']` não correspondiam aos slots reais de classes não-Mago (`J`/`K`). Labels agora derivados de `vm.activeSlots[i].key` em `render()`; botão também exibe o nome da magia já equipada no slot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ Escopos sugeridos: player, dungeon, combat, xp, enemy, input, render, config, ci
 
 ---
 
+## [1.0.2] — 2026-05-21
+
+### Fixed
+
+- **Testes do sistema de magias desatualizados**: `spell-system.test.js` falhava em 3 casos após mudanças na implementação — `fire_bolt.manaCost` reduzido de 8 → 6, `fire_bolt` reconfigurado com `range: 2 / areaType: 'line'` (inimigo a 2 tiles em linha agora é alcançado), e nível 1 passou a desbloquear 4 magias (`fire_bolt`, `minor_healing`, `ice_bolt`, `great_fire`). Testes atualizados para refletir o comportamento atual da implementação
+
+---
+
 ## [1.0.1] — 2026-05-20
 
 ### Fixed
@@ -690,6 +698,9 @@ procedural de masmorras, combate turno-a-turno e progressão de personagem.
 
 ---
 
+[1.0.2]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.6.0...v1.0.0
 [0.6.0]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/IA-para-DEVs-SCTEC-T2/projeto_final/compare/v0.5.2...v0.5.3

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,10 +1,10 @@
 # PRD — Product Requirements Document
 # Dungeon of Echoes
 
-**Versão:** 1.0.1  
-**Data:** 2026-05-20  
+**Versão:** 1.0.2  
+**Data:** 2026-05-21  
 **Equipe:** Equipe 7 — IA para DEVs SCTEC T2  
-**Status:** v1.0.1 — Hotfix: crash ao coletar poções, labels incorretos no painel de magias e promises sem tratamento de erro
+**Status:** v1.0.2 — Fix: testes do sistema de magias desatualizados após rebalanceamento de fire_bolt e spell-progression
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jogo-dungeon-of-echoes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "description": "Dungeon of Echoes – RPG 2D tile-based com geração procedural",
   "scripts": {

--- a/tests/spell-system.test.js
+++ b/tests/spell-system.test.js
@@ -52,7 +52,7 @@ describe('SpellSystem — desbloqueio por nível', () => {
   });
 
   it('não adiciona magia duplicada se já desbloqueada', () => {
-    const player = makePlayer({ unlockedSpells: ['fire_bolt', 'minor_healing'] });
+    const player = makePlayer({ unlockedSpells: ['fire_bolt', 'minor_healing', 'ice_bolt', 'great_fire'] });
     const added = spellSystem.unlockSpellsForLevel(player, 1);
     expect(added).toHaveLength(0);
     expect(player.unlockedSpells.filter(s => s === 'fire_bolt')).toHaveLength(1);
@@ -156,7 +156,7 @@ describe('SpellCastingSystem — cast bem-sucedido', () => {
   it('desconta mana ao cast', () => {
     const enemies = [];
     castingSystem.cast(0, player, spellSystem, enemies, 1000);
-    expect(player.mana).toBe(42); // 50 - 8 (fire_bolt manaCost)
+    expect(player.mana).toBe(44); // 50 - 6 (fire_bolt manaCost)
   });
 
   it('inclui todos os inimigos adjacentes nos 4 cardinais', () => {
@@ -171,7 +171,7 @@ describe('SpellCastingSystem — cast bem-sucedido', () => {
   });
 
   it('não inclui inimigos não adjacentes', () => {
-    const enemies = [makeEnemy(5, 3), makeEnemy(8, 5)]; // fora do alcance
+    const enemies = [makeEnemy(5, 2), makeEnemy(9, 5)]; // fora do alcance (range=2 em linha)
     const result = castingSystem.cast(0, player, spellSystem, enemies, 1000);
     expect(result.hitEnemies).toHaveLength(0);
   });


### PR DESCRIPTION
## Descrição

Corrige 3 testes quebrados em `spell-system.test.js` que ficaram desatualizados após rebalanceamento do `fire_bolt` e expansão da `spell-progression`. Também bump de versão para `1.0.2` com atualização de CHANGELOG, PRD e `.kiro`.

---

## Tipo de mudança

- [x] `fix` — correção de bug
- [x] `chore` — CI, dependências, configuração

---

## O que foi feito

- Corrigido teste "não adiciona magia duplicada se já desbloqueada": player agora inicia com as 4 magias do nível 1 já desbloqueadas (`fire_bolt`, `minor_healing`, `ice_bolt`, `great_fire`), refletindo a `spell-progression` atual
- Corrigido teste "desconta mana ao cast": valor esperado ajustado de 42 → 44, pois `fire_bolt.manaCost` é 6 (não 8)
- Corrigido teste "não inclui inimigos não adjacentes": inimigos movidos para (5,2) e (9,5) — fora do alcance `range: 2` em linha do `fire_bolt`
- Versão bumped para `1.0.2` em `package.json`, `CHANGELOG.md`, `docs/PRD.md`, `.kiro/steering/game-steering.md` e `.kiro/specs/product.md`

---

## Como testar

1. `npm install`
2. `npm test`
3. Verificar que todos os 20 testes de `tests/spell-system.test.js` passam (0 falhas)

---

## Evidências

<img width="875" height="777" alt="Captura de tela de 2026-05-21 19-55-09" src="https://github.com/user-attachments/assets/5926f5a0-0d47-4edf-8986-2ae844c24d17" />
